### PR TITLE
Add Schema::Exclude(schema).

### DIFF
--- a/cpp/src/lance/format/schema.cc
+++ b/cpp/src/lance/format/schema.cc
@@ -75,6 +75,20 @@ Field::Field(const pb::Field& pb)
 
 void Field::AddChild(std::shared_ptr<Field> child) { children_.emplace_back(child); }
 
+bool Field::RemoveChild(int32_t id) {
+  for (std::size_t i = 0; i < children_.size(); i++) {
+    auto& child = children_[i];
+    if (child->id() == id) {
+      children_.erase(children_.begin() + i);
+      return true;
+    }
+    if (child->RemoveChild(id)) {
+      return true;
+    }
+  }
+  return false;
+}
+
 // TODO: lets use a map to speed up this. for now it is just O(n) scan.
 std::shared_ptr<Field> Field::Get(int32_t id) {
   for (auto& child : children_) {
@@ -150,7 +164,7 @@ const std::shared_ptr<::arrow::Array>& Field::dictionary() const { return dictio
   assert(::arrow::is_dictionary(type()->id()));
   auto dict_type = std::dynamic_pointer_cast<::arrow::DictionaryType>(type());
   ///
-  assert (dict_type->value_type()->Equals(::arrow::utf8()));
+  assert(dict_type->value_type()->Equals(::arrow::utf8()));
 
   auto decoder = lance::encodings::VarBinaryDecoder<::arrow::StringType>(infile, ::arrow::utf8());
   decoder.Reset(dictionary_offset_, dictionary_page_length_);
@@ -228,14 +242,8 @@ std::vector<lance::format::pb::Field> Field::ToProto() const {
   field.set_encoding(encoding_);
   field.set_dictionary_offset(dictionary_offset_);
   field.set_dictionary_page_length(dictionary_page_length_);
+  field.set_type(GetNodeType());
 
-  if (logical_type_ == "struct") {
-    field.set_type(pb::Field::PARENT);
-  } else if (logical_type_ == "list.struct" || logical_type_ == "list") {
-    field.set_type(pb::Field::REPEATED);
-  } else {
-    field.set_type(pb::Field::LEAF);
-  }
   pb_fields.emplace_back(field);
 
   for (auto& child : children_) {
@@ -271,16 +279,6 @@ void Field::SetId(int32_t parent_id, int32_t* current_id) {
   *current_id += 1;
   for (auto& child : children_) {
     child->SetId(id_, current_id);
-  }
-}
-
-void Field::SetId(int32_t parent_id,
-                  int32_t* current_id,
-                  std::map<int32_t, std::shared_ptr<Field>>* field_map) {
-  assert(field_map != nullptr);
-  SetId(parent_id, current_id);
-  for (auto& child : children_) {
-    field_map->emplace(id_, child);
   }
 }
 
@@ -344,8 +342,6 @@ bool Field::Equals(const std::shared_ptr<Field>& other, bool check_id) const {
 
 bool Field::operator==(const Field& other) const { return Equals(other, true); }
 
-
-
 //------ Schema
 
 Schema::Schema(const google::protobuf::RepeatedPtrField<::lance::format::pb::Field>& pb_fields) {
@@ -358,8 +354,6 @@ Schema::Schema(const google::protobuf::RepeatedPtrField<::lance::format::pb::Fie
       assert(parent);
       parent->AddChild(field);
     }
-
-    fields_map_.emplace(field->id(), field);
   }
 }
 
@@ -431,11 +425,50 @@ Schema::Schema(std::shared_ptr<::arrow::Schema> schema) {
   return projection;
 }
 
+::arrow::Result<std::shared_ptr<Schema>> Schema::Exclude(std::shared_ptr<Schema> other) const {
+
+  /// An visitor to remove fields in place.
+  class SchemaExcludeVisitor : public FieldVisitor {
+   public:
+    SchemaExcludeVisitor(std::shared_ptr<Schema> excluded) : excluded_(excluded) {}
+
+    ::arrow::Status Visit(std::shared_ptr<Field> field) override {
+      for (auto& field : field->fields()) {
+        ARROW_RETURN_NOT_OK(Visit(field));
+      }
+      auto excluded_field = excluded_->GetField(field->id());
+      if (!excluded_field) {
+        return ::arrow::Status::OK();
+      }
+      if (field->fields().empty() ||
+          (excluded_field->GetNodeType() != pb::Field::LEAF && excluded_field->fields().empty())) {
+        excluded_->RemoveField(field->id());
+      }
+
+      return ::arrow::Status::OK();
+    }
+
+   private:
+    std::shared_ptr<Schema> excluded_;
+  };
+
+  auto excluded = Copy();
+  auto visitor = SchemaExcludeVisitor(excluded);
+  ARROW_RETURN_NOT_OK(visitor.VisitSchema(other));
+  return excluded;
+}
+
 void Schema::AddField(std::shared_ptr<Field> f) { fields_.emplace_back(f); }
 
 std::shared_ptr<Field> Schema::GetField(int32_t id) const {
-  if (auto it = fields_map_.find(id); it != fields_map_.end()) {
-    return it->second;
+  for (auto& field : fields_) {
+    if (field->id() == id) {
+      return field;
+    }
+    auto subfield = field->Get(id);
+    if (subfield) {
+      return subfield;
+    }
   }
   return nullptr;
 };
@@ -467,13 +500,33 @@ std::vector<lance::format::pb::Field> Schema::ToProto() const {
   return pb_fields;
 }
 
+/// Make a full copy of the schema.
+std::shared_ptr<Schema> Schema::Copy() const {
+  auto copy = std::make_shared<Schema>();
+  for (auto& field : fields_) {
+    copy->fields_.emplace_back(field->Copy(true));
+  };
+  return copy;
+}
+
 void Schema::AssignIds() {
   int cur_id = 0;
-  fields_map_.clear();
   for (auto& field : fields_) {
-    field->SetId(-1, &cur_id, &fields_map_);
-    fields_map_[field->id()] = field;
+    field->SetId(-1, &cur_id);
   }
+}
+
+bool Schema::RemoveField(int32_t id) {
+  for (std::size_t i = 0; i < fields_.size(); i++) {
+    if (fields_[i]->id() == id) {
+      fields_.erase(fields_.begin() + i);
+      return true;
+    }
+    if (fields_[i]->RemoveChild(id)) {
+      return true;
+    }
+  }
+  return false;
 }
 
 bool Schema::Equals(const Schema& other, bool check_id) const {
@@ -512,6 +565,16 @@ std::shared_ptr<::arrow::Schema> Schema::ToArrow() const {
     arrow_fields.emplace_back(f->ToArrow());
   }
   return ::arrow::schema(arrow_fields);
+}
+
+pb::Field::Type Field::GetNodeType() const {
+  if (logical_type_ == "struct") {
+    return pb::Field::PARENT;
+  } else if (logical_type_ == "list.struct" || logical_type_ == "list") {
+    return pb::Field::REPEATED;
+  } else {
+    return pb::Field::LEAF;
+  }
 }
 
 }  // namespace lance::format

--- a/cpp/src/lance/format/schema.cc
+++ b/cpp/src/lance/format/schema.cc
@@ -76,13 +76,12 @@ Field::Field(const pb::Field& pb)
 void Field::AddChild(std::shared_ptr<Field> child) { children_.emplace_back(child); }
 
 bool Field::RemoveChild(int32_t id) {
-  for (std::size_t i = 0; i < children_.size(); i++) {
-    auto& child = children_[i];
-    if (child->id() == id) {
-      children_.erase(children_.begin() + i);
+  for (auto it = children_.begin(); it != children_.end(); ++it) {
+    if ((*it)->id() == id) {
+      children_.erase(it);
       return true;
     }
-    if (child->RemoveChild(id)) {
+    if ((*it)->RemoveChild(id)) {
       return true;
     }
   }
@@ -426,7 +425,6 @@ Schema::Schema(std::shared_ptr<::arrow::Schema> schema) {
 }
 
 ::arrow::Result<std::shared_ptr<Schema>> Schema::Exclude(std::shared_ptr<Schema> other) const {
-
   /// An visitor to remove fields in place.
   class SchemaExcludeVisitor : public FieldVisitor {
    public:
@@ -517,12 +515,12 @@ void Schema::AssignIds() {
 }
 
 bool Schema::RemoveField(int32_t id) {
-  for (std::size_t i = 0; i < fields_.size(); i++) {
-    if (fields_[i]->id() == id) {
-      fields_.erase(fields_.begin() + i);
+  for (auto it = fields_.begin(); it != fields_.end(); ++it) {
+    if ((*it)->id() == id) {
+      fields_.erase(it);
       return true;
     }
-    if (fields_[i]->RemoveChild(id)) {
+    if ((*it)->RemoveChild(id)) {
       return true;
     }
   }

--- a/cpp/src/lance/format/schema.h
+++ b/cpp/src/lance/format/schema.h
@@ -60,6 +60,9 @@ class Schema final {
   /// Use arrow::schema to create a project of the current schema.
   ::arrow::Result<std::shared_ptr<Schema>> Project(const ::arrow::Schema& arrow_schema) const;
 
+  /// Exclude (subtract) the fields from the given schema.
+  ::arrow::Result<std::shared_ptr<Schema>> Exclude(std::shared_ptr<Schema> other) const;
+
   /// Add a new parent field.
   void AddField(std::shared_ptr<Field> f);
 
@@ -75,9 +78,6 @@ class Schema final {
   /// \return the field if found. Return nullptr if not found.
   std::shared_ptr<Field> GetField(const std::string& name) const;
 
-  /// (Re-)Assign Field IDs to all the fields.
-  void AssignIds();
-
   std::string ToString() const;
 
   bool Equals(const std::shared_ptr<Schema>& other, bool check_id = true) const;
@@ -88,10 +88,15 @@ class Schema final {
   bool operator==(const Schema& other) const;
 
  private:
-  std::vector<std::shared_ptr<Field>> fields_;
+  /// (Re-)Assign Field IDs to all the fields.
+  void AssignIds();
 
-  // for fast access.
-  std::map<int32_t, std::shared_ptr<Field>> fields_map_;
+  /// Make a full copy of the schema.
+  std::shared_ptr<Schema> Copy() const;
+
+  bool RemoveField(int32_t id);
+
+  std::vector<std::shared_ptr<Field>> fields_;
 };
 
 /// \brief Field is the metadata of a column on disk.
@@ -152,13 +157,6 @@ class Field final {
   /// Returns the direct child with the name. Returns nullptr if such field does not exist.
   const std::shared_ptr<Field> Get(const std::string_view& name) const;
 
-  /// TODO(make it private)
-  void SetId(int32_t parent_id, int32_t* current_id);
-
-  void SetId(int32_t parent_id,
-             int32_t* current_id,
-             std::map<int32_t, std::shared_ptr<Field>>* field_map);
-
   /// Check if two fields are equal.
   ///
   /// \param other the point to the other field to check against to.
@@ -184,6 +182,13 @@ class Field final {
 
   /// Load dictionary array from disk.
   ::arrow::Status LoadDictionary(std::shared_ptr<::arrow::io::RandomAccessFile> infile);
+
+  void SetId(int32_t parent_id, int32_t* current_id);
+
+  bool RemoveChild(int32_t id);
+
+  // TODO: use enum to replace protobuf enum.
+  pb::Field::Type GetNodeType() const;
 
   int32_t id_ = -1;
   int32_t parent_ = -1;

--- a/cpp/src/lance/format/schema.h
+++ b/cpp/src/lance/format/schema.h
@@ -61,6 +61,9 @@ class Schema final {
   ::arrow::Result<std::shared_ptr<Schema>> Project(const ::arrow::Schema& arrow_schema) const;
 
   /// Exclude (subtract) the fields from the given schema.
+  ///
+  /// \param other the schema to be excluded. It must to be a strict subset of this schema.
+  /// \return The newly created schema, excluding any column in "other".
   ::arrow::Result<std::shared_ptr<Schema>> Exclude(std::shared_ptr<Schema> other) const;
 
   /// Add a new parent field.

--- a/cpp/src/lance/format/schema_test.cc
+++ b/cpp/src/lance/format/schema_test.cc
@@ -81,7 +81,8 @@ TEST_CASE("Exclude schema") {
 
   auto excluded_arrow_schema = ::arrow::schema(
       {::arrow::field("pk", ::arrow::utf8()),
-       ::arrow::field("annotations", ::arrow::struct_({::arrow::field("label", ::arrow::utf8())}))});
+       ::arrow::field("annotations",
+                      ::arrow::struct_({::arrow::field("label", ::arrow::utf8())}))});
   auto expected = original.Project(*excluded_arrow_schema).ValueOrDie();
 
   INFO("Expected: " << expected->ToString() << "\nActual: " << excluded->ToString());

--- a/cpp/src/lance/format/schema_test.cc
+++ b/cpp/src/lance/format/schema_test.cc
@@ -73,6 +73,17 @@ TEST_CASE("Get projection via arrow schema") {
   CHECK(expect_schema.Equals(projection, false));
 }
 
-TEST_CASE("Write dictionary type") {
+TEST_CASE("Exclude schema") {
+  auto original = lance::format::Schema(arrow_schema);
+  auto projected = original.Project({"split", "annotations.box"}).ValueOrDie();
+  fmt::print("Project schema: {}\n", projected->ToString());
+  auto excluded = original.Exclude(projected).ValueOrDie();
 
+  auto excluded_arrow_schema = ::arrow::schema(
+      {::arrow::field("pk", ::arrow::utf8()),
+       ::arrow::field("annotations", ::arrow::struct_({::arrow::field("label", ::arrow::utf8())}))});
+  auto expected = original.Project(*excluded_arrow_schema).ValueOrDie();
+
+  INFO("Expected: " << expected->ToString() << "\nActual: " << excluded->ToString());
+  CHECK(excluded->Equals(expected));
 }

--- a/cpp/src/lance/format/schema_test.cc
+++ b/cpp/src/lance/format/schema_test.cc
@@ -76,7 +76,7 @@ TEST_CASE("Get projection via arrow schema") {
 TEST_CASE("Exclude schema") {
   auto original = lance::format::Schema(arrow_schema);
   auto projected = original.Project({"split", "annotations.box"}).ValueOrDie();
-  fmt::print("Project schema: {}\n", projected->ToString());
+  INFO("Projected schema: " << projected->ToString());
   auto excluded = original.Exclude(projected).ValueOrDie();
 
   auto excluded_arrow_schema = ::arrow::schema(


### PR DESCRIPTION
# Use case:

When we executing predicate pushdown, we will first read the columns in the filter schema (#36). We don't need to read these columns again when executing the Projection (#32).

For example, for a query:

```sql
SELECT image, split FROM data WHERE split = "train" 
```

The column `split` will be populated during filtering execution (#36), thus it should not be read again to populate the final results.  With `Schema::Exclude`, we can remove filtered schema from projected schema (in `arrow::dataset::ScanOptions`). 