### PR TITLE
CI fix: update mac homebrew to use the latest version of protobuf

### DIFF
--- a/.github/workflows/cpp.yml
+++ b/.github/workflows/cpp.yml
@@ -40,7 +40,9 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - name: Install dependencies
-        run: brew install apache-arrow protobuf
+        run: |
+          brew update
+          brew install apache-arrow protobuf
       - name: Cmake
         run: cmake -B build
       - name: Build


### PR DESCRIPTION
A quick fix for Mac builds failed to link faulty-built protobuf 21.2 from homebrew.