### PR TITLE
Add scipy2022 poster link to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,7 @@
 # Lance: A Columnar Data Format
+
+
+## Presentations and Talks
+
+* [Lance: A New Columnar Data Format](https://docs.google.com/presentation/d/1a4nAiQAkPDBtOfXFpPg7lbeDAxcNDVKgoUkw3cUs2rE/edit#slide=id.p).
+[Scipy 2022, Austin, TX](https://www.scipy2022.scipy.org/posters). July, 2022.


### PR DESCRIPTION
Add the `scipy 2022` conference poster link to the project README.md file.