### PR TITLE
Parse ExtensionType

### DIFF
--- a/cpp/src/lance/arrow/type.cc
+++ b/cpp/src/lance/arrow/type.cc
@@ -77,12 +77,15 @@ std::string ToString(::arrow::TimeUnit::type unit) {
                        dict_type->index_type()->ToString(),
                        dict_type->ordered());
   } else if (::lance::arrow::is_extension(dtype)) {
-    // TODO what if extension_name has a `:` in it?
     auto ext_type = std::dynamic_pointer_cast<::arrow::ExtensionType>(dtype);
+    // TODO how to deal with parametric types?
+    if (ext_type->extension_name().find(':') != std::string::npos) {
+      return ::arrow::Status::Invalid(fmt::format("Extension name {} cannot have a ':' in it", ext_type->extension_name()));
+    }
     return fmt::format("extension:{}",
                        ext_type->extension_name());
   } else {
-      return dtype->ToString();
+    return dtype->ToString();
   }
 }
 

--- a/cpp/src/lance/arrow/type.h
+++ b/cpp/src/lance/arrow/type.h
@@ -67,6 +67,11 @@ inline bool is_map(std::shared_ptr<::arrow::DataType> dtype) {
 /// Returns True if the data type is timestamp type.
 bool is_timestamp(std::shared_ptr<::arrow::DataType> dtype);
 
+/// Returns True if the given Arrow DataType is an ExtensionType
+inline bool is_extension(std::shared_ptr<::arrow::DataType> dtype) {
+  return dtype->id() == ::arrow::Type::EXTENSION;
+}
+
 /// Convert arrow DataType to a string representation.
 ::arrow::Result<std::string> ToLogicalType(std::shared_ptr<::arrow::DataType> dtype);
 

--- a/cpp/src/lance/format/visitors.cc
+++ b/cpp/src/lance/format/visitors.cc
@@ -44,7 +44,7 @@ std::shared_ptr<::arrow::Schema> ToArrowVisitor::Finish() { return ::arrow::sche
 
 ::arrow::Result<::std::shared_ptr<::arrow::Field>> ToArrowVisitor::DoVisit(
     std::shared_ptr<Field> node) {
-  return std::make_shared<::arrow::Field>(node->name(), node->type());
+  return node->ToArrow();
 }
 
 WriteDictionaryVisitor::WriteDictionaryVisitor(std::shared_ptr<::arrow::io::OutputStream> out)


### PR DESCRIPTION
We use `extension:<extension_name>` as the lance logical type for Arrow ExtensionType.

This PR is just for the logical type parsing

Next steps (i'll make separate PR's for easier review):

- [ ] Lance Field/Schema needs to be able to translate to/from ExtensionType and storage type. 
- [ ] Lance writer needs to be able to write extension arrays
- [ ] Lance reader needs to be able to read extension arrays