### PR TITLE
Update README to add instruction for building C++

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -39,3 +39,4 @@ dist/
 
 .idea
 cmake-build-*
+.vscode

--- a/README.md
+++ b/README.md
@@ -1,1 +1,1 @@
-# Lance: A Columnar Data Foramt
+# Lance: A Columnar Data Format

--- a/cpp/README.md
+++ b/cpp/README.md
@@ -1,7 +1,9 @@
 # Lance: A Columnar File Format
 
 
-## Development
+# Development
+
+## Code Style
 
 The core of `Lance` data format is developed in `C++20`.
 
@@ -11,9 +13,11 @@ With exceptions:
 
 The code style is enforced via [`clang-format`](https://clang.llvm.org/docs/ClangFormat.html). Please make sure `clang-format` has been set up appropriately in the IDE.
 
-The code is developed on `macOS 12+` and recent Linux (`Ubuntu 22.04`). Feel free to file bugs or contribute if you encounter issues with other Linux flavors.
+## Build
 
-The C++ codebase is on C++20, so a recent compiler is expected, the toolchain that is tested:
+The code is developed on `macOS 12+` and a recent Linux (`Ubuntu 22.04`). Please file bugs or contribute fixes if you encounter issues with other Linux flavors.
+
+A recent C++ compiler that supports C++20 is needed. The toolchain that has been tested is:
 
 * AppleClang >= 13.1.6
 * GCC >= 11.2
@@ -24,6 +28,8 @@ The C++ codebase is on C++20, so a recent compiler is expected, the toolchain th
 ```sh
 # On macOS 12+
 brew install apache-arrow cmake protobuf
+# Optionally, build document
+brew install doxygen
 ```
 
 ```sh
@@ -37,12 +43,13 @@ sudo apt update
 
 # Install arrow, protobuf, cmake
 sudo apt install -y -V libarrow-dev libarrow-dataset-dev libparquet-dev libarrow-python-dev cmake libprotobuf-dev protobuf-compiler
+# Optionally, build document
+sudo apt install -y -V install doxygen
 ```
 
 Once the installation is completed, we can check out `lance` from github and start building.
 
 ```sh
-
 git clone git@github.com:eto-ai/lance.git
 cd lance/cpp
 mkdir -p build
@@ -50,6 +57,6 @@ cmake -B build
 cd build
 make -j
 
-# Run unit test
+# Run unit tests
 make test
 ```

--- a/cpp/README.md
+++ b/cpp/README.md
@@ -1,4 +1,4 @@
-# Lance: A Columnar File Format
+# Lance: A Columnar Data Format
 
 
 # Development
@@ -34,15 +34,10 @@ brew install doxygen
 
 ```sh
 # On Ubuntu 22.04
-# Follow https://arrow.apache.org/install/
-sudo apt update
-sudo apt install -y -V ca-certificates lsb-release wget
-wget https://apache.jfrog.io/artifactory/arrow/$(lsb_release --id --short | tr 'A-Z' 'a-z')/apache-arrow-apt-source-latest-$(lsb_release --codename --short).deb
-sudo apt install -y -V ./apache-arrow-apt-source-latest-$(lsb_release --codename --short).deb
-sudo apt update
+# Step 1. Follow https://arrow.apache.org/install/
 
-# Install arrow, protobuf, cmake
-sudo apt install -y -V libarrow-dev libarrow-dataset-dev libparquet-dev libarrow-python-dev cmake libprotobuf-dev protobuf-compiler
+# Step 2. Install arrow, protobuf, cmake
+sudo apt install -y -V libarrow-dev libarrow-dataset-dev libparquet-dev libarrow-python-dev cmake libprotobuf-dev
 # Optionally, build document
 sudo apt install -y -V install doxygen
 ```

--- a/cpp/README.md
+++ b/cpp/README.md
@@ -1,0 +1,55 @@
+# Lance: A Columnar File Format
+
+
+## Development
+
+The core of `Lance` data format is developed in `C++20`.
+
+The code base follows Apache Arrow and [Google C++ Code Style](https://google.github.io/styleguide/cppguide.html).
+With exceptions:
+* Line width: 100
+
+The code style is enforced via [`clang-format`](https://clang.llvm.org/docs/ClangFormat.html). Please make sure `clang-format` has been set up appropriately in the IDE.
+
+The code is developed on `macOS 12+` and recent Linux (`Ubuntu 22.04`). Feel free to file bugs or contribute if you encounter issues with other Linux flavors.
+
+The C++ codebase is on C++20, so a recent compiler is expected, the toolchain that is tested:
+
+* AppleClang >= 13.1.6
+* GCC >= 11.2
+* CMake >= 3.22
+* Apache Arrow >= 8.0
+* Protobuf > 3.12
+
+```sh
+# On macOS 12+
+brew install apache-arrow cmake protobuf
+```
+
+```sh
+# On Ubuntu 22.04
+# Follow https://arrow.apache.org/install/
+sudo apt update
+sudo apt install -y -V ca-certificates lsb-release wget
+wget https://apache.jfrog.io/artifactory/arrow/$(lsb_release --id --short | tr 'A-Z' 'a-z')/apache-arrow-apt-source-latest-$(lsb_release --codename --short).deb
+sudo apt install -y -V ./apache-arrow-apt-source-latest-$(lsb_release --codename --short).deb
+sudo apt update
+
+# Install arrow, protobuf, cmake
+sudo apt install -y -V libarrow-dev libarrow-dataset-dev libparquet-dev libarrow-python-dev cmake libprotobuf-dev protobuf-compiler
+```
+
+Once the installation is completed, we can check out `lance` from github and start building.
+
+```sh
+
+git clone git@github.com:eto-ai/lance.git
+cd lance/cpp
+mkdir -p build
+cmake -B build
+cd build
+make -j
+
+# Run unit test
+make test
+```


### PR DESCRIPTION
Added instructions to build C++ on `macOS` and `Ubuntu 22.04`