### PR TITLE
Fix compiling cython on Mac

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,9 @@
 
 ![CI](https://github.com/eto-ai/lance/actions/workflows/cpp.yml/badge.svg)
 
+![PyPi](https://img.shields.io/pypi/v/pylance)
+![Python versions](https://img.shields.io/pypi/pyversions/pylance)
+
 Lance is a *cloud-native columnar data format* designed for unstructured machine learning datasets, featuring:
 
 * Fast columnar scan for ML dataset analysis, ML training, and evaluation.

--- a/python/lance/_lib.pyx
+++ b/python/lance/_lib.pyx
@@ -14,7 +14,7 @@ from pyarrow.includes.common cimport *
 from pyarrow._compute cimport Expression, _bind
 from pyarrow.includes.libarrow cimport CTable, COutputStream
 from pyarrow.includes.libarrow_dataset cimport CFileFormat
-from pyarrow.lib cimport *
+from pyarrow.lib cimport GetResultValue, check_status, pyarrow_unwrap_table, get_writer, RecordBatchReader, CExpression
 from pyarrow.lib import tobytes
 
 

--- a/python/setup.py
+++ b/python/setup.py
@@ -1,3 +1,19 @@
+#!/usr/bin/env python3
+#
+# Copyright 2022 Lance Developers
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 from pathlib import Path
 from setuptools import Extension, find_packages, setup
 
@@ -6,6 +22,7 @@ import pyarrow as pa
 from Cython.Build import cythonize
 
 arrow_includes = pa.get_include()
+arrow_library_dirs = pa.get_library_dirs()
 numpy_includes = np.get_include()
 
 # TODO allow for custom liblance directory
@@ -13,16 +30,18 @@ lance_cpp = Path(__file__).resolve().parent.parent / "cpp"
 lance_includes = str(lance_cpp / "include")
 lance_libs = str(lance_cpp / "build")
 
-extensions = [Extension(
-    "lance.lib",
-    ["lance/_lib.pyx"],
-    include_dirs=[lance_includes, arrow_includes, numpy_includes],
-    libraries=['lance'],
-    library_dirs=[lance_libs],
-    language="c++",
-    extra_compile_args=["-Wall", "-std=c++20", "-O3"],
-    extra_link_args=["-Wl,-rpath", lance_libs, "-larrow_python"]
-)]
+extensions = [
+    Extension(
+        "lance.lib",
+        ["lance/_lib.pyx"],
+        include_dirs=[lance_includes, arrow_includes, numpy_includes],
+        libraries=["lance"],
+        library_dirs=[lance_libs] + arrow_library_dirs,
+        language="c++",
+        extra_compile_args=["-Wall", "-std=c++20", "-O3"],
+        extra_link_args=["-Wl,-rpath", lance_libs, "-larrow_python"],
+    )
+]
 
 # The information here can also be placed in setup.cfg - better separation of
 # logic and declaration, and simpler if you include description/version in a file.


### PR DESCRIPTION
On Mac, `python setup.py build` complaints about not finding `-larrow_python`. 