### PR TITLE
Restore the custom build script for pyarrow

### DIFF
--- a/python/thirdparty/build.sh
+++ b/python/thirdparty/build.sh
@@ -1,0 +1,22 @@
+#!/bin/bash
+
+set -ex
+
+APACHE_ARROW_VERSION=apache-arrow-8.0.1
+
+# Build apache arrow
+build_arrow() {
+    git clone git@github.com:apache/arrow
+    pushd arrow
+    git pull --tags    
+    git checkout ${APACHE_ARROW_VERSION}
+    git submodule update --init
+    pushd python
+    pip install -r requirements-build.txt
+
+    export OPENSSL_ROOT_DIR=/opt/homebrew/opt/openssl@1.1
+    python setup.py build_ext --inplace --with-dataset --with-parquet --with-s3
+    python setup.py develop
+}
+
+build_arrow


### PR DESCRIPTION
For local development it's much faster to be able do python setup.py develop
So we use the previous thirdparty build script to build pyarrow against
system libarrow that we installed to enable liblance build.

The main change in this PR is changing the arrow ref being checked out. By
default this builds pyarrow 8.0.0.devXXX, which fails the pylance requirement
of pyarrow>=8,<9. Instead we use the 8.0.1 tag in pyarrow