### PR TITLE
Fix warnings for CMP0135

### DIFF
--- a/cpp/CMakeLists.txt
+++ b/cpp/CMakeLists.txt
@@ -14,7 +14,7 @@
 
 cmake_minimum_required(VERSION 3.22)
 
-if (${CMAKE_VERSION} VERSION_GREATER "3.23")
+if (${CMAKE_VERSION} VERSION_GREATER_EQUAL "3.24")
     cmake_policy(SET CMP0135 NEW)
 endif ()
 

--- a/cpp/CMakeLists.txt
+++ b/cpp/CMakeLists.txt
@@ -14,6 +14,10 @@
 
 cmake_minimum_required(VERSION 3.22)
 
+if (${CMAKE_VERSION} VERSION_GREATER "3.23")
+    cmake_policy(SET CMP0135 NEW)
+endif ()
+
 project(lance CXX)
 
 set(CMAKE_CXX_STANDARD 20)


### PR DESCRIPTION
Fix a new CMake warning appears with cmake 2.24