### PR TITLE
Coco benchmarks for lance and parquet formats

### DIFF
--- a/python/benchmarks/bench_utils.py
+++ b/python/benchmarks/bench_utils.py
@@ -107,13 +107,12 @@ class Benchmark:
         self.func = func
         self.key = key
         self.num_runs = num_runs
-        self._components = {}
+        self._timings = {}
 
     def repeat(self, num_runs: int):
         return Benchmark(self.name, self.func, key=self.key, num_runs=num_runs)
 
     def run(self, *args, **kwargs):
-        self._components = {}
         output = None
         func = self.timeit("total")(self.func)
         for i in range(self.num_runs):
@@ -121,7 +120,7 @@ class Benchmark:
         return output
 
     def to_df(self):
-        return pd.DataFrame(self._components)
+        return pd.DataFrame(self._timings)
 
     def timeit(self, name):
         def benchmark_decorator(func):
@@ -134,7 +133,7 @@ class Benchmark:
                 # first item in the args, ie `args[0]` is `self`
                 print(f"Function {func.__name__}{args} {kwargs} Took {total_time:.4f} seconds")
                 key = tuple([name] + [kwargs.get(k) for k in self.key])
-                self._components.setdefault(key, []).append(total_time)
+                self._timings.setdefault(key, []).append(total_time)
                 return result
             return timeit_wrapper
         return benchmark_decorator

--- a/python/benchmarks/coco.py
+++ b/python/benchmarks/coco.py
@@ -46,6 +46,7 @@ def filter_data(base_uri: str, fmt: str, flavor: str = None):
         return _filter_data_parquet(base_uri, flavor=flavor)
     raise NotImplementedError()
 
+
 def _label_distribution_raw(base_uri: str):
     """Minic
     SELECT label, count(1) FROM coco_dataset GROUP BY 1

--- a/python/benchmarks/coco.py
+++ b/python/benchmarks/coco.py
@@ -104,9 +104,9 @@ def _filter_data_lance(base_uri: str, klass="cat", offset=20, limit=50):
     query = (f"SELECT distinct id FROM ("
              f"  SELECT id, UNNEST(annotations) as ann FROM index_scanner"
              f") WHERE ann.label == '{klass}'")
-    filtered_ids = duckdb.query(query).arrow().column("id").to_numpy().tolist()
-    scanner = lance.scanner(uri, ['image', 'annotations.label'],
-                            filter=pc.field("annotations", "label") == klass,
+    filtered_ids = duckdb.query(query).arrow().column("id").combine_chunks()
+    scanner = lance.scanner(uri, ['id', 'image', 'annotations.label'],
+                            #filter=pc.field("id").isin(filtered_ids),
                             limit=50, offset=20)
     return scanner.to_table().to_pandas()
 

--- a/python/benchmarks/coco.py
+++ b/python/benchmarks/coco.py
@@ -106,6 +106,7 @@ def _filter_data_lance(base_uri: str, klass="cat", offset=20, limit=50):
              f") WHERE ann.label == '{klass}'")
     filtered_ids = duckdb.query(query).arrow().column("id").to_numpy().tolist()
     scanner = lance.scanner(uri, ['image', 'annotations.label'],
+                            filter=pc.field("annotations", "label") == klass,
                             limit=50, offset=20)
     return scanner.to_table().to_pandas()
 
@@ -154,6 +155,7 @@ def main(base_uri, fmt, flavor, benchmark, repeats, output):
     if fmt:
         fmt = fmt.strip().lower()
         assert fmt in KNOWN_FORMATS
+        fmt = [fmt]
     else:
         fmt = KNOWN_FORMATS
     base_uri = f'{base_uri}/datasets/coco'

--- a/python/benchmarks/coco.py
+++ b/python/benchmarks/coco.py
@@ -1,24 +1,17 @@
 #!/usr/bin/env python3
-import pathlib
-from typing import Union
 
-import click
-import json
-import os
+from typing import Union
 
 import duckdb
 import pandas as pd
-import pyarrow as pa
-import pyarrow.dataset as ds
-import pyarrow.fs
-import pyarrow.compute as pc
 
 import lance
-from parse_coco import CocoConverter
+import pyarrow.compute as pc
+import pyarrow.dataset as ds
 from bench_utils import download_uris, get_uri, get_dataset, BenchmarkSuite
+from parse_coco import CocoConverter
 
-
-coco_benchmarks = BenchmarkSuite()
+coco_benchmarks = BenchmarkSuite("coco")
 
 
 @coco_benchmarks.benchmark("label_distribution", key=['fmt', 'flavor'])
@@ -52,14 +45,14 @@ def _label_distribution_raw(base_uri: str):
     SELECT label, count(1) FROM coco_dataset GROUP BY 1
     """
     c = CocoConverter(base_uri)
-    df = c.read_instances()
+    df = c.read_metadata()
     return pd.json_normalize(df.annotations.explode()).name.value_counts()
 
 
 def _filter_data_raw(base_uri: str, klass="cat", offset=20, limit=50):
     """SELECT image, annotations FROM coco WHERE annotations.label = 'cat' LIMIT 50 OFFSET 20"""
     c = CocoConverter(base_uri)
-    df = c.read_instances()
+    df = c.read_metadata()
     mask = df.annotations.apply(lambda ann: any([a["name"] == klass for a in ann]))
     filtered = df.loc[mask, ["image_uri", "annotations"]]
     limited = filtered[offset:offset + limit]
@@ -75,7 +68,7 @@ def _filter_data_lance(base_uri: str, klass="cat", offset=20, limit=50, flavor=N
              f") WHERE ann.name == '{klass}'")
     filtered_ids = duckdb.query(query).arrow().column("image_id").combine_chunks()
     scanner = lance.scanner(uri, ['image_id', 'image', 'annotations.name'],
-                            #filter=pc.field("image_id").isin(filtered_ids),
+                            # filter=pc.field("image_id").isin(filtered_ids),
                             limit=50, offset=20)
     return scanner.to_table().to_pandas()
 
@@ -87,7 +80,11 @@ def _filter_data_parquet(base_uri: str, klass="cat", offset=20, limit=50, flavor
              f"  SELECT image_id, UNNEST(annotations) as ann FROM dataset"
              f") WHERE ann.name == '{klass}'")
     filtered_ids = duckdb.query(query).arrow().column("image_id").to_numpy().tolist()
-    return duckdb.query("SELECT image, annotations FROM dataset LIMIT 50 OFFSET 20").to_arrow_table()
+    id_string = ','.join([f"'{x}'" for x in filtered_ids])
+    return duckdb.query(f"SELECT image, annotations "
+                        f"FROM dataset "
+                        f"WHERE image_id in ({id_string}) "
+                        f"LIMIT 50 OFFSET 20").to_arrow_table()
 
 
 def _label_distribution_lance(dataset: ds.Dataset):
@@ -104,45 +101,6 @@ def _label_distribution_duckdb(arrow_obj: Union[ds.Dataset | ds.Scanner]):
     return duckdb.query(query).to_df()
 
 
-KNOWN_FORMATS = ["lance", "parquet", "raw"]
-
-
-@click.command
-@click.option('-u', '--base-uri', required=True, type=str,
-              help="Base uri to the benchmark dataset catalog")
-@click.option('-f', '--format', 'fmt',
-              help="'lance', 'parquet', or 'raw'. Omit for all")
-@click.option('--flavor', type=str,
-              help="external if parquet/lance had external images version")
-@click.option('-b', '--benchmark', type=str,
-              help="which benchmark to run. Omit for all")
-@click.option('-r', '--repeats', type=int,
-              help="number of times to run each benchmark")
-@click.option('-o', '--output', type=str,
-              help="save timing results to directory")
-def main(base_uri, fmt, flavor, benchmark, repeats, output):
-    if fmt:
-        fmt = fmt.strip().lower()
-        assert fmt in KNOWN_FORMATS
-        fmt = [fmt]
-    else:
-        fmt = KNOWN_FORMATS
-    base_uri = f'{base_uri}/datasets/coco'
-
-    def run_benchmark(bmark):
-        b = bmark.repeat(repeats or 1)
-        for f in fmt:
-            b.run(base_uri=base_uri, fmt=f, flavor=flavor)
-        if output:
-            path = pathlib.Path(output) / f"{bmark.name}.csv"
-            b.to_df().to_csv(path, index=False)
-
-    if benchmark is not None:
-        b = coco_benchmarks.get_benchmark(benchmark)
-        run_benchmark(b)
-    else:
-        [run_benchmark(b) for b in coco_benchmarks.list_benchmarks()]
-
-
 if __name__ == "__main__":
+    main = coco_benchmarks.create_main()
     main()

--- a/python/benchmarks/oxford_pet.py
+++ b/python/benchmarks/oxford_pet.py
@@ -1,48 +1,74 @@
-import multiprocessing as mp
+#!/usr/bin/env python3
+
 import os
+from typing import Optional
 
-import numpy as np
+import duckdb
 import pandas as pd
-import pyarrow.fs as fs
+
+import lance
+import pyarrow as pa
+import pyarrow.compute as pc
+import pyarrow.dataset
+from bench_utils import BenchmarkSuite, download_uris
+from parse_pet import OxfordPetConverter
+
+oxford_pet_benchmarks = BenchmarkSuite("oxford_pet")
 
 
-def read_pets_metadata(url):
-    list_txt = os.path.join(url, "annotations/list.txt")
-    df = pd.read_csv(list_txt, delimiter=" ", comment="#", header=None)
-    df.columns = ["filename", "class", "species", "breed"]
-
-    species_dtype = pd.CategoricalDtype(["Unknown", "Cat", "Dog"])
-    df.species = pd.Categorical.from_codes(df.species, dtype=species_dtype)
-
-    breeds = df.filename.str.rsplit("_", 1).str[0].unique()
-    assert len(breeds) == 37
-
-    breeds = np.concatenate([["Unknown"], breeds])
-    class_dtype = pd.CategoricalDtype(breeds)
-    df["class"] = pd.Categorical.from_codes(df["class"], dtype=class_dtype)
-
-    return df
+@oxford_pet_benchmarks.benchmark("label_distribution", key=['fmt', 'flavor'])
+def label_distribution(base_uri: str, fmt: str, flavor: Optional[str]):
+    if fmt == "raw":
+        return get_pets_class_distribution(base_uri)
+    suffix = '' if not flavor else f'_{flavor}'
+    ds = _get_dataset(os.path.join(base_uri, f'oxford_pet{suffix}.{fmt}'), fmt)
+    query = "SELECT class, count(1) FROM ds GROUP BY 1"
+    return duckdb.query(query).to_df()
 
 
-def get_pets_class_distribution(url):
-    # %time df = bench.get_pets_class_distribution(url)
-    df = read_pets_metadata(url)
+@oxford_pet_benchmarks.benchmark("filter_data", key=['fmt', 'flavor'])
+def filter_data(base_uri: str, fmt: str, flavor: Optional[str]):
+    if fmt == "raw":
+        return get_pets_filtered_data(base_uri)
+    suffix = '' if not flavor else f'_{flavor}'
+    uri = os.path.join(base_uri, f'oxford_pet{suffix}.{fmt}')
+    if fmt == "parquet":
+        ds = _get_dataset(uri, fmt)
+        query = ("SELECT image, class FROM ds WHERE class='pug' "
+                 "LIMIT 50 OFFSET 20")
+        return duckdb.query(query).to_df()
+    elif fmt == "lance":
+        scanner = lance.scanner(uri, columns=["image", "class"],
+                                filter=pc.field("class") == "pug",
+                                limit=50, offset=20)
+        return scanner.to_table().to_pandas()
+
+
+def _get_dataset(uri, fmt):
+    if fmt == "parquet":
+        return pa.dataset.dataset(uri)
+    elif fmt == "lance":
+        return lance.dataset(uri)
+    raise NotImplementedError()
+
+
+def get_pets_class_distribution(base_uri):
+    c = OxfordPetConverter(base_uri)
+    df = c.read_metadata()
     return df.groupby("class")["class"].count()
 
 
-def get_pets_filtered_data(url, klass="pug", offset=20, limit=50):
-    # %time rs = bench.get_pets_filtered_data(url, "pug", 20, 50)
-    df = read_pets_metadata(url)
+def get_pets_filtered_data(base_uri, klass="pug", offset=20, limit=50):
+    c = OxfordPetConverter(base_uri)
+    df = c.read_metadata()
     filtered = df.loc[df["class"] == klass, ["class", "filename"]]
-    limited = filtered[offset : offset + limit]
-    pool = mp.Pool(mp.cpu_count() - 1)
-    all_bytes = pool.map(get_bytes, limited.filename.values)
-    limited["image"] = all_bytes
+    limited = filtered[offset: offset + limit]
+    uris = [os.path.join(base_uri, f"images/{x}.jpg")
+            for x in limited.filename.values]
+    limited.assign(images=download_uris(pd.Series(uris)))
     return limited
 
 
-def get_bytes(name):
-    s3, key = fs.FileSystem.from_uri(
-        f"s3://eto-public/datasets/oxford_pet/images/{name}.jpg"
-    )
-    return s3.open_input_file(key).read()
+if __name__ == "__main__":
+    main = oxford_pet_benchmarks.create_main()
+    main()

--- a/python/benchmarks/oxford_pet.py
+++ b/python/benchmarks/oxford_pet.py
@@ -62,11 +62,10 @@ def get_pets_filtered_data(base_uri, klass="pug", offset=20, limit=50):
     c = OxfordPetConverter(base_uri)
     df = c.read_metadata()
     filtered = df.loc[df["class"] == klass, ["class", "filename"]]
-    limited = filtered[offset: offset + limit]
+    limited: pd.DataFrame = filtered[offset: offset + limit]
     uris = [os.path.join(base_uri, f"images/{x}.jpg")
             for x in limited.filename.values]
-    limited.assign(images=download_uris(pd.Series(uris)))
-    return limited
+    return limited.assign(images=download_uris(pd.Series(uris)))
 
 
 if __name__ == "__main__":

--- a/python/benchmarks/parse_coco.py
+++ b/python/benchmarks/parse_coco.py
@@ -32,6 +32,7 @@ class CocoConverter(DatasetConverter):
         category_df = (pd.DataFrame(instances_json["categories"])
                        .rename({'id': 'category_id'}, axis=1))
         annotations_df = df.merge(category_df, on="category_id")
+        annotations_df['iscrowd'] = annotations_df.iscrowd.astype(bool)
         anno_df = (
             pd.DataFrame(
                 {
@@ -86,7 +87,7 @@ class CocoConverter(DatasetConverter):
         ])
         names = ['segmentation', 'area', 'iscrowd', 'bbox', 'category_id', 'id',
                  'supercategory', 'name']
-        types = [segmentation_type, pa.float64(), pa.int8(),
+        types = [segmentation_type, pa.float64(), pa.bool_(),
                  pa.list_(pa.float32()), pa.int16(), pa.int64(),
                  pa.utf8(), pa.utf8()]
         schema = pa.list_(pa.struct([pa.field(name, dtype)

--- a/python/benchmarks/parse_coco.py
+++ b/python/benchmarks/parse_coco.py
@@ -1,0 +1,130 @@
+#!/usr/bin/env python
+"""Parse coco dataset"""
+import click
+import json
+import os
+
+import pandas as pd
+import pyarrow as pa
+import pyarrow.fs
+import pyarrow.parquet as pq
+
+import lance
+
+
+class CocoConverter:
+
+    def __init__(self, dataset_root, version='2017'):
+        self.dataset_root = dataset_root
+        self.version = version
+
+    def _get_instances_json(self, split):
+        uri = os.path.join(self.dataset_root, 'annotations',
+                           f'instances_{split}{self.version}.json')
+        fs, path = pa.fs.FileSystem.from_uri(uri)
+        with fs.open_input_file(path) as fobj:
+            return json.load(fobj)
+
+    def _instances_to_df(self, split, instances_json):
+        df = pd.DataFrame(instances_json["annotations"])
+        df['segmentation'] = df.segmentation.apply(_convert_segmentation)
+        category_df = (pd.DataFrame(instances_json["categories"])
+                       .rename({'id': 'category_id'}, axis=1))
+        annotations_df = df.merge(category_df, on="category_id")
+        anno_df = (
+            pd.DataFrame(
+                {
+                    "image_id": df.image_id,
+                    "annotations": annotations_df.drop(
+                        columns=["image_id"], axis=1
+                    ).to_dict(orient="records"),
+                }
+            )
+            .groupby("image_id")
+            .agg(list)
+        ).reset_index()
+        images_df = (pd.DataFrame(instances_json["images"])
+                     .rename({'id': 'image_id'}, axis=1))
+        images_df["split"] = split
+        images_df["image_uri"] = images_df["file_name"].apply(
+            lambda fname: os.path.join(self.dataset_root,
+                                       f"{split}{self.version}", fname)
+        )
+        # TODO join images_df.license to instances_json['license']
+        return images_df.merge(anno_df, on="image_id")
+
+    def read_instances(self) -> pd.DataFrame:
+        def read_split(split):
+            json_data = self._get_instances_json(split)
+            return self._instances_to_df(split, json_data)
+        df = pd.concat([read_split(split) for split in ['train', 'val']])
+        # df['date_captured'] = pd.to_datetime(df.date_captured)  # lance GH#98
+        return df
+
+    def save_df(self, df, fmt='lance', output_path=None):
+        if output_path is None:
+            output_path = os.path.join(self.dataset_root, f'coco_links.{fmt}')
+        table = pa.Table.from_pandas(df, get_schema())
+        if fmt == 'parquet':
+            return pq.write_table(table, output_path)
+        elif fmt == 'lance':
+            return lance.write_table(table, output_path)
+
+
+def _ann_schema():
+    segmentation_type = pa.struct([
+        pa.field("polygon", pa.list_(pa.list_(pa.int32()))),
+        pa.field("coco_rle", pa.struct([
+            pa.field('counts', pa.list_(pa.int32())),
+            pa.field('size', pa.list_(pa.int32()))])),
+    ])
+    names = ['segmentation', 'area', 'iscrowd', 'bbox', 'category_id', 'id',
+             'supercategory', 'name']
+    types = [segmentation_type, pa.float64(), pa.int8(),
+             pa.list_(pa.float32()), pa.int16(), pa.int64(),
+             pa.utf8(), pa.utf8()]
+    schema = pa.list_(pa.struct([pa.field(name, dtype)
+                                 for name, dtype in zip(names, types)]))
+    return schema
+
+
+def get_schema():
+    names = ['license', 'file_name', 'coco_url', 'height', 'width',
+             'date_captured', 'flickr_url', 'image_id', 'split', 'image_uri',
+             'annotations']
+    types = [pa.int64(), pa.utf8(), pa.utf8(), pa.int64(), pa.int64(),
+             pa.utf8(), pa.utf8(), pa.int64(), pa.utf8(), pa.utf8(),
+             _ann_schema()]
+    return pa.schema([pa.field(name, dtype)
+                      for name, dtype in zip(names, types)])
+
+
+def _convert_segmentation(s):
+    if isinstance(s, list):
+        return {'polygon': s}
+    return s
+
+
+@click.command
+@click.option('-u', '--base-uri', type=str, help='Coco dataset root')
+@click.option('-v', '--version', type=str, default='2017',
+              help='Dataset version. Default 2017')
+@click.option('-f', '--fmt', type=str,
+              help='Output format (parquet or lance)')
+@click.option('-o', '--output-path', type=str,
+              help='Output path. Default is {base_uri}/coco_links.{fmt}')
+def main(base_uri, version, fmt, output_path):
+    converter = CocoConverter(base_uri, version=version)
+    df = converter.read_instances()
+    known_formats = ['lance', 'parquet']
+    if fmt is not None:
+        assert fmt in known_formats
+        fmt = [fmt]
+    else:
+        fmt = known_formats
+    for f in fmt:
+        return converter.save_df(df, f, output_path)
+
+
+if __name__ == '__main__':
+    main()

--- a/python/benchmarks/parse_coco.py
+++ b/python/benchmarks/parse_coco.py
@@ -10,17 +10,17 @@ import pyarrow.fs
 import pyarrow.parquet as pq
 
 import lance
-from bench_utils import download_uris
+from bench_utils import download_uris, DatasetConverter
 
 
-class CocoConverter:
+class CocoConverter(DatasetConverter):
 
-    def __init__(self, dataset_root, version='2017'):
-        self.dataset_root = dataset_root
+    def __init__(self, uri_root, version='2017'):
+        super(CocoConverter, self).__init__("coco", uri_root)
         self.version = version
 
     def _get_instances_json(self, split):
-        uri = os.path.join(self.dataset_root, 'annotations',
+        uri = os.path.join(self.uri_root, 'annotations',
                            f'instances_{split}{self.version}.json')
         fs, path = pa.fs.FileSystem.from_uri(uri)
         with fs.open_input_file(path) as fobj:
@@ -48,70 +48,50 @@ class CocoConverter:
                      .rename({'id': 'image_id'}, axis=1))
         images_df["split"] = split
         images_df["image_uri"] = images_df["file_name"].apply(
-            lambda fname: os.path.join(self.dataset_root,
+            lambda fname: os.path.join(self.uri_root,
                                        f"{split}{self.version}", fname)
         )
         # TODO join images_df.license to instances_json['license']
         return images_df.merge(anno_df, on="image_id")
 
-    def read_instances(self) -> pd.DataFrame:
+    def read_metadata(self) -> pd.DataFrame:
         def read_split(split):
             json_data = self._get_instances_json(split)
             return self._instances_to_df(split, json_data)
+
         df = pd.concat([read_split(split) for split in ['train', 'val']])
         # df['date_captured'] = pd.to_datetime(df.date_captured)  # lance GH#98
         return df
 
-    def save_df(self, df, fmt='lance', output_path=None):
-        if output_path is None:
-            output_path = os.path.join(self.dataset_root, f'coco_links.{fmt}')
-        table = pa.Table.from_pandas(df, get_schema())
-        if fmt == 'parquet':
-            pq.write_table(table, output_path)
-        elif fmt == 'lance':
-            lance.write_table(table, output_path)
-        return table
+    def image_uris(self, table):
+        return table["image_uri"].to_numpy()
 
-    def make_embedded_dataset(self, table: pa.Table, fmt='lance', output_path=None):
-        if output_path is None:
-            output_path = os.path.join(self.dataset_root, f'coco.{fmt}')
-        uris = table["image_uri"].to_numpy()
-        images = download_uris(pd.Series(uris))
-        arr = pa.BinaryArray.from_pandas(images)
-        embedded = table.append_column(pa.field("image", pa.binary()), arr)
-        if fmt == 'parquet':
-            pq.write_table(embedded, output_path)
-        elif fmt == 'lance':
-            lance.write_table(embedded, output_path)
-        return embedded
+    def get_schema(self):
+        names = ['license', 'file_name', 'coco_url', 'height', 'width',
+                 'date_captured', 'flickr_url', 'image_id', 'split', 'image_uri',
+                 'annotations']
+        types = [pa.int64(), pa.utf8(), pa.utf8(), pa.int64(), pa.int64(),
+                 pa.utf8(), pa.utf8(), pa.int64(), pa.utf8(), pa.utf8(),
+                 self._ann_schema()]
+        return pa.schema([pa.field(name, dtype)
+                          for name, dtype in zip(names, types)])
 
-
-def _ann_schema():
-    segmentation_type = pa.struct([
-        pa.field("polygon", pa.list_(pa.list_(pa.int32()))),
-        pa.field("coco_rle", pa.struct([
-            pa.field('counts', pa.list_(pa.int32())),
-            pa.field('size', pa.list_(pa.int32()))])),
-    ])
-    names = ['segmentation', 'area', 'iscrowd', 'bbox', 'category_id', 'id',
-             'supercategory', 'name']
-    types = [segmentation_type, pa.float64(), pa.int8(),
-             pa.list_(pa.float32()), pa.int16(), pa.int64(),
-             pa.utf8(), pa.utf8()]
-    schema = pa.list_(pa.struct([pa.field(name, dtype)
-                                 for name, dtype in zip(names, types)]))
-    return schema
-
-
-def get_schema():
-    names = ['license', 'file_name', 'coco_url', 'height', 'width',
-             'date_captured', 'flickr_url', 'image_id', 'split', 'image_uri',
-             'annotations']
-    types = [pa.int64(), pa.utf8(), pa.utf8(), pa.int64(), pa.int64(),
-             pa.utf8(), pa.utf8(), pa.int64(), pa.utf8(), pa.utf8(),
-             _ann_schema()]
-    return pa.schema([pa.field(name, dtype)
-                      for name, dtype in zip(names, types)])
+    @staticmethod
+    def _ann_schema():
+        segmentation_type = pa.struct([
+            pa.field("polygon", pa.list_(pa.list_(pa.int32()))),
+            pa.field("coco_rle", pa.struct([
+                pa.field('counts', pa.list_(pa.int32())),
+                pa.field('size', pa.list_(pa.int32()))])),
+        ])
+        names = ['segmentation', 'area', 'iscrowd', 'bbox', 'category_id', 'id',
+                 'supercategory', 'name']
+        types = [segmentation_type, pa.float64(), pa.int8(),
+                 pa.list_(pa.float32()), pa.int16(), pa.int64(),
+                 pa.utf8(), pa.utf8()]
+        schema = pa.list_(pa.struct([pa.field(name, dtype)
+                                     for name, dtype in zip(names, types)]))
+        return schema
 
 
 def _convert_segmentation(s):
@@ -130,7 +110,7 @@ def _convert_segmentation(s):
               help='Output path. Default is {base_uri}/coco_links.{fmt}')
 def main(base_uri, version, fmt, output_path):
     converter = CocoConverter(base_uri, version=version)
-    df = converter.read_instances()
+    df = converter.read_metadata()
     known_formats = ['lance', 'parquet']
     if fmt is not None:
         assert fmt in known_formats

--- a/python/benchmarks/parse_pet.py
+++ b/python/benchmarks/parse_pet.py
@@ -11,37 +11,97 @@
 #  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 #  See the License for the specific language governing permissions and
 #  limitations under the License.
+
+import multiprocessing as mp
 import os
+import pathlib
+from typing import Iterable
 
 import numpy as np
 import pandas as pd
+import xmltodict
 
 import pyarrow as pa
-from bench_utils import DatasetConverter
+import pyarrow.fs
+from bench_utils import DatasetConverter, download_uris, read_file
+
+
+# Oxford PET has dataset quality issues:
+#
+# The following exists in the XMLs but are not part of the list.txt index
+# Bombay_11,Bombay_189,Bombay_190,Bombay_192,Egyptian_Mau_129,Egyptian_Mau_183,
+# Siamese_203,english_cocker_spaniel_162,english_cocker_spaniel_163,
+# english_cocker_spaniel_164,english_cocker_spaniel_179,newfoundland_152,
+# newfoundland_153,newfoundland_154,newfoundland_155
+#
+# The following are listed as trainval set but do not have xml annotations:
+# Abyssinian_104,Bengal_111,samoyed_10,Bengal_175,Egyptian_Mau_14,
+# Egyptian_Mau_156,Egyptian_Mau_186,Ragdoll_199,saint_bernard_15
 
 
 class OxfordPetConverter(DatasetConverter):
 
     def __init__(self, uri_root):
         super(OxfordPetConverter, self).__init__("oxford_pet", uri_root)
+        self._data_quality_issues = {}
 
-    def read_metadata(self) -> pd.DataFrame:
+    def read_metadata(self, check_quality=False) -> pd.DataFrame:
+        df = self._get_index("list")
+        self._to_category(df)
+        trainval = self._get_index("trainval")
+        i = self._find_split_index(trainval)
+        train = pd.Series("train", index=trainval.filename[:i])
+        val = pd.Series("val", index=trainval.filename[i:])
+        test = self._get_index("test")
+        test = pd.Series("test", index=test.filename)
+        split = pd.concat([train, val, test])
+        split.name = "split"
+        split = split.reset_index()
+        with_split = df.merge(split, how='left', on="filename")
+        xml_files = (os.path.join(self.uri_root, "annotations", "xmls/")
+                     + with_split.filename + ".xml")
+        ann_df = pd.DataFrame(download_uris(xml_files, func=_get_xml))
+        with_xmls = pd.concat([with_split, ann_df.drop(columns=['filename'])],
+                              axis=1)
+
+        if check_quality:
+            trainval = df[df.split.isin(['train', 'val'])]
+            self._data_quality_issues["missing_xml"] = (
+                trainval[trainval.folder.isna()].filename.values.tolist()
+            )
+
+            p = pathlib.Path(self.uri_root) / "annotations" / "xmls"
+            names = pd.Series([p.name[:-4] for p in p.iterdir()])
+            no_index = pd.Index(names.values).difference(df.filename)
+            self._data_quality_issues["missing_index"] = no_index
+
+        with_xmls['segmented'] = with_xmls.segmented.astype(bool)
+        return with_xmls
+
+    def _get_index(self, name: str) -> pd.DataFrame:
         list_txt = os.path.join(self.uri_root,
-                                "annotations/list.txt")
+                                f"annotations/{name}.txt")
         df = pd.read_csv(list_txt, delimiter=" ", comment="#", header=None)
         df.columns = ["filename", "class", "species", "breed"]
+        return df
 
+    @staticmethod
+    def _find_split_index(trainval_df):
+        classnames = trainval_df.filename.str.rsplit('_', 1).str[0].str.lower()
+        return np.argmax(classnames < classnames.shift(1))
+
+    @staticmethod
+    def _to_category(metadata_df: pd.DataFrame):
         species_dtype = pd.CategoricalDtype(["Unknown", "Cat", "Dog"])
-        df.species = pd.Categorical.from_codes(df.species, dtype=species_dtype)
+        metadata_df['species'] = pd.Categorical.from_codes(metadata_df.species, dtype=species_dtype)
 
-        breeds = df.filename.str.rsplit("_", 1).str[0].unique()
+        breeds = metadata_df.filename.str.rsplit("_", 1).str[0].unique()
         assert len(breeds) == 37
 
         breeds = np.concatenate([["Unknown"], breeds])
         class_dtype = pd.CategoricalDtype(breeds)
-        df["class"] = pd.Categorical.from_codes(df["class"], dtype=class_dtype)
-
-        return df
+        metadata_df["class"] = pd.Categorical.from_codes(metadata_df["class"], dtype=class_dtype)
+        return metadata_df
 
     def default_dataset_path(self, fmt, flavor=None):
         suffix = f"_{flavor}" if flavor else ""
@@ -53,7 +113,60 @@ class OxfordPetConverter(DatasetConverter):
                 for x in table["filename"].to_numpy()]
 
     def get_schema(self):
-        names = ["filename", "class", "species", "breed"]
-        types = [pa.string(), pa.string(), pa.string(), pa.int16()]
+        source_schema = pa.struct([
+            pa.field("database", pa.string()),
+            pa.field("annotation", pa.string()),
+            pa.field("image", pa.string())
+        ])
+        size_schema = pa.struct([
+            pa.field("width", pa.int32()),
+            pa.field("height", pa.int32()),
+            pa.field("depth", pa.uint8())
+        ])
+        bbox = pa.struct([
+            pa.field("xmin", pa.int32()),
+            pa.field("ymin", pa.int32()),
+            pa.field("xmax", pa.int32()),
+            pa.field("ymax", pa.int32()),
+        ])
+        object_schema = pa.list_(pa.struct([
+            pa.field("name", pa.string()),
+            pa.field("pose", pa.string()),
+            pa.field("truncated", pa.bool_()),
+            pa.field("occluded", pa.bool_()),
+            pa.field("bndbox", bbox),
+            pa.field("difficult", pa.bool_())
+        ]))
+        names = ["filename", "class", "species", "breed", "split",
+                 "folder", "source", "size", "segmented", "object"]
+        types = [pa.string(), pa.string(), pa.string(), pa.int16(),
+                 pa.string(), pa.string(), source_schema, size_schema,
+                 pa.bool_(), object_schema]
         return pa.schema([pa.field(name, dtype)
                           for name, dtype in zip(names, types)])
+
+
+def _get_xml(uri):
+    fs, key = pa.fs.FileSystem.from_uri(uri)
+    try:
+        with fs.open_input_file(key) as fh:
+            dd = xmltodict.parse(fh.read())['annotation']
+            if not isinstance(dd['object'], list):
+                dd['object'] = [dd['object']]
+            sz = dd['size']
+            sz['width'] = int(sz['width'])
+            sz['height'] = int(sz['height'])
+            sz['depth'] = int(sz['depth'])
+            for obj in dd['object']:
+                obj['truncated'] = bool(obj['truncated'])
+                obj['occluded'] = bool(obj['occluded'])
+                obj['difficult'] = bool(obj['difficult'])
+                obj['bndbox'] = {
+                    'xmin': int(obj['bndbox']['xmin']),
+                    'xmax': int(obj['bndbox']['xmax']),
+                    'ymin': int(obj['bndbox']['ymin']),
+                    'ymax': int(obj['bndbox']['ymax']),
+                }
+            return dd
+    except Exception:
+        return {}

--- a/python/benchmarks/parse_pet.py
+++ b/python/benchmarks/parse_pet.py
@@ -1,0 +1,59 @@
+#  Copyright (c) 2022. Lance Developers
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+import os
+
+import numpy as np
+import pandas as pd
+
+import pyarrow as pa
+from bench_utils import DatasetConverter
+
+
+class OxfordPetConverter(DatasetConverter):
+
+    def __init__(self, uri_root):
+        super(OxfordPetConverter, self).__init__("oxford_pet", uri_root)
+
+    def read_metadata(self) -> pd.DataFrame:
+        list_txt = os.path.join(self.uri_root,
+                                "annotations/list.txt")
+        df = pd.read_csv(list_txt, delimiter=" ", comment="#", header=None)
+        df.columns = ["filename", "class", "species", "breed"]
+
+        species_dtype = pd.CategoricalDtype(["Unknown", "Cat", "Dog"])
+        df.species = pd.Categorical.from_codes(df.species, dtype=species_dtype)
+
+        breeds = df.filename.str.rsplit("_", 1).str[0].unique()
+        assert len(breeds) == 37
+
+        breeds = np.concatenate([["Unknown"], breeds])
+        class_dtype = pd.CategoricalDtype(breeds)
+        df["class"] = pd.Categorical.from_codes(df["class"], dtype=class_dtype)
+
+        return df
+
+    def default_dataset_path(self, fmt, flavor=None):
+        suffix = f"_{flavor}" if flavor else ""
+        return os.path.join(self.uri_root,
+                            f'{self.name}{suffix}.{fmt}')
+
+    def image_uris(self, table):
+        return [os.path.join(self.uri_root, f"images/{x}.jpg")
+                for x in table["filename"].to_numpy()]
+
+    def get_schema(self):
+        names = ["filename", "class", "species", "breed"]
+        types = [pa.string(), pa.string(), pa.string(), pa.int16()]
+        return pa.schema([pa.field(name, dtype)
+                          for name, dtype in zip(names, types)])

--- a/python/benchmarks/parse_pet.py
+++ b/python/benchmarks/parse_pet.py
@@ -75,7 +75,8 @@ class OxfordPetConverter(DatasetConverter):
             no_index = pd.Index(names.values).difference(df.filename)
             self._data_quality_issues["missing_index"] = no_index
 
-        with_xmls['segmented'] = with_xmls.segmented.astype(bool)
+        # TODO lance doesn't support writing booleans yet
+        with_xmls['segmented'] = with_xmls.segmented.astype(pd.Int8Dtype())
         return with_xmls
 
     def _get_index(self, name: str) -> pd.DataFrame:
@@ -132,16 +133,16 @@ class OxfordPetConverter(DatasetConverter):
         object_schema = pa.list_(pa.struct([
             pa.field("name", pa.string()),
             pa.field("pose", pa.string()),
-            pa.field("truncated", pa.bool_()),
-            pa.field("occluded", pa.bool_()),
+            pa.field("truncated", pa.uint8()),
+            pa.field("occluded", pa.uint8()),
             pa.field("bndbox", bbox),
-            pa.field("difficult", pa.bool_())
+            pa.field("difficult", pa.uint8())
         ]))
         names = ["filename", "class", "species", "breed", "split",
                  "folder", "source", "size", "segmented", "object"]
         types = [pa.string(), pa.string(), pa.string(), pa.int16(),
                  pa.string(), pa.string(), source_schema, size_schema,
-                 pa.bool_(), object_schema]
+                 pa.uint8(), object_schema]
         return pa.schema([pa.field(name, dtype)
                           for name, dtype in zip(names, types)])
 
@@ -158,9 +159,9 @@ def _get_xml(uri):
             sz['height'] = int(sz['height'])
             sz['depth'] = int(sz['depth'])
             for obj in dd['object']:
-                obj['truncated'] = bool(obj['truncated'])
-                obj['occluded'] = bool(obj['occluded'])
-                obj['difficult'] = bool(obj['difficult'])
+                obj['truncated'] = int(obj['truncated'])
+                obj['occluded'] = int(obj['occluded'])
+                obj['difficult'] = int(obj['difficult'])
                 obj['bndbox'] = {
                     'xmin': int(obj['bndbox']['xmin']),
                     'xmax': int(obj['bndbox']['xmax']),

--- a/python/lance/__init__.py
+++ b/python/lance/__init__.py
@@ -44,7 +44,7 @@ def scanner(
     filter: Optional[pc.Expression] = None,
     limit: Optional[int] = None,
     offset: int = 0,
-):
+) -> ds.Scanner:
     if isinstance(data, (str, Path)):
         data = dataset(str(data))
     return BuildScanner(

--- a/python/setup.py
+++ b/python/setup.py
@@ -69,7 +69,7 @@ setup(
     ext_modules=cythonize(extensions, language_level="3"),
     zip_safe=False,
     install_requires=["pyarrow>=9,<10"],
-    extras_require={"test": ["pytest>=6.0", "pandas", "duckdb"]},
+    extras_require={"test": ["pytest>=6.0", "pandas", "duckdb", "click"]},
     python_requires=">=3.8",
     packages=find_packages(),
     classifiers=[


### PR DESCRIPTION
Local data using Coco train2017 + val2017 instances (122K images)

![image](https://user-images.githubusercontent.com/759245/184518461-29f04f16-ae99-40a5-ac84-a5a4e8674dc1.png)


Discoveries (priority ordering):
- [x] #94 
- [x] #96 
- [x] #98 
- [ ] #95 
- [ ] #93 