### PR TITLE
PlainEncoding uses raw value pointer to write data to disk.

### DIFF
--- a/cpp/src/lance/encodings/binary.cc
+++ b/cpp/src/lance/encodings/binary.cc
@@ -41,11 +41,12 @@ Result<int64_t> VarBinaryEncoder::Write(const std::shared_ptr<::arrow::Array> da
   ARROW_ASSIGN_OR_RAISE(auto offsets_position, out_->Tell());
   offsetBuilder_.Reset();
   assert(arr->length() > 0);
-  for (int64_t i = 0; i < arr->length(); ++i) {
+  for (int64_t i = 0; i <= arr->length(); ++i) {
     ARROW_RETURN_NOT_OK(offsetBuilder_.Append(start_offset + arr->value_offset(i)));
   }
-  ARROW_RETURN_NOT_OK(offsetBuilder_.Append(offsets_position));
   ARROW_RETURN_NOT_OK(offsetBuilder_.Finish(&offsetsArr));
+  assert(offsetsArr->length() == arr->length() + 1);
+  assert(offsetsArr->values()->size() == arr->value_offset(arr->length()) - arr->value_offset(0));
   ARROW_RETURN_NOT_OK(out_->Write(offsetsArr->values()));
   return offsets_position;
 }

--- a/cpp/src/lance/encodings/binary.cc
+++ b/cpp/src/lance/encodings/binary.cc
@@ -39,15 +39,14 @@ Result<int64_t> VarBinaryEncoder::Write(const std::shared_ptr<::arrow::Array> da
   ARROW_RETURN_NOT_OK(out_->Write(arr->raw_data(), bytes));
 
   ARROW_ASSIGN_OR_RAISE(auto offsets_position, out_->Tell());
-  offsetBuilder_.Reset();
+  offsets_builder_.Reset();
   assert(arr->length() > 0);
   for (int64_t i = 0; i <= arr->length(); ++i) {
-    ARROW_RETURN_NOT_OK(offsetBuilder_.Append(start_offset + arr->value_offset(i)));
+    ARROW_RETURN_NOT_OK(offsets_builder_.Append(start_offset + arr->value_offset(i)));
   }
-  ARROW_RETURN_NOT_OK(offsetBuilder_.Finish(&offsetsArr));
-  assert(offsetsArr->length() == arr->length() + 1);
-  assert(offsetsArr->values()->size() == arr->value_offset(arr->length()) - arr->value_offset(0));
-  ARROW_RETURN_NOT_OK(out_->Write(offsetsArr->values()));
+  ARROW_RETURN_NOT_OK(offsets_builder_.Finish(&offsets_));
+
+  ARROW_RETURN_NOT_OK(out_->Write(offsets_->values()));
   return offsets_position;
 }
 

--- a/cpp/src/lance/encodings/binary.cc
+++ b/cpp/src/lance/encodings/binary.cc
@@ -35,7 +35,8 @@ VarBinaryEncoder::VarBinaryEncoder(std::shared_ptr<::arrow::io::OutputStream> ou
 Result<int64_t> VarBinaryEncoder::Write(const std::shared_ptr<::arrow::Array> data) {
   ARROW_ASSIGN_OR_RAISE(auto start_offset, out_->Tell());
   auto arr = std::static_pointer_cast<::arrow::BinaryArray>(data);
-  ARROW_RETURN_NOT_OK(out_->Write(arr->value_data()));
+  auto bytes = arr->value_offset(arr->length()) - arr->value_offset(0);
+  ARROW_RETURN_NOT_OK(out_->Write(arr->raw_data(), bytes));
 
   ARROW_ASSIGN_OR_RAISE(auto offsets_position, out_->Tell());
   offsetBuilder_.Reset();

--- a/cpp/src/lance/encodings/binary.h
+++ b/cpp/src/lance/encodings/binary.h
@@ -58,8 +58,8 @@ class VarBinaryEncoder : public Encoder {
   std::string ToString() const override { return "Encoder(type=VarBinary)"; }
 
  private:
-  ::arrow::TypeTraits<OffsetType>::BuilderType offsetBuilder_;
-  std::shared_ptr<::arrow::TypeTraits<OffsetType>::ArrayType> offsetsArr;
+  ::arrow::TypeTraits<OffsetType>::BuilderType offsets_builder_;
+  std::shared_ptr<::arrow::TypeTraits<OffsetType>::ArrayType> offsets_;
 };
 
 /// Decode for Var-length binary encoding.

--- a/cpp/src/lance/encodings/dictionary.cc
+++ b/cpp/src/lance/encodings/dictionary.cc
@@ -33,7 +33,7 @@ DictionaryEncoder::DictionaryEncoder(std::shared_ptr<::arrow::io::OutputStream> 
 
 ::arrow::Result<int64_t> DictionaryEncoder::Write(std::shared_ptr<::arrow::Array> arr) {
   assert(::arrow::is_dictionary(arr->type_id()));
-  auto dict_arr = std::static_pointer_cast<::arrow::DictionaryArray>(arr);
+  auto dict_arr = std::dynamic_pointer_cast<::arrow::DictionaryArray>(arr);
   return plain_encoder_->Write(dict_arr->indices());
 }
 

--- a/cpp/src/lance/encodings/plain.cc
+++ b/cpp/src/lance/encodings/plain.cc
@@ -51,6 +51,12 @@ template <ArrowType T>
                            const std::shared_ptr<::arrow::Array>& arr) {
   auto width = ::arrow::bit_width(arr->type_id()) / 8;
   assert(width > 0);
+  fmt::print(
+      "Write arr pos: {} type={} bytes={}\n",
+      fmt::ptr(
+          std::dynamic_pointer_cast<typename ::arrow::TypeTraits<T>::ArrayType>(arr)->raw_values()),
+      arr->type()->ToString(),
+      arr->length() * width);
   return out->Write(
       std::dynamic_pointer_cast<typename ::arrow::TypeTraits<T>::ArrayType>(arr)->raw_values(),
       arr->length() * width);

--- a/cpp/src/lance/encodings/plain.cc
+++ b/cpp/src/lance/encodings/plain.cc
@@ -51,12 +51,6 @@ template <ArrowType T>
                            const std::shared_ptr<::arrow::Array>& arr) {
   auto width = ::arrow::bit_width(arr->type_id()) / 8;
   assert(width > 0);
-  fmt::print(
-      "Write arr pos: {} type={} bytes={}\n",
-      fmt::ptr(
-          std::dynamic_pointer_cast<typename ::arrow::TypeTraits<T>::ArrayType>(arr)->raw_values()),
-      arr->type()->ToString(),
-      arr->length() * width);
   return out->Write(
       std::dynamic_pointer_cast<typename ::arrow::TypeTraits<T>::ArrayType>(arr)->raw_values(),
       arr->length() * width);

--- a/cpp/src/lance/format/schema.cc
+++ b/cpp/src/lance/format/schema.cc
@@ -248,8 +248,13 @@ std::shared_ptr<lance::encodings::Encoder> Field::GetEncoder(
   } else if (encoding_ == pb::Encoding::DICTIONARY) {
     auto dict_type = std::static_pointer_cast<::arrow::DictionaryType>(type());
     if (!dictionary()) {
-      /// Fetch dictionary on demand?
-      ARROW_RETURN_NOT_OK(LoadDictionary(infile));
+      {
+        std::scoped_lock lock(lock_);
+        if (!dictionary()) {
+          /// Fetch dictionary on demand?
+          ARROW_RETURN_NOT_OK(LoadDictionary(infile));
+        }
+      }
     }
     decoder =
         std::make_shared<lance::encodings::DictionaryDecoder>(infile, dict_type, dictionary());

--- a/cpp/src/lance/format/schema.h
+++ b/cpp/src/lance/format/schema.h
@@ -18,6 +18,7 @@
 
 #include <map>
 #include <memory>
+#include <mutex>
 #include <string>
 #include <vector>
 
@@ -218,6 +219,8 @@ class Field final {
   int64_t dictionary_offset_ = -1;
   int64_t dictionary_page_length_ = 0;
   std::shared_ptr<::arrow::Array> dictionary_;
+
+  std::mutex lock_;
 
   friend class FieldVisitor;
   friend class ToArrowVisitor;

--- a/cpp/src/lance/io/writer.cc
+++ b/cpp/src/lance/io/writer.cc
@@ -105,9 +105,6 @@ FileWriter::~FileWriter() {}
 
 ::arrow::Status FileWriter::WritePrimitiveArray(const std::shared_ptr<format::Field>& field,
                                                 const std::shared_ptr<::arrow::Array>& arr) {
-  if (arr->length() == 0) {
-    return ::arrow::Status::OK();
-  }
   auto field_id = field->id();
   auto encoder = field->GetEncoder(destination_);
   auto type = field->type();


### PR DESCRIPTION
Closes #113.

The reason of the bug was that Arrow re-uses the underneath buffer object for multiple arrays. Each array is with different offsets on the same buffer.  `PlainEncoder` used to write Array::data() which always pointed to the first batch.