### PR TITLE
Build python wheels using Manylinux

### DIFF
--- a/cpp/CMakeLists.txt
+++ b/cpp/CMakeLists.txt
@@ -64,7 +64,10 @@ find_package(Protobuf REQUIRED)
 include_directories(${Protobuf_INCLUDE_DIRS})
 
 if (CMAKE_SYSTEM_NAME STREQUAL "Linux")
-    list(APPEND CMAKE_MODULE_PATH /usr/lib/x86_64-linux-gnu/cmake/arrow)
+    list(APPEND CMAKE_MODULE_PATH
+            /usr/lib/x86_64-linux-gnu/cmake/arrow
+            /usr/lib64/cmake/arrow
+            )
 endif ()
 
 if (APPLE)

--- a/python/setup.py
+++ b/python/setup.py
@@ -37,6 +37,7 @@ setup(
     long_description="",
     ext_modules=cythonize(extensions, language_level="3"),
     zip_safe=False,
+    install_requires=["pyarrow"],
     extras_require={"test": ["pytest>=6.0", "pandas"]},
     python_requires=">=3.8",
     packages=find_packages()

--- a/python/tools/Dockerfile.manylinux2014
+++ b/python/tools/Dockerfile.manylinux2014
@@ -1,0 +1,16 @@
+FROM quay.io/pypa/manylinux2014_x86_64
+
+ENV LD_LIBRARY_PATH=/usr/local/lib
+
+RUN yum update -y \
+    && yum install -y epel-release || yum install -y https://dl.fedoraproject.org/pub/epel/epel-release-latest-$(cut -d: -f5 /etc/system-release-cpe | cut -d. -f1).noarch.rpm \
+    && yum install -y https://apache.jfrog.io/artifactory/arrow/centos/$(cut -d: -f5 /etc/system-release-cpe | cut -d. -f1)/apache-arrow-release-latest.rpm \
+    && yum install -y --enablerepo=epel arrow-devel \
+        arrow-dataset-devel parquet-devel wget \
+    && cd /tmp \
+    && wget -q https://github.com/protocolbuffers/protobuf/releases/download/v3.20.1/protobuf-cpp-3.20.1.tar.gz -O - | tar -xz \
+    && cd protobuf* \
+    && ./configure \
+    && make -j \
+    && make install \
+    && rm -rf /tmp/proto*

--- a/python/tools/auditwheel
+++ b/python/tools/auditwheel
@@ -1,0 +1,13 @@
+#!/opt/_internal/pipx/venvs/auditwheel/bin/python
+#
+# Monkey patch to not ship libarrow(*).so in pypi wheels
+import sys
+
+from auditwheel.main import main
+from auditwheel.policy import _POLICIES as POLICIES
+
+for p in POLICIES:
+    p['lib_whitelist'].extend(['libarrow.so.800', 'libarrow_dataset.so.800'])
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/python/tools/build_manylinux_wheels.sh
+++ b/python/tools/build_manylinux_wheels.sh
@@ -1,0 +1,39 @@
+#!/bin/bash
+
+set -ex
+
+yum update -y
+yum install -y epel-release || yum install -y https://dl.fedoraproject.org/pub/epel/epel-release-latest-$(cut -d: -f5 /etc/system-release-cpe | cut -d. -f1).noarch.rpm
+yum install -y https://apache.jfrog.io/artifactory/arrow/centos/$(cut -d: -f5 /etc/system-release-cpe | cut -d. -f1)/apache-arrow-release-latest.rpm
+yum install -y --enablerepo=epel arrow-devel \
+  arrow-dataset-devel parquet-devel wget
+
+# Build protobuf manually
+pushd /tmp
+wget -q https://github.com/protocolbuffers/protobuf/releases/download/v3.20.1/protobuf-cpp-3.20.1.tar.gz -O - | tar -xz
+cd protobuf-*
+./configure
+make -j
+make install
+popd
+
+export LD_LIBRARY_PATH=${LD_LIBRARY_PATH}:/usr/local/lib
+
+pushd /code/cpp
+rm -rf build
+mkdir -p build
+cd build
+cmake -DCMAKE_BUILD_TYPE=Release ..
+popd
+
+pushd /code/python
+rm -rf wheels dist
+for py in cp38 cp39 cp310
+do
+  /opt/python/${py}-${py}/bin/pip install numpy pyarrow cython
+  /opt/python/${py}-${py}/bin/python setup.py bdist_wheel
+done
+
+for whl in dist/*.whl; do
+    auditwheel repair "$whl" -w wheels
+done

--- a/python/tools/build_manylinux_wheels.sh
+++ b/python/tools/build_manylinux_wheels.sh
@@ -2,21 +2,6 @@
 
 set -ex
 
-yum update -y
-yum install -y epel-release || yum install -y https://dl.fedoraproject.org/pub/epel/epel-release-latest-$(cut -d: -f5 /etc/system-release-cpe | cut -d. -f1).noarch.rpm
-yum install -y https://apache.jfrog.io/artifactory/arrow/centos/$(cut -d: -f5 /etc/system-release-cpe | cut -d. -f1)/apache-arrow-release-latest.rpm
-yum install -y --enablerepo=epel arrow-devel \
-  arrow-dataset-devel parquet-devel wget
-
-# Build protobuf manually
-pushd /tmp
-wget -q https://github.com/protocolbuffers/protobuf/releases/download/v3.20.1/protobuf-cpp-3.20.1.tar.gz -O - | tar -xz
-cd protobuf-*
-./configure
-make -j
-make install
-popd
-
 export LD_LIBRARY_PATH=${LD_LIBRARY_PATH}:/usr/local/lib
 
 pushd /code/cpp
@@ -24,16 +9,17 @@ rm -rf build
 mkdir -p build
 cd build
 cmake -DCMAKE_BUILD_TYPE=Release ..
+make -j
 popd
 
-pushd /code/python
-rm -rf wheels dist
-for py in cp38 cp39 cp310
-do
-  /opt/python/${py}-${py}/bin/pip install numpy pyarrow cython
-  /opt/python/${py}-${py}/bin/python setup.py bdist_wheel
-done
+#pushd /code/python
+#rm -rf wheels dist build
+#for py in cp38 cp39 cp310
+#do
+#  /opt/python/${py}-${py}/bin/pip install numpy pyarrow cython
+#  /opt/python/${py}-${py}/bin/python setup.py bdist_wheel
+#done
 
 for whl in dist/*.whl; do
-    auditwheel repair "$whl" -w wheels
+    /code/python/tools/auditwheel.py repair "$whl" -w wheels
 done

--- a/python/tools/build_manylinux_wheels.sh
+++ b/python/tools/build_manylinux_wheels.sh
@@ -12,14 +12,14 @@ cmake -DCMAKE_BUILD_TYPE=Release ..
 make -j
 popd
 
-#pushd /code/python
-#rm -rf wheels dist build
-#for py in cp38 cp39 cp310
-#do
-#  /opt/python/${py}-${py}/bin/pip install numpy pyarrow cython
-#  /opt/python/${py}-${py}/bin/python setup.py bdist_wheel
-#done
+pushd /code/python
+rm -rf wheels dist build
+for py in cp38 cp39 cp310
+do
+  /opt/python/${py}-${py}/bin/pip install numpy pyarrow cython
+  /opt/python/${py}-${py}/bin/python setup.py bdist_wheel
+done
 
 for whl in dist/*.whl; do
-    /code/python/tools/auditwheel.py repair "$whl" -w wheels
+    /code/python/tools/auditwheel repair "$whl" -w wheels
 done

--- a/python/tools/build_wheel.sh
+++ b/python/tools/build_wheel.sh
@@ -1,0 +1,16 @@
+#!/usr/bin/env bash
+#
+# Build pylance manylinux wheels
+
+set -x
+
+TOOLS_DIR=$(dirname $(realpath $0))
+LANCE_ROOT=$(realpath ${TOOLS_DIR}/../..)
+
+docker build -t pylance_manylinux -f Dockerfile.manylinux2014 .
+
+docker run -v ${TOOLS_DIR}:/opt/lance/tools \
+  -v ${LANCE_ROOT}:/code --rm \
+  -w /code \
+  quay.io/pypa/manylinux2014_x86_64 \
+  /opt/lance/tools/build_manylinux_wheels.sh

--- a/python/tools/build_wheel.sh
+++ b/python/tools/build_wheel.sh
@@ -7,10 +7,10 @@ set -x
 TOOLS_DIR=$(dirname $(realpath $0))
 LANCE_ROOT=$(realpath ${TOOLS_DIR}/../..)
 
-docker build -t pylance_manylinux -f Dockerfile.manylinux2014 .
+docker build -t pylance_manylinux -f ${TOOLS_DIR}/Dockerfile.manylinux2014 ${TOOLS_DIR}
 
 docker run -v ${TOOLS_DIR}:/opt/lance/tools \
   -v ${LANCE_ROOT}:/code --rm \
   -w /code \
-  quay.io/pypa/manylinux2014_x86_64 \
+  pylance_manylinux \
   /opt/lance/tools/build_manylinux_wheels.sh


### PR DESCRIPTION
Using `manylinux2014` to build the the wheels for python 3.8 - 3.10. Makes the wheels compatible with the pyarrow installed via `pypi`.

Note: This does not work with conda pyarrow.