### PR TITLE
Add support for Arrow temporal types, large binarys, and null type

### DIFF
--- a/cpp/src/lance/arrow/type.cc
+++ b/cpp/src/lance/arrow/type.cc
@@ -43,36 +43,34 @@ namespace lance::arrow {
   }
 }
 
+const static std::map<std::string, std::shared_ptr<::arrow::DataType>> kPrimitiveTypeMap = {
+    {"null", ::arrow::null()},
+    {"bool", ::arrow::boolean()},
+    {"int8", ::arrow::int8()},
+    {"uint8", ::arrow::uint8()},
+    {"int16", ::arrow::int16()},
+    {"uint16", ::arrow::uint16()},
+    {"int32", ::arrow::int32()},
+    {"uint32", ::arrow::uint32()},
+    {"int64", ::arrow::int64()},
+    {"uint64", ::arrow::uint64()},
+    {"halffloat", ::arrow::float16()},
+    {"float", ::arrow::float32()},
+    {"double", ::arrow::float64()},
+    {"string", ::arrow::utf8()},
+    {"binary", ::arrow::binary()},
+    {"large_string", ::arrow::large_utf8()},
+    {"large_binary", ::arrow::large_binary()},
+};
+
 ::arrow::Result<std::shared_ptr<::arrow::DataType>> FromLogicalType(
     ::arrow::util::string_view logical_type) {
   // TODO: optimize this lookup table?
-  if (logical_type == "bool") {
-    return ::arrow::boolean();
-  } else if (logical_type == "int8") {
-    return ::arrow::int8();
-  } else if (logical_type == "uint8") {
-    return ::arrow::utf8();
-  } else if (logical_type == "int16") {
-    return ::arrow::int16();
-  } else if (logical_type == "uint16") {
-    return ::arrow::uint16();
-  } else if (logical_type == "int32") {
-    return ::arrow::int32();
-  } else if (logical_type == "uint32") {
-    return ::arrow::uint32();
-  } else if (logical_type == "int64") {
-    return ::arrow::int64();
-  } else if (logical_type == "uint64") {
-    return ::arrow::uint64();
-  } else if (logical_type == "float") {
-    return ::arrow::float32();
-  } else if (logical_type == "double") {
-    return ::arrow::float64();
-  } else if (logical_type == "string") {
-    return ::arrow::utf8();
-  } else if (logical_type == "binary") {
-    return ::arrow::binary();
-  } else if (logical_type.starts_with("dict")) {
+  const auto& it = kPrimitiveTypeMap.find(logical_type.to_string());
+  if (it != kPrimitiveTypeMap.end()) {
+    return it->second;
+  }
+  if (logical_type.starts_with("dict")) {
     auto components = ::arrow::internal::SplitString(logical_type, ':');
     if (components.size() != 4) {
       return ::arrow::Status::Invalid(

--- a/cpp/src/lance/arrow/type.h
+++ b/cpp/src/lance/arrow/type.h
@@ -59,10 +59,13 @@ inline bool is_struct(const std::shared_ptr<::arrow::DataType>& dtype) {
   return dtype->id() == ::arrow::Type::STRUCT;
 }
 
-/// Returns True if the data type si a map.
+/// Returns True if the data type is a map.
 inline bool is_map(std::shared_ptr<::arrow::DataType> dtype) {
   return dtype->id() == ::arrow::Type::MAP;
 }
+
+/// Returns True if the data type is timestamp type.
+bool is_timestamp(std::shared_ptr<::arrow::DataType> dtype);
 
 /// Convert arrow DataType to a string representation.
 ::arrow::Result<std::string> ToLogicalType(std::shared_ptr<::arrow::DataType> dtype);

--- a/cpp/src/lance/arrow/type_test.cc
+++ b/cpp/src/lance/arrow/type_test.cc
@@ -45,6 +45,7 @@ TEST_CASE("Parse dictionary type") {
 TEST_CASE("Logical type coverage") {
   const auto kArrayTypeMap =
       std::vector<std::tuple<std::shared_ptr<::arrow::DataType>, std::string>>({
+          // Primitive types
           {::arrow::null(), "null"},
           {::arrow::boolean(), "bool"},
           {::arrow::int8(), "int8"},
@@ -62,6 +63,14 @@ TEST_CASE("Logical type coverage") {
           {::arrow::binary(), "binary"},
           {::arrow::large_utf8(), "large_string"},
           {::arrow::large_binary(), "large_binary"},
+          {::arrow::fixed_size_binary(1234), "fixed_size_binary:1234"},
+          // Time
+          {::arrow::date32(), "date32:day"},
+          {::arrow::date64(), "date64:ms"},
+          {::arrow::timestamp(::arrow::TimestampType::Unit::SECOND), "timestamp:s"},
+          {::arrow::timestamp(::arrow::TimestampType::Unit::MILLI), "timestamp:ms"},
+          {::arrow::timestamp(::arrow::TimestampType::Unit::MICRO), "timestamp:us"},
+          {::arrow::timestamp(::arrow::TimestampType::Unit::NANO), "timestamp:ns"},
       });
 
   for (auto& [arrow_type, type_str] : kArrayTypeMap) {

--- a/cpp/src/lance/arrow/type_test.cc
+++ b/cpp/src/lance/arrow/type_test.cc
@@ -71,6 +71,10 @@ TEST_CASE("Logical type coverage") {
           {::arrow::timestamp(::arrow::TimestampType::Unit::MILLI), "timestamp:ms"},
           {::arrow::timestamp(::arrow::TimestampType::Unit::MICRO), "timestamp:us"},
           {::arrow::timestamp(::arrow::TimestampType::Unit::NANO), "timestamp:ns"},
+          {::arrow::time32(::arrow::TimeUnit::SECOND), "time32:s"},
+          {::arrow::time32(::arrow::TimeUnit::MILLI), "time32:ms"},
+          {::arrow::time64(::arrow::TimeUnit::MICRO), "time64:us"},
+          {::arrow::time64(::arrow::TimeUnit::NANO), "time64:ns"},
       });
 
   for (auto& [arrow_type, type_str] : kArrayTypeMap) {

--- a/cpp/src/lance/arrow/type_test.cc
+++ b/cpp/src/lance/arrow/type_test.cc
@@ -17,7 +17,9 @@
 #include <arrow/type.h>
 
 #include <catch2/catch_test_macros.hpp>
+#include <memory>
 #include <string>
+#include <tuple>
 #include <vector>
 
 using std::string;
@@ -37,4 +39,34 @@ TEST_CASE("Parse dictionary type") {
 
   actual = lance::arrow::FromLogicalType(logical_type).ValueOrDie();
   CHECK(dict_type->Equals(actual));
+}
+
+// Type reference: https://arrow.apache.org/docs/cpp/api/datatype.html
+TEST_CASE("Logical type coverage") {
+  const auto kArrayTypeMap =
+      std::vector<std::tuple<std::shared_ptr<::arrow::DataType>, std::string>>({
+          {::arrow::null(), "null"},
+          {::arrow::boolean(), "bool"},
+          {::arrow::int8(), "int8"},
+          {::arrow::uint8(), "uint8"},
+          {::arrow::int16(), "int16"},
+          {::arrow::uint16(), "uint16"},
+          {::arrow::int32(), "int32"},
+          {::arrow::uint32(), "uint32"},
+          {::arrow::int64(), "int64"},
+          {::arrow::uint64(), "uint64"},
+          {::arrow::float16(), "halffloat"},
+          {::arrow::float32(), "float"},
+          {::arrow::float64(), "double"},
+          {::arrow::utf8(), "string"},
+          {::arrow::binary(), "binary"},
+          {::arrow::large_utf8(), "large_string"},
+          {::arrow::large_binary(), "large_binary"},
+      });
+
+  for (auto& [arrow_type, type_str] : kArrayTypeMap) {
+    INFO("Data type: " << arrow_type->ToString() << " type string: " << type_str);
+    CHECK(lance::arrow::ToLogicalType(arrow_type).ValueOrDie() == type_str);
+    CHECK(lance::arrow::FromLogicalType(type_str).ValueOrDie()->Equals(arrow_type));
+  }
 }

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -1,5 +1,5 @@
 [build-system]
-requires = ["setuptools>=42", "wheel", "ninja", "numpy", "cython", "pyarrow<9"]
+requires = ["setuptools>=42", "wheel", "ninja", "numpy", "cython", "pyarrow>=9,<10"]
 build-backend = "setuptools.build_meta"
 
 [tool.isort]

--- a/python/setup.py
+++ b/python/setup.py
@@ -68,7 +68,7 @@ setup(
     long_description_content_type="text/markdown",
     ext_modules=cythonize(extensions, language_level="3"),
     zip_safe=False,
-    install_requires=["pyarrow>=8,<9"],
+    install_requires=["pyarrow>=9,<10"],
     extras_require={"test": ["pytest>=6.0", "pandas", "duckdb"]},
     python_requires=">=3.8",
     packages=find_packages(),

--- a/python/thirdparty/build.sh
+++ b/python/thirdparty/build.sh
@@ -1,0 +1,22 @@
+#!/bin/bash
+
+set -ex
+
+APACHE_ARROW_VERSION=apache-arrow-8.0.1
+
+# Build apache arrow
+build_arrow() {
+    git clone git@github.com:apache/arrow
+    pushd arrow
+    git pull --tags    
+    git checkout ${APACHE_ARROW_VERSION}
+    git submodule update --init
+    pushd python
+    pip install -r requirements-build.txt
+
+    export OPENSSL_ROOT_DIR=/opt/homebrew/opt/openssl@1.1
+    python setup.py build_ext --inplace --with-dataset --with-parquet --with-s3
+    python setup.py develop
+}
+
+build_arrow

--- a/python/thirdparty/build.sh
+++ b/python/thirdparty/build.sh
@@ -2,7 +2,7 @@
 
 set -ex
 
-APACHE_ARROW_VERSION=apache-arrow-8.0.1
+APACHE_ARROW_VERSION=apache-arrow-9.0.0
 
 # Build apache arrow
 build_arrow() {

--- a/python/tools/Dockerfile.manylinux2014
+++ b/python/tools/Dockerfile.manylinux2014
@@ -2,13 +2,12 @@ FROM quay.io/pypa/manylinux2014_x86_64
 
 ENV LD_LIBRARY_PATH=/usr/local/lib
 
-ENV ARROW_VERSION=8.0.0-1.el7.x86_64
+ENV ARROW_VERSION=9.0.0-1.el7.x86_64
 
 RUN yum update -y \
   && yum install -y epel-release || yum install -y https://dl.fedoraproject.org/pub/epel/epel-release-latest-$(cut -d: -f5 /etc/system-release-cpe | cut -d. -f1).noarch.rpm \
-  && yum install -y https://apache.jfrog.io/artifactory/arrow/centos/7/x86_64/Packages/apache-arrow-release-8.0.0-1.el7.noarch.rpm \
+  && yum install -y https://apache.jfrog.io/artifactory/arrow/centos/7/x86_64/Packages/apache-arrow-release-9.0.0-1.el7.noarch.rpm \
   && yum install -y --enablerepo=epel \
-  arrow-python-devel-${ARROW_VERSION} \
   arrow-devel-${ARROW_VERSION} \
   arrow-glib-devel-${ARROW_VERSION} \
   arrow-dataset-devel-${ARROW_VERSION} \

--- a/python/tools/auditwheel
+++ b/python/tools/auditwheel
@@ -9,10 +9,10 @@ from auditwheel.policy import _POLICIES as POLICIES
 for p in POLICIES:
     p["lib_whitelist"].extend(
         [
-            "libarrow.so.800",
-            "libarrow_dataset.so.800",
-            "libarrow_python.so.800",
-            "libparquet.so.800",
+            "libarrow.so.900",
+            "libarrow_dataset.so.900",
+            "libarrow_python.so.900",
+            "libparquet.so.900",
         ]
     )
 

--- a/python/tools/build_manylinux_wheels.sh
+++ b/python/tools/build_manylinux_wheels.sh
@@ -23,10 +23,10 @@ pushd /code/python
 rm -rf wheels dist build
 for py in "${py_versions[@]}"
 do
-  /opt/python/${py}-${py}/bin/pip install numpy "pyarrow<9" cython
+  /opt/python/${py}-${py}/bin/pip install numpy "pyarrow>=9,<10" cython
   /opt/python/${py}-${py}/bin/python setup.py bdist_wheel
 done
 
 for whl in dist/*.whl; do
-    /code/python/tools/auditwheel repair "$whl" -w wheels
+  /code/python/tools/auditwheel repair "$whl" -w wheels
 done


### PR DESCRIPTION
Add type parsing for:

* timestamp
* date32/date64
* time32/time64
* null

Upgrade arrow to 9.0 and fix CI.

Closes #30 