### PR TITLE
Refactor I/O exec nodes

### DIFF
--- a/cpp/CMakeLists.txt
+++ b/cpp/CMakeLists.txt
@@ -117,6 +117,7 @@ set(lance_objects
         $<TARGET_OBJECTS:encodings>
         $<TARGET_OBJECTS:format>
         $<TARGET_OBJECTS:io>
+        $<TARGET_OBJECTS:lance_io_exec>
         )
 
 add_subdirectory(src)

--- a/cpp/src/lance/arrow/file_lance.cc
+++ b/cpp/src/lance/arrow/file_lance.cc
@@ -24,7 +24,7 @@
 #include "lance/arrow/reader.h"
 #include "lance/format/schema.h"
 #include "lance/io/exec/filter.h"
-#include "lance/io/project.h"
+#include "lance/io/exec/project.h"
 #include "lance/io/reader.h"
 #include "lance/io/record_batch_reader.h"
 #include "lance/io/writer.h"

--- a/cpp/src/lance/arrow/file_lance.cc
+++ b/cpp/src/lance/arrow/file_lance.cc
@@ -23,7 +23,7 @@
 #include "lance/arrow/file_lance_ext.h"
 #include "lance/arrow/reader.h"
 #include "lance/format/schema.h"
-#include "lance/io/filter.h"
+#include "lance/io/exec/filter.h"
 #include "lance/io/project.h"
 #include "lance/io/reader.h"
 #include "lance/io/record_batch_reader.h"

--- a/cpp/src/lance/encodings/binary.h
+++ b/cpp/src/lance/encodings/binary.h
@@ -103,7 +103,7 @@ template <ArrowType T>
     return ::arrow::Status::IndexError(
         fmt::format("VarBinaryDecoder::ToArray: out of range: start={} length={} page_length={}\n",
                     start,
-                    length.value_or(length_),
+                    length.value_or(-1),
                     length_));
   }
 

--- a/cpp/src/lance/encodings/binary.h
+++ b/cpp/src/lance/encodings/binary.h
@@ -98,28 +98,26 @@ template <ArrowType T>
 template <ArrowType T>
 ::arrow::Result<std::shared_ptr<::arrow::Array>> VarBinaryDecoder<T>::ToArray(
     int32_t start, std::optional<int32_t> length) const {
-  if (!length.has_value()) {
-    length = length_ - start;
-  }
-  if (start + *length > length_) {
+  auto len = std::min(length.value_or(length_), length_ - start);
+  if (len < 0) {
     return ::arrow::Status::IndexError(
         fmt::format("VarBinaryDecoder::ToArray: out of range: start={} length={} page_length={}\n",
                     start,
-                    *length,
+                    length.value_or(length_),
                     length_));
   }
 
   auto offsets_buf =
-      infile_->ReadAt(position_ + start * sizeof(OffsetCType), (*length + 1) * sizeof(OffsetCType));
+      infile_->ReadAt(position_ + start * sizeof(OffsetCType), (len + 1) * sizeof(OffsetCType));
   if (!offsets_buf.ok()) {
     return ::arrow::Status::IOError(
         fmt::format("VarBinaryDecoder::ToArray: failed to read offset: start={}, length={}: {}",
                     start,
-                    *length,
+                    len,
                     offsets_buf.status().message()));
   }
-  auto positions = std::make_shared<typename ::arrow::TypeTraits<OffsetType>::ArrayType>(
-      *length + 1, *offsets_buf);
+  auto positions =
+      std::make_shared<typename ::arrow::TypeTraits<OffsetType>::ArrayType>(len + 1, *offsets_buf);
   auto start_offset = positions->Value(0);
 
   ::arrow::Int32Builder builder;
@@ -133,7 +131,7 @@ template <ArrowType T>
   auto value_offsets = std::static_pointer_cast<::arrow::Int32Array>(*value_offsets_buf);
   auto read_length = positions->Value(positions->length() - 1) - start_offset;
   ARROW_ASSIGN_OR_RAISE(auto data_buf, infile_->ReadAt(start_offset, read_length));
-  return std::make_shared<ArrayType>(*length, value_offsets->values(), data_buf);
+  return std::make_shared<ArrayType>(len, value_offsets->values(), data_buf);
 }
 
 }  // namespace lance::encodings

--- a/cpp/src/lance/encodings/plain.cc
+++ b/cpp/src/lance/encodings/plain.cc
@@ -125,8 +125,8 @@ class PlainDecoderImpl : public Decoder {
 
   ::arrow::Result<std::shared_ptr<::arrow::Array>> ToArray(
       int32_t start, std::optional<int32_t> length) const override {
-    auto read_length = std::min(length.value_or(length_), length_ - start);
-    if (read_length <= 0) {
+    auto len = std::min(length.value_or(length_), length_ - start);
+    if (len <= 0) {
       return ::arrow::Status::IndexError(
           fmt::format("{}::ToArray: out of range: start={}, length={}, page_length={}\n",
                       ToString(),
@@ -135,9 +135,9 @@ class PlainDecoderImpl : public Decoder {
                       length_));
     }
     auto byte_length = type_->byte_width();
-    ARROW_ASSIGN_OR_RAISE(
-        auto buf, infile_->ReadAt(position_ + start * byte_length, read_length * byte_length));
-    return std::make_shared<ArrayType>(type_, read_length, buf);
+    ARROW_ASSIGN_OR_RAISE(auto buf,
+                          infile_->ReadAt(position_ + start * byte_length, len * byte_length));
+    return std::make_shared<ArrayType>(type_, len, buf);
   }
 
   ::arrow::Result<std::shared_ptr<::arrow::Array>> Take(

--- a/cpp/src/lance/encodings/plain.cc
+++ b/cpp/src/lance/encodings/plain.cc
@@ -134,9 +134,9 @@ class PlainDecoderImpl : public Decoder {
                       length.value_or(-1),
                       length_));
     }
-    auto byte_length = type_->byte_width();
+    auto byte_width = type_->byte_width();
     ARROW_ASSIGN_OR_RAISE(auto buf,
-                          infile_->ReadAt(position_ + start * byte_length, len * byte_length));
+                          infile_->ReadAt(position_ + start * byte_width, len * byte_width));
     return std::make_shared<ArrayType>(type_, len, buf);
   }
 

--- a/cpp/src/lance/encodings/plain.cc
+++ b/cpp/src/lance/encodings/plain.cc
@@ -125,21 +125,19 @@ class PlainDecoderImpl : public Decoder {
 
   ::arrow::Result<std::shared_ptr<::arrow::Array>> ToArray(
       int32_t start, std::optional<int32_t> length) const override {
-    if (!length.has_value()) {
-      length = length_ - start;
-    }
-    if (start + length.value() > length_ || start > length_) {
+    auto read_length = std::min(length.value_or(length_), length_ - start);
+    if (read_length <= 0) {
       return ::arrow::Status::IndexError(
           fmt::format("{}::ToArray: out of range: start={}, length={}, page_length={}\n",
                       ToString(),
                       start,
-                      length.value(),
+                      length.value_or(-1),
                       length_));
     }
     auto byte_length = type_->byte_width();
     ARROW_ASSIGN_OR_RAISE(
-        auto buf, infile_->ReadAt(position_ + start * byte_length, length.value() * byte_length));
-    return std::make_shared<ArrayType>(type_, length.value(), buf);
+        auto buf, infile_->ReadAt(position_ + start * byte_length, read_length * byte_length));
+    return std::make_shared<ArrayType>(type_, read_length, buf);
   }
 
   ::arrow::Result<std::shared_ptr<::arrow::Array>> Take(

--- a/cpp/src/lance/encodings/plain_test.cc
+++ b/cpp/src/lance/encodings/plain_test.cc
@@ -46,8 +46,8 @@ TEST_CASE("Test Write Int32 array") {
   }
 }
 
-TEST_CASE("Read not full batch") {
-  auto arr = lance::arrow::ToArray({1, 2, 3, 4, 5, 6, 7, 8}).ValueOrDie();
+TEST_CASE("Do not read full batch") {
+  auto arr = lance::arrow::ToArray({10, 20, 30, 40, 50, 60, 70, 80}).ValueOrDie();
   CHECK(arr->length() == 8);
 
   auto sink = arrow::io::BufferOutputStream::Create().ValueOrDie();
@@ -60,8 +60,9 @@ TEST_CASE("Read not full batch") {
   CHECK(decoder.Init().ok());
   decoder.Reset(offset, arr->length());
 
+  // Decode arr[6:8]
   auto values = decoder.ToArray(6, 8).ValueOrDie();
-  CHECK(values->Equals(lance::arrow::ToArray({7, 8}).ValueOrDie()));
+  CHECK(values->Equals(lance::arrow::ToArray({70, 80}).ValueOrDie()));
 }
 
 TEST_CASE("Test take plain values") {

--- a/cpp/src/lance/format/schema.cc
+++ b/cpp/src/lance/format/schema.cc
@@ -519,8 +519,8 @@ Schema::Schema(std::shared_ptr<::arrow::Schema> schema) {
     SchemaExcludeVisitor(std::shared_ptr<Schema> excluded) : excluded_(excluded) {}
 
     ::arrow::Status Visit(std::shared_ptr<Field> field) override {
-      for (auto& field : field->fields()) {
-        ARROW_RETURN_NOT_OK(Visit(field));
+      for (auto& f : field->fields()) {
+        ARROW_RETURN_NOT_OK(Visit(f));
       }
       auto excluded_field = excluded_->GetField(field->id());
       if (!excluded_field) {

--- a/cpp/src/lance/format/schema.cc
+++ b/cpp/src/lance/format/schema.cc
@@ -512,7 +512,7 @@ Schema::Schema(std::shared_ptr<::arrow::Schema> schema) {
   return Project(columns);
 }
 
-::arrow::Result<std::shared_ptr<Schema>> Schema::Exclude(std::shared_ptr<Schema> other) const {
+::arrow::Result<std::shared_ptr<Schema>> Schema::Exclude(const Schema& other) const {
   /// An visitor to remove fields in place.
   class SchemaExcludeVisitor : public FieldVisitor {
    public:

--- a/cpp/src/lance/format/schema.h
+++ b/cpp/src/lance/format/schema.h
@@ -72,7 +72,7 @@ class Schema final {
   ///
   /// \param other the schema to be excluded. It must to be a strict subset of this schema.
   /// \return The newly created schema, excluding any column in "other".
-  ::arrow::Result<std::shared_ptr<Schema>> Exclude(std::shared_ptr<Schema> other) const;
+  ::arrow::Result<std::shared_ptr<Schema>> Exclude(const Schema& other) const;
 
   /// Add a new parent field.
   void AddField(std::shared_ptr<Field> f);

--- a/cpp/src/lance/format/schema_test.cc
+++ b/cpp/src/lance/format/schema_test.cc
@@ -100,7 +100,7 @@ TEST_CASE("Exclude schema") {
   auto original = lance::format::Schema(arrow_schema);
   auto projected = original.Project({"split", "annotations.box"}).ValueOrDie();
   INFO("Projected schema: " << projected->ToString());
-  auto excluded = original.Exclude(projected).ValueOrDie();
+  auto excluded = original.Exclude(*projected).ValueOrDie();
 
   auto excluded_arrow_schema = ::arrow::schema(
       {::arrow::field("pk", ::arrow::utf8()),

--- a/cpp/src/lance/format/visitors.cc
+++ b/cpp/src/lance/format/visitors.cc
@@ -25,8 +25,8 @@
 
 namespace lance::format {
 
-::arrow::Status FieldVisitor::VisitSchema(std::shared_ptr<Schema> schema) {
-  for (auto& field : schema->fields()) {
+::arrow::Status FieldVisitor::VisitSchema(const Schema& schema) {
+  for (auto& field : schema.fields()) {
     ARROW_RETURN_NOT_OK(Visit(field));
   }
   return ::arrow::Status::OK();

--- a/cpp/src/lance/format/visitors.h
+++ b/cpp/src/lance/format/visitors.h
@@ -33,7 +33,7 @@ class FieldVisitor {
 
   virtual ::arrow::Status Visit(std::shared_ptr<Field> field) = 0;
 
-  ::arrow::Status VisitSchema(std::shared_ptr<Schema> schema);
+  ::arrow::Status VisitSchema(const Schema& schema);
 };
 
 /// A Visitor to convert Field / Schema to an arrow::Schema

--- a/cpp/src/lance/io/CMakeLists.txt
+++ b/cpp/src/lance/io/CMakeLists.txt
@@ -21,12 +21,9 @@ add_library(
         io
         OBJECT
         endian.h
-        limit.cc
-        limit.h
+
         pb.cc
         pb.h
-        project.cc
-        project.h
         reader.cc
         reader.h
         record_batch_reader.cc
@@ -38,6 +35,4 @@ target_include_directories(io SYSTEM PRIVATE ${Protobuf_INCLUDE_DIR})
 # Depend on lance::format to generate protobuf
 add_dependencies(io format lance_io_exec)
 
-add_lance_test(limit_test)
-add_lance_test(project_test)
 add_lance_test(reader_test)

--- a/cpp/src/lance/io/CMakeLists.txt
+++ b/cpp/src/lance/io/CMakeLists.txt
@@ -15,12 +15,12 @@
 
 # Internal I/O
 
+add_subdirectory(exec)
+
 add_library(
         io
         OBJECT
         endian.h
-        filter.cc
-        filter.h
         limit.cc
         limit.h
         pb.cc
@@ -36,9 +36,8 @@ add_library(
 )
 target_include_directories(io SYSTEM PRIVATE ${Protobuf_INCLUDE_DIR})
 # Depend on lance::format to generate protobuf
-add_dependencies(io format)
+add_dependencies(io format lance_io_exec)
 
-add_lance_test(filter_test)
 add_lance_test(limit_test)
 add_lance_test(project_test)
 add_lance_test(reader_test)

--- a/cpp/src/lance/io/exec/CMakeLists.txt
+++ b/cpp/src/lance/io/exec/CMakeLists.txt
@@ -12,7 +12,7 @@ add_library(
         scan.h
         take.cc
         take.h
-)
+        base.cc)
 target_include_directories(lance_io_exec SYSTEM PRIVATE ${Protobuf_INCLUDE_DIR})
 add_dependencies(lance_io_exec format)
 

--- a/cpp/src/lance/io/exec/CMakeLists.txt
+++ b/cpp/src/lance/io/exec/CMakeLists.txt
@@ -14,6 +14,7 @@ add_library(
         take.h
 )
 target_include_directories(lance_io_exec SYSTEM PRIVATE ${Protobuf_INCLUDE_DIR})
+add_dependencies(lance_io_exec format)
 
 add_lance_test(filter_test)
 add_lance_test(project_test)

--- a/cpp/src/lance/io/exec/CMakeLists.txt
+++ b/cpp/src/lance/io/exec/CMakeLists.txt
@@ -1,0 +1,21 @@
+add_library(
+        lance_io_exec
+        OBJECT
+        base.h
+        filter.cc
+        filter.h
+        limit.cc
+        limit.h
+        project.cc
+        project.h
+        scan.cc
+        scan.h
+        take.cc
+        take.h
+)
+target_include_directories(lance_io_exec SYSTEM PRIVATE ${Protobuf_INCLUDE_DIR})
+
+add_lance_test(filter_test)
+add_lance_test(project_test)
+add_lance_test(limit_test)
+add_lance_test(scan_test)

--- a/cpp/src/lance/io/exec/base.cc
+++ b/cpp/src/lance/io/exec/base.cc
@@ -1,0 +1,33 @@
+//  Copyright 2022 Lance Authors
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+
+#include "lance/io/exec/base.h"
+
+#include <memory>
+namespace lance::io::exec {
+
+ScanBatch ScanBatch::Null() { return ScanBatch(nullptr, -1); }
+
+ScanBatch::ScanBatch(std::shared_ptr<::arrow::RecordBatch> records, int32_t bid)
+    : batch(records), batch_id(bid) {}
+
+ScanBatch ScanBatch::Filtered(std::shared_ptr<::arrow::RecordBatch> records,
+                              int32_t batch_id,
+                              std::shared_ptr<::arrow::Int32Array> indices) {
+  auto batch = ScanBatch(records, batch_id);
+  batch.indices = std::move(indices);
+  return batch;
+}
+
+}  // namespace lance::io::exec

--- a/cpp/src/lance/io/exec/base.h
+++ b/cpp/src/lance/io/exec/base.h
@@ -21,10 +21,6 @@
 #include <string>
 #include <vector>
 
-namespace lance::format {
-class Schema;
-}
-
 namespace lance::io::exec {
 
 struct ScanBatch {

--- a/cpp/src/lance/io/exec/base.h
+++ b/cpp/src/lance/io/exec/base.h
@@ -21,6 +21,10 @@
 #include <string>
 #include <vector>
 
+namespace lance::format {
+class Schema;
+}
+
 namespace lance::io::exec {
 
 struct ScanBatch {
@@ -41,7 +45,7 @@ class ExecNode {
   /// Returns the next batch of rows, returns nullptr if EOF.
   virtual ::arrow::Result<ScanBatch> Next() = 0;
 
-  virtual std::string ToString() const = 0;
+  [[nodiscard]] virtual std::string ToString() const = 0;
 };
 
 }  // namespace lance::io::exec

--- a/cpp/src/lance/io/exec/base.h
+++ b/cpp/src/lance/io/exec/base.h
@@ -1,0 +1,41 @@
+//  Copyright 2022 Lance Authors
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+
+#pragma once
+
+#include <arrow/record_batch.h>
+#include <arrow/result.h>
+
+#include <memory>
+#include <string>
+
+namespace lance::io::exec {
+
+/// I/O execute base node.
+///
+/// TODO: investigate to adapt Arrow Acero.
+/// https://arrow.apache.org/docs/cpp/streaming_execution.html
+class ExecNode {
+ public:
+  ExecNode() = default;
+
+  virtual ~ExecNode() = default;
+
+  /// Returns the next batch of rows, returns nullptr if EOF.
+  virtual ::arrow::Result<std::shared_ptr<::arrow::RecordBatch>> Next() = 0;
+
+  virtual std::string ToString() const = 0;
+};
+
+}  // namespace lance::io::exec

--- a/cpp/src/lance/io/exec/base.h
+++ b/cpp/src/lance/io/exec/base.h
@@ -23,10 +23,41 @@
 
 namespace lance::io::exec {
 
+/// Emitted results from each ExecNode
 struct ScanBatch {
+  /// The resulted RecordBatch.
+  ///
+  /// If it is zero-sized batch, there is no valid values in this batch.
+  /// It it is nullptr, it reaches the end of the scan.
   std::shared_ptr<::arrow::RecordBatch> batch;
-  int32_t batch_id;
 
+  /// The Id of the batch this result belongs to.
+  int32_t batch_id = -1;
+
+  /// Indices returned from the filter.
+  std::shared_ptr<::arrow::Int32Array> indices;
+
+  /// Return a null ScanBatch indicates EOF.
+  static ScanBatch Null();
+
+  /// Constructor with a record batch and batch id.
+  ///
+  /// \param records A record batch of values to return
+  /// \param batch_id the id of the batch
+  static ScanBatch Filtered(std::shared_ptr<::arrow::RecordBatch> records,
+                            int32_t batch_id,
+                            std::shared_ptr<::arrow::Int32Array> indices);
+
+  /// Construct an empty response.
+  ScanBatch() = default;
+
+  /// Constructor with a record batch and batch id.
+  ///
+  /// \param records A record batch of values to return
+  /// \param batch_id the id of the batch
+  ScanBatch(std::shared_ptr<::arrow::RecordBatch> records, int32_t batch_id);
+
+  /// Returns True if the end of file is reached.
   bool eof() const { return !batch; }
 };
 
@@ -34,6 +65,23 @@ struct ScanBatch {
 ///
 /// TODO: investigate to adapt Arrow Acero.
 /// https://arrow.apache.org/docs/cpp/streaming_execution.html
+///
+/// A exec plan is usually starts with Project and ends with Scan.
+///
+/// \example
+///  A few examples of the exec plan tree for common queries.
+///
+/// SELECT * FROM dataset
+///    Project (*) --> Scan (*)
+///
+/// SELECT a, b FROM dataset WHERE c = 123
+///    Project (a, b) -> Take(a,b) -> Filter(c=123) -> Scan(c)
+///
+/// SELECT a, b FROM dataset LIMIT 200 OFFSET 5000
+///    Project (a, b) -> Limit(200, 5000) -> Scan(a, b)
+///
+/// SELECT a, b, c FROM dataset WHERE c = 123 LIMIT 50 OFFSET 200
+///    Project (a, b, c) -> Take(a, b) -> Limit(50, 200) -> Filter(c=123) -> Scan(c)
 class ExecNode {
  public:
   enum Type {

--- a/cpp/src/lance/io/exec/base.h
+++ b/cpp/src/lance/io/exec/base.h
@@ -19,8 +19,14 @@
 
 #include <memory>
 #include <string>
+#include <vector>
 
 namespace lance::io::exec {
+
+struct ScanBatch {
+  std::shared_ptr<::arrow::RecordBatch> batch;
+  int32_t batch_id;
+};
 
 /// I/O execute base node.
 ///
@@ -33,7 +39,7 @@ class ExecNode {
   virtual ~ExecNode() = default;
 
   /// Returns the next batch of rows, returns nullptr if EOF.
-  virtual ::arrow::Result<std::shared_ptr<::arrow::RecordBatch>> Next() = 0;
+  virtual ::arrow::Result<ScanBatch> Next() = 0;
 
   virtual std::string ToString() const = 0;
 };

--- a/cpp/src/lance/io/exec/base.h
+++ b/cpp/src/lance/io/exec/base.h
@@ -40,9 +40,20 @@ struct ScanBatch {
 /// https://arrow.apache.org/docs/cpp/streaming_execution.html
 class ExecNode {
  public:
+  enum Type {
+    kScan = 0,
+    kProject = 1,
+    kFilter = 2,
+    kLimit = 3,
+    kTake = 4,
+    kTableScan = 256,
+  };
+
   ExecNode() = default;
 
   virtual ~ExecNode() = default;
+
+  virtual constexpr Type type() const = 0;
 
   /// Returns the next batch of rows, returns nullptr if EOF.
   virtual ::arrow::Result<ScanBatch> Next() = 0;

--- a/cpp/src/lance/io/exec/base.h
+++ b/cpp/src/lance/io/exec/base.h
@@ -30,6 +30,8 @@ namespace lance::io::exec {
 struct ScanBatch {
   std::shared_ptr<::arrow::RecordBatch> batch;
   int32_t batch_id;
+
+  bool eof() const { return !batch; }
 };
 
 /// I/O execute base node.

--- a/cpp/src/lance/io/exec/filter.cc
+++ b/cpp/src/lance/io/exec/filter.cc
@@ -47,8 +47,10 @@ bool Filter::HasFilter(const ::arrow::compute::Expression& filter) {
   auto [indices, values] = indices_and_values;
   assert(indices->length() == values->num_rows());
   ARROW_ASSIGN_OR_RAISE(auto values_arr, values->ToStructArray());
-  ARROW_ASSIGN_OR_RAISE(auto struct_arr,
-                        ::arrow::StructArray::Make({indices, values_arr}, {"indices", "values"}));
+  ARROW_ASSIGN_OR_RAISE(
+      auto struct_arr,
+      ::arrow::StructArray::Make({indices, values_arr},
+                                 std::vector<std::string>({"indices", "values"})));
   ARROW_ASSIGN_OR_RAISE(auto result_batch, ::arrow::RecordBatch::FromStructArray(struct_arr));
   return ScanBatch{result_batch, batch.batch_id};
 }

--- a/cpp/src/lance/io/exec/filter.cc
+++ b/cpp/src/lance/io/exec/filter.cc
@@ -37,7 +37,7 @@ Filter::Filter(std::shared_ptr<lance::format::Schema> schema,
   return std::unique_ptr<Filter>(new Filter(filter_schema, filter));
 }
 
-::arrow::Result<std::shared_ptr<::arrow::RecordBatch>> Filter::Next() { return child_->Next(); }
+::arrow::Result<ScanBatch> Filter::Next() { return child_->Next(); }
 
 ::arrow::Result<
     std::tuple<std::shared_ptr<::arrow::Int32Array>, std::shared_ptr<::arrow::RecordBatch>>>

--- a/cpp/src/lance/io/exec/filter.cc
+++ b/cpp/src/lance/io/exec/filter.cc
@@ -65,7 +65,7 @@ Filter::Execute(std::shared_ptr<FileReader> reader, int32_t batch_id) const {
   return Execute(batch);
 }
 
-// const std::shared_ptr<lance::format::Schema>& Filter::schema() const { return schema_; }
+const std::shared_ptr<lance::format::Schema>& Filter::schema() const { return schema_; }
 
 std::string Filter::ToString() const { return filter_.ToString(); }
 

--- a/cpp/src/lance/io/exec/filter.cc
+++ b/cpp/src/lance/io/exec/filter.cc
@@ -12,7 +12,7 @@
 //  See the License for the specific language governing permissions and
 //  limitations under the License.
 
-#include "lance/io/filter.h"
+#include "filter.h"
 
 #include <arrow/array.h>
 #include <arrow/compute/api.h>
@@ -22,7 +22,7 @@
 #include "lance/arrow/type.h"
 #include "lance/io/reader.h"
 
-namespace lance::io {
+namespace lance::io::exec {
 
 Filter::Filter(std::shared_ptr<lance::format::Schema> schema,
                const ::arrow::compute::Expression& filter)
@@ -36,6 +36,8 @@ Filter::Filter(std::shared_ptr<lance::format::Schema> schema,
   }
   return std::unique_ptr<Filter>(new Filter(filter_schema, filter));
 }
+
+::arrow::Result<std::shared_ptr<::arrow::RecordBatch>> Filter::Next() { return child_->Next(); }
 
 ::arrow::Result<
     std::tuple<std::shared_ptr<::arrow::Int32Array>, std::shared_ptr<::arrow::RecordBatch>>>
@@ -63,7 +65,7 @@ Filter::Execute(std::shared_ptr<FileReader> reader, int32_t batch_id) const {
   return Execute(batch);
 }
 
-const std::shared_ptr<lance::format::Schema>& Filter::schema() const { return schema_; }
+// const std::shared_ptr<lance::format::Schema>& Filter::schema() const { return schema_; }
 
 std::string Filter::ToString() const { return filter_.ToString(); }
 

--- a/cpp/src/lance/io/exec/filter.cc
+++ b/cpp/src/lance/io/exec/filter.cc
@@ -12,7 +12,7 @@
 //  See the License for the specific language governing permissions and
 //  limitations under the License.
 
-#include "filter.h"
+#include "lance/io/exec/filter.h"
 
 #include <arrow/array.h>
 #include <arrow/compute/api.h>
@@ -45,7 +45,6 @@ bool Filter::HasFilter(const ::arrow::compute::Expression& filter) {
   }
   ARROW_ASSIGN_OR_RAISE(auto indices_and_values, Apply(*batch.batch));
   auto [indices, values] = indices_and_values;
-  assert(indices->length() == values->num_rows());
   ARROW_ASSIGN_OR_RAISE(auto values_arr, values->ToStructArray());
   ARROW_ASSIGN_OR_RAISE(
       auto struct_arr,
@@ -71,6 +70,7 @@ Filter::Apply(const ::arrow::RecordBatch& batch) const {
   auto indices = std::static_pointer_cast<::arrow::Int32Array>(indices_datum.make_array());
   auto values_arr = values.make_array();
   ARROW_ASSIGN_OR_RAISE(auto result_batch, ::arrow::RecordBatch::FromStructArray(values_arr));
+  assert(indices->length() == result_batch->num_rows());
   return std::make_tuple(indices, result_batch);
 }
 

--- a/cpp/src/lance/io/exec/filter.h
+++ b/cpp/src/lance/io/exec/filter.h
@@ -38,6 +38,13 @@ class Filter : public ExecNode {
   /// Returns true if the filter expression has filter over actual columns.
   static bool HasFilter(const ::arrow::compute::Expression& filter);
 
+  ::arrow::Result<ScanBatch> Next() override;
+
+  std::string ToString() const override;
+
+ private:
+  Filter(const ::arrow::compute::Expression& filter, std::unique_ptr<ExecNode> child);
+
   /// Execute the filter on an arrow RecordBatch.
   ///
   /// \return a tuple of [indices, filtered_array].
@@ -48,18 +55,7 @@ class Filter : public ExecNode {
   /// { Int32Array({2, 4}), RecordBatch({"bar": [32, 32]}) }
   ::arrow::Result<
       std::tuple<std::shared_ptr<::arrow::Int32Array>, std::shared_ptr<::arrow::RecordBatch>>>
-      Execute(std::shared_ptr<::arrow::RecordBatch>) const;
-
-  ::arrow::Result<ScanBatch> Next() override;
-
-  ::arrow::Result<
-      std::tuple<std::shared_ptr<::arrow::Int32Array>, std::shared_ptr<::arrow::RecordBatch>>>
-  Execute(std::shared_ptr<lance::io::FileReader> reader, int32_t batch_id) const;
-
-  std::string ToString() const override;
-
- private:
-  Filter(const ::arrow::compute::Expression& filter, std::unique_ptr<ExecNode> child);
+  Apply(const ::arrow::RecordBatch& batch) const;
 
   ::arrow::compute::Expression filter_;
   std::unique_ptr<ExecNode> child_;

--- a/cpp/src/lance/io/exec/filter.h
+++ b/cpp/src/lance/io/exec/filter.h
@@ -33,7 +33,11 @@ class Filter : public ExecNode {
 
   /// Build a filter from arrow's filter expression and dataset schema.
   static ::arrow::Result<std::unique_ptr<Filter>> Make(const lance::format::Schema& schema,
-                                                       const ::arrow::compute::Expression& filter);
+                                                       const ::arrow::compute::Expression& filter,
+                                                       std::unique_ptr<ExecNode> child);
+
+  /// Returns true if the filter expression has filter over actual columns.
+  static bool HasFilter(const ::arrow::compute::Expression& filter);
 
   /// Execute the filter on an arrow RecordBatch.
   ///
@@ -53,12 +57,12 @@ class Filter : public ExecNode {
       std::tuple<std::shared_ptr<::arrow::Int32Array>, std::shared_ptr<::arrow::RecordBatch>>>
   Execute(std::shared_ptr<lance::io::FileReader> reader, int32_t batch_id) const;
 
-  const std::shared_ptr<lance::format::Schema>& schema() const;
-
   std::string ToString() const override;
 
  private:
-  Filter(std::shared_ptr<lance::format::Schema> schema, const ::arrow::compute::Expression& filter);
+  Filter(std::shared_ptr<lance::format::Schema> schema,
+         const ::arrow::compute::Expression& filter,
+         std::unique_ptr<ExecNode> child);
 
   std::shared_ptr<lance::format::Schema> schema_;
   ::arrow::compute::Expression filter_;

--- a/cpp/src/lance/io/exec/filter.h
+++ b/cpp/src/lance/io/exec/filter.h
@@ -21,13 +21,13 @@
 #include <tuple>
 
 #include "lance/format/schema.h"
+#include "lance/io/exec/base.h"
+#include "lance/io/reader.h"
 
-namespace lance::io {
-
-class FileReader;
+namespace lance::io::exec {
 
 /// Filter.
-class Filter {
+class Filter : public ExecNode {
  public:
   Filter() = delete;
 
@@ -47,19 +47,23 @@ class Filter {
       std::tuple<std::shared_ptr<::arrow::Int32Array>, std::shared_ptr<::arrow::RecordBatch>>>
       Execute(std::shared_ptr<::arrow::RecordBatch>) const;
 
+  ::arrow::Result<std::shared_ptr<::arrow::RecordBatch>> Next() override;
+
   ::arrow::Result<
       std::tuple<std::shared_ptr<::arrow::Int32Array>, std::shared_ptr<::arrow::RecordBatch>>>
-  Execute(std::shared_ptr<FileReader> reader, int32_t batch_id) const;
+  Execute(std::shared_ptr<lance::io::FileReader> reader, int32_t batch_id) const;
 
-  const std::shared_ptr<lance::format::Schema>& schema() const;
+  //  const std::shared_ptr<lance::format::Schema>& schema() const;
 
-  std::string ToString() const;
+  std::string ToString() const override;
 
  private:
   Filter(std::shared_ptr<lance::format::Schema> schema, const ::arrow::compute::Expression& filter);
 
   std::shared_ptr<lance::format::Schema> schema_;
   ::arrow::compute::Expression filter_;
+
+  std::unique_ptr<ExecNode> child_;
 };
 
 }  // namespace lance::io

--- a/cpp/src/lance/io/exec/filter.h
+++ b/cpp/src/lance/io/exec/filter.h
@@ -47,7 +47,7 @@ class Filter : public ExecNode {
       std::tuple<std::shared_ptr<::arrow::Int32Array>, std::shared_ptr<::arrow::RecordBatch>>>
       Execute(std::shared_ptr<::arrow::RecordBatch>) const;
 
-  ::arrow::Result<std::shared_ptr<::arrow::RecordBatch>> Next() override;
+  ::arrow::Result<ScanBatch> Next() override;
 
   ::arrow::Result<
       std::tuple<std::shared_ptr<::arrow::Int32Array>, std::shared_ptr<::arrow::RecordBatch>>>

--- a/cpp/src/lance/io/exec/filter.h
+++ b/cpp/src/lance/io/exec/filter.h
@@ -40,6 +40,8 @@ class Filter : public ExecNode {
 
   ::arrow::Result<ScanBatch> Next() override;
 
+  constexpr Type type() const override { return Type::kFilter; }
+
   std::string ToString() const override;
 
  private:

--- a/cpp/src/lance/io/exec/filter.h
+++ b/cpp/src/lance/io/exec/filter.h
@@ -53,7 +53,7 @@ class Filter : public ExecNode {
       std::tuple<std::shared_ptr<::arrow::Int32Array>, std::shared_ptr<::arrow::RecordBatch>>>
   Execute(std::shared_ptr<lance::io::FileReader> reader, int32_t batch_id) const;
 
-  //  const std::shared_ptr<lance::format::Schema>& schema() const;
+  const std::shared_ptr<lance::format::Schema>& schema() const;
 
   std::string ToString() const override;
 

--- a/cpp/src/lance/io/exec/filter.h
+++ b/cpp/src/lance/io/exec/filter.h
@@ -32,10 +32,8 @@ class Filter : public ExecNode {
   Filter() = delete;
 
   /// Build a filter from arrow's filter expression and dataset schema.
-  static ::arrow::Result<std::unique_ptr<Filter>> Make(const lance::format::Schema& schema,
-                                                       const ::arrow::compute::Expression& filter,
-                                                       std::unique_ptr<ExecNode> scan,
-                                                       std::unique_ptr<ExecNode> take);
+  static ::arrow::Result<std::unique_ptr<Filter>> Make(const ::arrow::compute::Expression& filter,
+                                                       std::unique_ptr<ExecNode> child);
 
   /// Returns true if the filter expression has filter over actual columns.
   static bool HasFilter(const ::arrow::compute::Expression& filter);
@@ -61,14 +59,10 @@ class Filter : public ExecNode {
   std::string ToString() const override;
 
  private:
-  Filter(const ::arrow::compute::Expression& filter,
-         std::unique_ptr<ExecNode> scan,
-         std::unique_ptr<ExecNode> take);
+  Filter(const ::arrow::compute::Expression& filter, std::unique_ptr<ExecNode> child);
 
   ::arrow::compute::Expression filter_;
-
-  std::unique_ptr<ExecNode> scan_;
-  std::unique_ptr<ExecNode> take_;
+  std::unique_ptr<ExecNode> child_;
 };
 
-}  // namespace lance::io
+}  // namespace lance::io::exec

--- a/cpp/src/lance/io/exec/filter.h
+++ b/cpp/src/lance/io/exec/filter.h
@@ -34,7 +34,8 @@ class Filter : public ExecNode {
   /// Build a filter from arrow's filter expression and dataset schema.
   static ::arrow::Result<std::unique_ptr<Filter>> Make(const lance::format::Schema& schema,
                                                        const ::arrow::compute::Expression& filter,
-                                                       std::unique_ptr<ExecNode> child);
+                                                       std::unique_ptr<ExecNode> scan,
+                                                       std::unique_ptr<ExecNode> take);
 
   /// Returns true if the filter expression has filter over actual columns.
   static bool HasFilter(const ::arrow::compute::Expression& filter);
@@ -60,14 +61,14 @@ class Filter : public ExecNode {
   std::string ToString() const override;
 
  private:
-  Filter(std::shared_ptr<lance::format::Schema> schema,
-         const ::arrow::compute::Expression& filter,
-         std::unique_ptr<ExecNode> child);
+  Filter(const ::arrow::compute::Expression& filter,
+         std::unique_ptr<ExecNode> scan,
+         std::unique_ptr<ExecNode> take);
 
-  std::shared_ptr<lance::format::Schema> schema_;
   ::arrow::compute::Expression filter_;
 
-  std::unique_ptr<ExecNode> child_;
+  std::unique_ptr<ExecNode> scan_;
+  std::unique_ptr<ExecNode> take_;
 };
 
 }  // namespace lance::io

--- a/cpp/src/lance/io/exec/filter_test.cc
+++ b/cpp/src/lance/io/exec/filter_test.cc
@@ -24,12 +24,14 @@
 #include "lance/arrow/stl.h"
 #include "lance/arrow/type.h"
 #include "lance/format/schema.h"
+#include "lance/testing/io.h"
 
 using ::arrow::compute::equal;
 using ::arrow::compute::field_ref;
 using ::arrow::compute::literal;
 using ::arrow::compute::or_;
 using lance::io::exec::Filter;
+using lance::testing::TableScan;
 
 TEST_CASE("Test with one condition") {
   auto filter = Filter::Make(equal(field_ref("value"), literal("32")), nullptr);
@@ -46,17 +48,20 @@ TEST_CASE("value = 32") {
   auto bar = lance::arrow::ToArray({1, 2, 32, 0, 32}).ValueOrDie();
   auto struct_arr =
       ::arrow::StructArray::Make({bar}, {::arrow::field("value", ::arrow::int32())}).ValueOrDie();
+  auto table =
+      ::arrow::Table::Make(::arrow::schema({::arrow::field("value", ::arrow::int32())}), {bar});
   auto batch = ::arrow::RecordBatch::FromStructArray(struct_arr).ValueOrDie();
 
-  auto filter = Filter::Make(expr, nullptr).ValueOrDie();
-  auto [indices, output] = filter->Execute(batch).ValueOrDie();
+  auto filter = Filter::Make(expr, TableScan::Make(*table)).ValueOrDie();
+  auto filtered_batch = filter->Next().ValueOrDie();
+  auto indices = filtered_batch.batch->GetColumnByName("indices");
+  auto output = filtered_batch.batch->GetColumnByName("values");
   CHECK(indices->Equals(lance::arrow::ToArray({2, 4}).ValueOrDie()));
 
   bar = lance::arrow::ToArray({32, 32}).ValueOrDie();
   struct_arr =
       ::arrow::StructArray::Make({bar}, {::arrow::field("value", ::arrow::int32())}).ValueOrDie();
-  batch = ::arrow::RecordBatch::FromStructArray(struct_arr).ValueOrDie();
-  CHECK(output->Equals(*batch));
+  CHECK(output->Equals(struct_arr));
 }
 
 TEST_CASE("label = cat or label = dog") {
@@ -64,17 +69,17 @@ TEST_CASE("label = cat or label = dog") {
       or_(equal(field_ref("label"), literal("cat")), equal(field_ref("label"), literal("dog")));
   auto labels =
       lance::arrow::ToArray({"person", "dog", "cat", "car", "cat", "food", "hotdog"}).ValueOrDie();
-  auto struct_arr =
-      ::arrow::StructArray::Make({labels}, {::arrow::field("label", ::arrow::utf8())}).ValueOrDie();
-  auto batch = ::arrow::RecordBatch::FromStructArray(struct_arr).ValueOrDie();
+  auto table =
+      ::arrow::Table::Make(::arrow::schema({::arrow::field("label", ::arrow::utf8())}), {labels});
 
-  auto filter = Filter::Make(expr, nullptr).ValueOrDie();
-  auto [indices, output] = filter->Execute(batch).ValueOrDie();
+  auto filter = Filter::Make(expr, TableScan::Make(*table)).ValueOrDie();
+  auto filtered_batch = filter->Next().ValueOrDie();
+  auto indices = filtered_batch.batch->GetColumnByName("indices");
+  auto output = filtered_batch.batch->GetColumnByName("values");
   CHECK(indices->Equals(lance::arrow::ToArray({1, 2, 4}).ValueOrDie()));
 
   labels = lance::arrow::ToArray({"dog", "cat", "cat"}).ValueOrDie();
-  struct_arr =
+  auto struct_arr =
       ::arrow::StructArray::Make({labels}, {::arrow::field("label", ::arrow::utf8())}).ValueOrDie();
-  auto expected = ::arrow::RecordBatch::FromStructArray(struct_arr).ValueOrDie();
-  CHECK(output->Equals(*expected));
+  CHECK(output->Equals(struct_arr));
 }

--- a/cpp/src/lance/io/exec/filter_test.cc
+++ b/cpp/src/lance/io/exec/filter_test.cc
@@ -31,16 +31,6 @@ using ::arrow::compute::literal;
 using ::arrow::compute::or_;
 using lance::io::exec::Filter;
 
-const auto kSchema =
-    lance::format::Schema(::arrow::schema({::arrow::field("pk", ::arrow::int32()),
-                                           ::arrow::field("value", ::arrow::int32()),
-                                           ::arrow::field("label", ::arrow::utf8())}));
-
-TEST_CASE("Test without filter") {
-  auto empty_filter = Filter::Make(::arrow::compute::literal(true), nullptr).ValueOrDie();
-  CHECK(empty_filter == nullptr);
-}
-
 TEST_CASE("Test with one condition") {
   auto filter = Filter::Make(equal(field_ref("value"), literal("32")), nullptr);
   INFO("filter " << filter.status().message());

--- a/cpp/src/lance/io/exec/filter_test.cc
+++ b/cpp/src/lance/io/exec/filter_test.cc
@@ -12,15 +12,14 @@
 //  See the License for the specific language governing permissions and
 //  limitations under the License.
 
-#include "lance/io/filter.h"
+#include "filter.h"
 
 #include <arrow/array.h>
 #include <arrow/compute/exec/expression.h>
 #include <arrow/record_batch.h>
-#include <fmt/format.h>
 
-#include <catch2/catch_test_macros.hpp>
-
+#include "catch2/catch_test_macros.hpp"
+#include "fmt/format.h"
 #include "lance/arrow/stl.h"
 #include "lance/arrow/type.h"
 #include "lance/format/schema.h"

--- a/cpp/src/lance/io/exec/filter_test.cc
+++ b/cpp/src/lance/io/exec/filter_test.cc
@@ -22,8 +22,6 @@
 #include <catch2/catch_test_macros.hpp>
 
 #include "lance/arrow/stl.h"
-#include "lance/arrow/type.h"
-#include "lance/format/schema.h"
 #include "lance/testing/io.h"
 
 using ::arrow::compute::equal;

--- a/cpp/src/lance/io/exec/filter_test.cc
+++ b/cpp/src/lance/io/exec/filter_test.cc
@@ -37,16 +37,16 @@ const auto kSchema =
                                            ::arrow::field("label", ::arrow::utf8())}));
 
 TEST_CASE("Test without filter") {
-  auto empty_filter = Filter::Make(kSchema, ::arrow::compute::literal(true)).ValueOrDie();
+  auto empty_filter = Filter::Make(kSchema, ::arrow::compute::literal(true), nullptr).ValueOrDie();
   CHECK(empty_filter == nullptr);
 }
 
 TEST_CASE("Test with one condition") {
-  auto filter = Filter::Make(kSchema, equal(field_ref("value"), literal("32")));
+  auto filter = Filter::Make(kSchema, equal(field_ref("value"), literal("32")), nullptr);
   INFO("filter " << filter.status().message());
   CHECK(filter.ok());
 
-  filter = Filter::Make(kSchema, equal(literal("32"), field_ref("value")));
+  filter = Filter::Make(kSchema, equal(literal("32"), field_ref("value")), nullptr);
   INFO("filter " << filter.status().message());
   CHECK(filter.ok());
 }

--- a/cpp/src/lance/io/exec/filter_test.cc
+++ b/cpp/src/lance/io/exec/filter_test.cc
@@ -37,16 +37,16 @@ const auto kSchema =
                                            ::arrow::field("label", ::arrow::utf8())}));
 
 TEST_CASE("Test without filter") {
-  auto empty_filter = Filter::Make(kSchema, ::arrow::compute::literal(true), nullptr).ValueOrDie();
+  auto empty_filter = Filter::Make(::arrow::compute::literal(true), nullptr).ValueOrDie();
   CHECK(empty_filter == nullptr);
 }
 
 TEST_CASE("Test with one condition") {
-  auto filter = Filter::Make(kSchema, equal(field_ref("value"), literal("32")), nullptr);
+  auto filter = Filter::Make(equal(field_ref("value"), literal("32")), nullptr);
   INFO("filter " << filter.status().message());
   CHECK(filter.ok());
 
-  filter = Filter::Make(kSchema, equal(literal("32"), field_ref("value")), nullptr);
+  filter = Filter::Make(equal(literal("32"), field_ref("value")), nullptr);
   INFO("filter " << filter.status().message());
   CHECK(filter.ok());
 }
@@ -58,7 +58,7 @@ TEST_CASE("value = 32") {
       ::arrow::StructArray::Make({bar}, {::arrow::field("value", ::arrow::int32())}).ValueOrDie();
   auto batch = ::arrow::RecordBatch::FromStructArray(struct_arr).ValueOrDie();
 
-  auto filter = Filter::Make(kSchema, expr).ValueOrDie();
+  auto filter = Filter::Make(expr, nullptr).ValueOrDie();
   auto [indices, output] = filter->Execute(batch).ValueOrDie();
   CHECK(indices->Equals(lance::arrow::ToArray({2, 4}).ValueOrDie()));
 
@@ -78,7 +78,7 @@ TEST_CASE("label = cat or label = dog") {
       ::arrow::StructArray::Make({labels}, {::arrow::field("label", ::arrow::utf8())}).ValueOrDie();
   auto batch = ::arrow::RecordBatch::FromStructArray(struct_arr).ValueOrDie();
 
-  auto filter = Filter::Make(kSchema, expr).ValueOrDie();
+  auto filter = Filter::Make(expr, nullptr).ValueOrDie();
   auto [indices, output] = filter->Execute(batch).ValueOrDie();
   CHECK(indices->Equals(lance::arrow::ToArray({1, 2, 4}).ValueOrDie()));
 

--- a/cpp/src/lance/io/exec/limit.cc
+++ b/cpp/src/lance/io/exec/limit.cc
@@ -64,16 +64,6 @@ std::optional<std::tuple<int64_t, int64_t>> Limit::Apply(int64_t length) {
   return ScanBatch{batch.batch->Slice(0, num_records), batch.batch_id};
 }
 
-::arrow::Result<std::shared_ptr<::arrow::RecordBatch>> Limit::ReadBatch(
-    const std::shared_ptr<FileReader>& reader, const lance::format::Schema& schema) {
-  if (seen_ >= limit_) {
-    return nullptr;
-  }
-  ARROW_ASSIGN_OR_RAISE(auto batch, reader->ReadAt(schema, offset_, limit_ - seen_));
-  seen_ += batch->num_rows();
-  return batch;
-}
-
 std::string Limit::ToString() const {
   return fmt::format("Limit(n={}, offset={})", limit_, offset_);
 }

--- a/cpp/src/lance/io/exec/limit.cc
+++ b/cpp/src/lance/io/exec/limit.cc
@@ -23,10 +23,10 @@
 
 namespace lance::io::exec {
 
-::arrow::Result<std::unique_ptr<Limit>> Limit::Make(int64_t limit,
-                                                    int64_t offset,
-                                                    std::unique_ptr<ExecNode> child) noexcept {
-  return std::unique_ptr<Limit>(new Limit(limit, offset, std::move(child)));
+::arrow::Result<std::unique_ptr<ExecNode>> Limit::Make(int64_t limit,
+                                                       int64_t offset,
+                                                       std::unique_ptr<ExecNode> child) noexcept {
+  return std::unique_ptr<ExecNode>(new Limit(limit, offset, std::move(child)));
 }
 
 Limit::Limit(int64_t limit, int64_t offset, std::unique_ptr<ExecNode> child) noexcept

--- a/cpp/src/lance/io/exec/limit.cc
+++ b/cpp/src/lance/io/exec/limit.cc
@@ -12,16 +12,16 @@
 //  See the License for the specific language governing permissions and
 //  limitations under the License.
 
-#include "lance/io/limit.h"
+#include "limit.h"
 
 #include <arrow/record_batch.h>
-#include <fmt/format.h>
 
 #include <algorithm>
 
+#include "fmt/format.h"
 #include "lance/io/reader.h"
 
-namespace lance::io {
+namespace lance::io::exec {
 
 Limit::Limit(int64_t limit, int64_t offset) noexcept : limit_(limit), offset_(offset) {
   assert(offset >= 0);

--- a/cpp/src/lance/io/exec/limit.h
+++ b/cpp/src/lance/io/exec/limit.h
@@ -27,8 +27,10 @@ class Schema;
 }  // namespace lance::format
 
 namespace lance::io {
-
 class FileReader;
+}
+
+namespace lance::io::exec {
 
 /// Plan for Limit clause:
 ///
@@ -74,4 +76,4 @@ class Limit {
   int64_t seen_ = 0;
 };
 
-}  // namespace lance::io
+}  // namespace lance::io::exec

--- a/cpp/src/lance/io/exec/limit.h
+++ b/cpp/src/lance/io/exec/limit.h
@@ -24,17 +24,13 @@
 
 #include "lance/io/exec/base.h"
 
-namespace lance::format {
-class Schema;
-}  // namespace lance::format
-
 namespace lance::io {
 class FileReader;
 }
 
 namespace lance::io::exec {
 
-/// Plan for Limit clause:
+/// Node for the Limit clause:
 ///
 ///   LIMIT value:int64 [OFFSET value:int64]
 ///
@@ -50,28 +46,10 @@ class Limit : public ExecNode {
   /// Construct a Limit Clause with limit, and optionally, with offset.
   explicit Limit(int64_t limit, int64_t offset, std::unique_ptr<ExecNode> child) noexcept;
 
-  /// Apply limit when reading a Batch.
-  ///
-  /// \param length the length of a Batch to be read.
-  /// \return a tuple of `[position, length]` that should be physically loaded
-  /// into memory. Return `[0, 0]` to skip this batch.
-  /// Return `std::nullopt` to indicate the end of the iteration.
-  ///
-  /// \code{.cpp}
-  /// auto length = GetPageLength(page_id);
-  /// auto limit = Limit(20, 30);
-  /// auto position_and_length = limit.Apply(length);
-  /// if (!offset_and_length) {
-  ///    // stop
-  ///    return;
-  /// }
-  /// auto [position, length] = position_and_length.value();
-  /// return infile->ReadAt(position, length);
-  /// \endcode
-  std::optional<std::tuple<int64_t, int64_t>> Apply(int64_t length);
-
   /// Apply the limits and returns the next batch.
   ::arrow::Result<ScanBatch> Next() override;
+
+  constexpr Type type() const override { return kLimit; }
 
   /// Debug String
   std::string ToString() const override;

--- a/cpp/src/lance/io/exec/limit.h
+++ b/cpp/src/lance/io/exec/limit.h
@@ -42,6 +42,7 @@ class Limit : public ExecNode {
  public:
   Limit() = delete;
 
+  /// Factory method.
   static ::arrow::Result<std::unique_ptr<Limit>> Make(int64_t limit,
                                                       int64_t offset,
                                                       std::unique_ptr<ExecNode> child) noexcept;
@@ -69,6 +70,7 @@ class Limit : public ExecNode {
   /// \endcode
   std::optional<std::tuple<int64_t, int64_t>> Apply(int64_t length);
 
+  /// Apply the limits and returns the next batch.
   ::arrow::Result<ScanBatch> Next() override;
 
   /// ReadBatch

--- a/cpp/src/lance/io/exec/limit.h
+++ b/cpp/src/lance/io/exec/limit.h
@@ -43,9 +43,9 @@ class Limit : public ExecNode {
   Limit() = delete;
 
   /// Factory method.
-  static ::arrow::Result<std::unique_ptr<Limit>> Make(int64_t limit,
-                                                      int64_t offset,
-                                                      std::unique_ptr<ExecNode> child) noexcept;
+  static ::arrow::Result<std::unique_ptr<ExecNode>> Make(int64_t limit,
+                                                         int64_t offset,
+                                                         std::unique_ptr<ExecNode> child) noexcept;
 
   /// Construct a Limit Clause with limit, and optionally, with offset.
   explicit Limit(int64_t limit, int64_t offset, std::unique_ptr<ExecNode> child) noexcept;

--- a/cpp/src/lance/io/exec/limit.h
+++ b/cpp/src/lance/io/exec/limit.h
@@ -24,10 +24,6 @@
 
 #include "lance/io/exec/base.h"
 
-namespace lance::io {
-class FileReader;
-}
-
 namespace lance::io::exec {
 
 /// Node for the Limit clause:

--- a/cpp/src/lance/io/exec/limit.h
+++ b/cpp/src/lance/io/exec/limit.h
@@ -73,10 +73,6 @@ class Limit : public ExecNode {
   /// Apply the limits and returns the next batch.
   ::arrow::Result<ScanBatch> Next() override;
 
-  /// ReadBatch
-  ::arrow::Result<std::shared_ptr<::arrow::RecordBatch>> ReadBatch(
-      const std::shared_ptr<FileReader>& reader, const lance::format::Schema& schema);
-
   /// Debug String
   std::string ToString() const override;
 

--- a/cpp/src/lance/io/exec/limit_test.cc
+++ b/cpp/src/lance/io/exec/limit_test.cc
@@ -35,25 +35,6 @@ using lance::io::exec::Limit;
 using lance::io::exec::Scan;
 using lance::testing::TableScan;
 
-TEST_CASE("LIMIT 100") {
-  auto limit = Limit(100, 0, TableScan::MakeEmpty());
-  CHECK(limit.Apply(10).value() == std::make_tuple(0, 10));
-  CHECK(limit.Apply(80).value() == std::make_tuple(0, 80));
-  CHECK(limit.Apply(20).value() == std::make_tuple(0, 10));
-  // Limit already reached.
-  CHECK(limit.Apply(30) == std::nullopt);
-}
-
-TEST_CASE("LIMIT 10 OFFSET 20") {
-  auto limit = Limit(10, 20, nullptr);
-  CHECK(limit.Apply(10).value() == std::make_tuple(0, 0));
-  CHECK(limit.Apply(5).value() == std::make_tuple(0, 0));
-  auto val = limit.Apply(20).value();
-  INFO("Limit::Apply(20): offset=" << std::get<0>(val) << " len=" << std::get<1>(val));
-  CHECK(val == std::make_tuple(5, 10));
-  CHECK(limit.Apply(5) == std::nullopt);
-}
-
 TEST_CASE("Read limit multiple times") {
   auto values = std::vector<int>(50);
   std::iota(std::begin(values), std::end(values), 1);

--- a/cpp/src/lance/io/exec/limit_test.cc
+++ b/cpp/src/lance/io/exec/limit_test.cc
@@ -12,7 +12,7 @@
 //  See the License for the specific language governing permissions and
 //  limitations under the License.
 
-#include "lance/io/limit.h"
+#include "lance/io/exec/limit.h"
 
 #include <arrow/io/api.h>
 #include <arrow/table.h>
@@ -28,8 +28,10 @@
 #include "lance/format/schema.h"
 #include "lance/io/reader.h"
 
+using lance::io::exec::Limit;
+
 TEST_CASE("LIMIT 100") {
-  auto limit = lance::io::Limit(100);
+  auto limit = Limit(100);
   CHECK(limit.Apply(10).value() == std::make_tuple(0, 10));
   CHECK(limit.Apply(80).value() == std::make_tuple(0, 80));
   CHECK(limit.Apply(20).value() == std::make_tuple(0, 10));
@@ -38,7 +40,7 @@ TEST_CASE("LIMIT 100") {
 }
 
 TEST_CASE("LIMIT 10 OFFSET 20") {
-  auto limit = lance::io::Limit(10, 20);
+  auto limit = Limit(10, 20);
   CHECK(limit.Apply(10).value() == std::make_tuple(0, 0));
   CHECK(limit.Apply(5).value() == std::make_tuple(0, 0));
   auto val = limit.Apply(20).value();
@@ -60,7 +62,7 @@ TEST_CASE("Read limit multiple times") {
   auto infile = make_shared<arrow::io::BufferReader>(sink->Finish().ValueOrDie());
   auto reader = std::make_shared<lance::io::FileReader>(infile);
   CHECK(reader->Open().ok());
-  auto limit = lance::io::Limit(5, 10);
+  auto limit = Limit(5, 10);
   auto batch = limit.ReadBatch(reader, reader->schema()).ValueOrDie();
   INFO("Actual: " << batch->column(0)->ToString());
   CHECK(batch->column(0)->Equals(lance::arrow::ToArray({11, 12, 13, 14, 15}).ValueOrDie()));

--- a/cpp/src/lance/io/exec/limit_test.cc
+++ b/cpp/src/lance/io/exec/limit_test.cc
@@ -27,20 +27,22 @@
 #include "lance/arrow/writer.h"
 #include "lance/format/schema.h"
 #include "lance/io/reader.h"
+#include "lance/testing/io.h"
 
 using lance::io::exec::Limit;
+using lance::testing::DummyNode;
 
 TEST_CASE("LIMIT 100") {
-  auto limit = Limit(100);
-  CHECK(limit.Apply(10).value() == std::make_tuple(0, 10));
-  CHECK(limit.Apply(80).value() == std::make_tuple(0, 80));
-  CHECK(limit.Apply(20).value() == std::make_tuple(0, 10));
+  auto limit = Limit::Make(100, 0, std::move(DummyNode::Make())).ValueOrDie();
+  CHECK(limit->Apply(10).value() == std::make_tuple(0, 10));
+  CHECK(limit->Apply(80).value() == std::make_tuple(0, 80));
+  CHECK(limit->Apply(20).value() == std::make_tuple(0, 10));
   // Limit already reached.
-  CHECK(limit.Apply(30) == std::nullopt);
+  CHECK(limit->Apply(30) == std::nullopt);
 }
 
 TEST_CASE("LIMIT 10 OFFSET 20") {
-  auto limit = Limit(10, 20);
+  auto limit = Limit(10, 20, nullptr);
   CHECK(limit.Apply(10).value() == std::make_tuple(0, 0));
   CHECK(limit.Apply(5).value() == std::make_tuple(0, 0));
   auto val = limit.Apply(20).value();

--- a/cpp/src/lance/io/exec/limit_test.cc
+++ b/cpp/src/lance/io/exec/limit_test.cc
@@ -33,12 +33,12 @@ using lance::io::exec::Limit;
 using lance::testing::DummyNode;
 
 TEST_CASE("LIMIT 100") {
-  auto limit = Limit::Make(100, 0, std::move(DummyNode::Make())).ValueOrDie();
-  CHECK(limit->Apply(10).value() == std::make_tuple(0, 10));
-  CHECK(limit->Apply(80).value() == std::make_tuple(0, 80));
-  CHECK(limit->Apply(20).value() == std::make_tuple(0, 10));
+  auto limit = Limit(100, 0, DummyNode::Make());
+  CHECK(limit.Apply(10).value() == std::make_tuple(0, 10));
+  CHECK(limit.Apply(80).value() == std::make_tuple(0, 80));
+  CHECK(limit.Apply(20).value() == std::make_tuple(0, 10));
   // Limit already reached.
-  CHECK(limit->Apply(30) == std::nullopt);
+  CHECK(limit.Apply(30) == std::nullopt);
 }
 
 TEST_CASE("LIMIT 10 OFFSET 20") {
@@ -64,7 +64,7 @@ TEST_CASE("Read limit multiple times") {
   auto infile = make_shared<arrow::io::BufferReader>(sink->Finish().ValueOrDie());
   auto reader = std::make_shared<lance::io::FileReader>(infile);
   CHECK(reader->Open().ok());
-  auto limit = Limit(5, 10);
+  auto limit = Limit(5, 10, nullptr);
   auto batch = limit.ReadBatch(reader, reader->schema()).ValueOrDie();
   INFO("Actual: " << batch->column(0)->ToString());
   CHECK(batch->column(0)->Equals(lance::arrow::ToArray({11, 12, 13, 14, 15}).ValueOrDie()));

--- a/cpp/src/lance/io/exec/project.cc
+++ b/cpp/src/lance/io/exec/project.cc
@@ -38,16 +38,22 @@ Project::Project(std::shared_ptr<format::Schema> projected_schema,
       limit_(limit.has_value() ? new Limit(limit.value(), offset) : nullptr) {}
 
 ::arrow::Result<std::unique_ptr<Project>> Project::Make(
+    std::shared_ptr<FileReader> reader,
     const format::Schema& schema,
     std::shared_ptr<::arrow::dataset::ScanOptions> scan_options,
     std::optional<int32_t> limit,
     int32_t offset) {
-  ARROW_ASSIGN_OR_RAISE(auto filter, Filter::Make(schema, scan_options->filter));
   auto projected_arrow_schema = scan_options->projected_schema;
   if (projected_arrow_schema->num_fields() == 0) {
     projected_arrow_schema = scan_options->dataset_schema;
   }
   ARROW_ASSIGN_OR_RAISE(auto projected_schema, schema.Project(*projected_arrow_schema));
+
+  if (Filter::HasFilter(scan_options->filter)) {
+    auto scan_schema =
+  } else {
+  }
+  ARROW_ASSIGN_OR_RAISE(auto filter, Filter::Make(schema, scan_options->filter, nullptr));
   auto scan_schema = projected_schema;
   if (filter) {
     // Remove the columns in filter from the project schema, to avoid duplicated scan

--- a/cpp/src/lance/io/exec/project.cc
+++ b/cpp/src/lance/io/exec/project.cc
@@ -17,7 +17,6 @@
 #include <arrow/api.h>
 #include <arrow/result.h>
 #include <fmt/format.h>
-#include <fmt/ranges.h>
 
 #include "lance/arrow/utils.h"
 #include "lance/io/exec/filter.h"
@@ -65,8 +64,6 @@ Project::Project(std::unique_ptr<ExecNode> child) : child_(std::move(child)) {}
   }
   return std::unique_ptr<Project>(new Project(std::move(child)));
 }
-
-const std::shared_ptr<format::Schema>& Project::schema() const { return projected_schema_; }
 
 std::string Project::ToString() const { return "Project"; }
 

--- a/cpp/src/lance/io/exec/project.cc
+++ b/cpp/src/lance/io/exec/project.cc
@@ -12,19 +12,20 @@
 //  See the License for the specific language governing permissions and
 //  limitations under the License.
 
-#include "lance/io/project.h"
+#include "project.h"
 
 #include <arrow/api.h>
 #include <arrow/result.h>
-#include <fmt/format.h>
-#include <fmt/ranges.h>
 
+#include "fmt/format.h"
+#include "fmt/ranges.h"
 #include "lance/arrow/utils.h"
 #include "lance/io/exec/filter.h"
-#include "lance/io/limit.h"
+#include "lance/io/exec/limit.h"
 #include "lance/io/reader.h"
+#include "limit.h"
 
-namespace lance::io {
+namespace lance::io::exec {
 
 Project::Project(std::shared_ptr<format::Schema> projected_schema,
                  std::shared_ptr<format::Schema> scan_schema,
@@ -98,4 +99,4 @@ const std::shared_ptr<format::Schema>& Project::schema() const { return projecte
   }
 }
 
-}  // namespace lance::io
+}  // namespace lance::io::exec

--- a/cpp/src/lance/io/exec/project.h
+++ b/cpp/src/lance/io/exec/project.h
@@ -55,11 +55,6 @@ class Project : ExecNode {
       std::optional<int32_t> limit = std::nullopt,
       int32_t offset = 0);
 
-  /// \brief Apply Projection over a batch.
-  ///
-  ::arrow::Result<std::shared_ptr<::arrow::RecordBatch>> Execute(std::shared_ptr<FileReader> reader,
-                                                                 int32_t batch_id);
-
   ::arrow::Result<ScanBatch> Next() override;
 
   /// Project schema

--- a/cpp/src/lance/io/exec/project.h
+++ b/cpp/src/lance/io/exec/project.h
@@ -47,8 +47,6 @@ class Project : ExecNode {
   /// \param reader file reader.
   /// \param schema dataset schema.
   /// \param scan_options Arrow scan options.
-  /// \param limit limit number of records to return. Optional.
-  /// \param offset offset to fetch the record. Optional.
   /// \return Project if success. Returns the error status otherwise.
   ///
   static ::arrow::Result<std::unique_ptr<Project>> Make(
@@ -67,12 +65,10 @@ class Project : ExecNode {
   /// Project schema
   const std::shared_ptr<format::Schema>& schema() const;
 
+  std::string ToString() const override;
+
  private:
-  Project(std::shared_ptr<format::Schema> projected_schema,
-          std::shared_ptr<format::Schema> scan_schema,
-          std::unique_ptr<Filter> filter,
-          std::optional<int32_t> limit = std::nullopt,
-          int32_t offset = 0);
+  Project(std::unique_ptr<ExecNode> child);
 
   std::shared_ptr<format::Schema> projected_schema_;
   /// scan_schema_ equals to projected_schema_ - filters_.schema()

--- a/cpp/src/lance/io/exec/project.h
+++ b/cpp/src/lance/io/exec/project.h
@@ -69,9 +69,6 @@ class Project : ExecNode {
   /// scan_schema_ equals to projected_schema_ - filters_.schema()
   /// It includes the columns that are not read from the filters yet.
   std::shared_ptr<format::Schema> scan_schema_;
-  std::unique_ptr<Filter> filter_;
-
-  std::unique_ptr<Limit> limit_;
   std::unique_ptr<ExecNode> child_;
 };
 

--- a/cpp/src/lance/io/exec/project.h
+++ b/cpp/src/lance/io/exec/project.h
@@ -26,8 +26,11 @@ class Schema;
 }
 
 namespace lance::io {
-
 class FileReader;
+}
+
+namespace lance::io::exec {
+
 class Filter;
 class Limit;
 
@@ -75,4 +78,4 @@ class Project {
   std::unique_ptr<Limit> limit_;
 };
 
-}  // namespace lance::io
+}  // namespace lance::io::exec

--- a/cpp/src/lance/io/exec/project.h
+++ b/cpp/src/lance/io/exec/project.h
@@ -21,6 +21,8 @@
 #include <memory>
 #include <optional>
 
+#include "lance/io/exec/base.h"
+
 namespace lance::format {
 class Schema;
 }
@@ -42,6 +44,7 @@ class Project {
 
   /// Make a Project from the full dataset schema and scan options.
   ///
+  /// \param reader file reader.
   /// \param schema dataset schema.
   /// \param scan_options Arrow scan options.
   /// \param limit limit number of records to return. Optional.
@@ -49,6 +52,7 @@ class Project {
   /// \return Project if success. Returns the error status otherwise.
   ///
   static ::arrow::Result<std::unique_ptr<Project>> Make(
+      std::shared_ptr<FileReader> reader,
       const format::Schema& schema,
       std::shared_ptr<::arrow::dataset::ScanOptions> scan_options,
       std::optional<int32_t> limit = std::nullopt,
@@ -76,6 +80,7 @@ class Project {
   std::unique_ptr<Filter> filter_;
 
   std::unique_ptr<Limit> limit_;
+  std::unique_ptr<ExecNode> child_;
 };
 
 }  // namespace lance::io::exec

--- a/cpp/src/lance/io/exec/project.h
+++ b/cpp/src/lance/io/exec/project.h
@@ -33,9 +33,6 @@ class FileReader;
 
 namespace lance::io::exec {
 
-class Filter;
-class Limit;
-
 /// \brief Projection over dataset.
 ///
 class Project : ExecNode {
@@ -57,9 +54,6 @@ class Project : ExecNode {
 
   ::arrow::Result<ScanBatch> Next() override;
 
-  /// Project schema
-  const std::shared_ptr<format::Schema>& schema() const;
-
   constexpr Type type() const override { return kProject; }
 
   std::string ToString() const override;
@@ -67,10 +61,6 @@ class Project : ExecNode {
  private:
   Project(std::unique_ptr<ExecNode> child);
 
-  std::shared_ptr<format::Schema> projected_schema_;
-  /// scan_schema_ equals to projected_schema_ - filters_.schema()
-  /// It includes the columns that are not read from the filters yet.
-  std::shared_ptr<format::Schema> scan_schema_;
   std::unique_ptr<ExecNode> child_;
 };
 

--- a/cpp/src/lance/io/exec/project.h
+++ b/cpp/src/lance/io/exec/project.h
@@ -38,7 +38,7 @@ class Limit;
 
 /// \brief Projection over dataset.
 ///
-class Project {
+class Project : ExecNode {
  public:
   Project() = delete;
 
@@ -53,7 +53,6 @@ class Project {
   ///
   static ::arrow::Result<std::unique_ptr<Project>> Make(
       std::shared_ptr<FileReader> reader,
-      const format::Schema& schema,
       std::shared_ptr<::arrow::dataset::ScanOptions> scan_options,
       std::optional<int32_t> limit = std::nullopt,
       int32_t offset = 0);
@@ -62,6 +61,8 @@ class Project {
   ///
   ::arrow::Result<std::shared_ptr<::arrow::RecordBatch>> Execute(std::shared_ptr<FileReader> reader,
                                                                  int32_t batch_id);
+
+  ::arrow::Result<ScanBatch> Next() override;
 
   /// Project schema
   const std::shared_ptr<format::Schema>& schema() const;

--- a/cpp/src/lance/io/exec/project.h
+++ b/cpp/src/lance/io/exec/project.h
@@ -60,6 +60,8 @@ class Project : ExecNode {
   /// Project schema
   const std::shared_ptr<format::Schema>& schema() const;
 
+  constexpr Type type() const override { return kProject; }
+
   std::string ToString() const override;
 
  private:

--- a/cpp/src/lance/io/exec/project.h
+++ b/cpp/src/lance/io/exec/project.h
@@ -23,9 +23,6 @@
 
 #include "lance/io/exec/base.h"
 
-namespace lance::format {
-class Schema;
-}
 
 namespace lance::io {
 class FileReader;

--- a/cpp/src/lance/io/exec/project_test.cc
+++ b/cpp/src/lance/io/exec/project_test.cc
@@ -60,9 +60,7 @@ TEST_CASE("Project schema") {
   auto project = lance::io::exec::Project::Make(reader, scanner->options()).ValueOrDie();
 
   auto result = project->Next();
-  fmt::print("Result status: {}\n", result.status().ToString());
   auto& batch = result.ValueOrDie();
-  fmt::print("Batcch is: {}\n", fmt::ptr(batch.batch));
 
   INFO("Array v = " << batch.batch->GetColumnByName("v")->ToString());
   CHECK(batch.batch->GetColumnByName("v")->Equals(lance::arrow::ToArray({20}).ValueOrDie()));

--- a/cpp/src/lance/io/exec/project_test.cc
+++ b/cpp/src/lance/io/exec/project_test.cc
@@ -57,9 +57,9 @@ TEST_CASE("Project schema") {
   auto scanner = scan_builder.Finish().ValueOrDie();
 
   auto lance_schema = lance::format::Schema(schema);
-  auto project = lance::io::exec::Project::Make(lance_schema, scanner->options()).ValueOrDie();
-
   auto reader = lance::testing::MakeReader(tbl).ValueOrDie();
+  auto project = lance::io::exec::Project::Make(reader, scanner->options()).ValueOrDie();
+
   auto batch = project->Execute(reader, 0).ValueOrDie();
   INFO("Array v = " << batch->GetColumnByName("v")->ToString());
   CHECK(batch->GetColumnByName("v")->Equals(lance::arrow::ToArray({20}).ValueOrDie()));

--- a/cpp/src/lance/io/exec/project_test.cc
+++ b/cpp/src/lance/io/exec/project_test.cc
@@ -56,11 +56,14 @@ TEST_CASE("Project schema") {
             .ok());
   auto scanner = scan_builder.Finish().ValueOrDie();
 
-  auto lance_schema = lance::format::Schema(schema);
   auto reader = lance::testing::MakeReader(tbl).ValueOrDie();
   auto project = lance::io::exec::Project::Make(reader, scanner->options()).ValueOrDie();
 
-  auto batch = project->Execute(reader, 0).ValueOrDie();
-  INFO("Array v = " << batch->GetColumnByName("v")->ToString());
-  CHECK(batch->GetColumnByName("v")->Equals(lance::arrow::ToArray({20}).ValueOrDie()));
+  auto result = project->Next();
+  fmt::print("Result status: {}\n", result.status().ToString());
+  auto& batch = result.ValueOrDie();
+  fmt::print("Batcch is: {}\n", fmt::ptr(batch.batch));
+
+  INFO("Array v = " << batch.batch->GetColumnByName("v")->ToString());
+  CHECK(batch.batch->GetColumnByName("v")->Equals(lance::arrow::ToArray({20}).ValueOrDie()));
 }

--- a/cpp/src/lance/io/exec/project_test.cc
+++ b/cpp/src/lance/io/exec/project_test.cc
@@ -12,29 +12,32 @@
 //  See the License for the specific language governing permissions and
 //  limitations under the License.
 
-#include "lance/io/project.h"
+#include "lance/io/exec/project.h"
 
 #include <arrow/compute/exec/expression.h>
 #include <arrow/dataset/dataset.h>
 #include <arrow/table.h>
 #include <arrow/type.h>
 
-#include <catch2/catch_test_macros.hpp>
 #include <string>
 #include <vector>
 
+#include "catch2/catch_test_macros.hpp"
 #include "lance/arrow/scanner.h"
 #include "lance/arrow/stl.h"
 #include "lance/format/schema.h"
 #include "lance/io/exec/filter.h"
-#include "lance/io/limit.h"
+#include "lance/io/exec/limit.h"
 #include "lance/io/reader.h"
 #include "lance/testing/io.h"
+
+using lance::io::exec::Project;
 
 TEST_CASE("Project schema") {
   auto schema =
       ::arrow::schema({arrow::field("k", arrow::int16()), arrow::field("v", arrow::int32())});
-  auto arr = arrow::StructArray::Make(::arrow::ArrayVector({
+  auto arr =
+      arrow::StructArray::Make(::arrow::ArrayVector({
                                    lance::arrow::ToArray<int16_t>({1, 2, 3, 4}).ValueOrDie(),
                                    lance::arrow::ToArray<int32_t>({10, 20, 30, 40}).ValueOrDie(),
                                }),
@@ -54,7 +57,7 @@ TEST_CASE("Project schema") {
   auto scanner = scan_builder.Finish().ValueOrDie();
 
   auto lance_schema = lance::format::Schema(schema);
-  auto project = lance::io::Project::Make(lance_schema, scanner->options()).ValueOrDie();
+  auto project = lance::io::exec::Project::Make(lance_schema, scanner->options()).ValueOrDie();
 
   auto reader = lance::testing::MakeReader(tbl).ValueOrDie();
   auto batch = project->Execute(reader, 0).ValueOrDie();

--- a/cpp/src/lance/io/exec/scan.cc
+++ b/cpp/src/lance/io/exec/scan.cc
@@ -54,6 +54,10 @@ Scan::Scan(std::shared_ptr<FileReader> reader,
       }
     }
   }
+  if (batch_id >= reader_->metadata().num_batches()) {
+    // EOF
+    return ScanBatch();
+  }
 
   ARROW_ASSIGN_OR_RAISE(auto batch, reader_->ReadBatch(*schema_, batch_id, offset, batch_size_));
   return ScanBatch{

--- a/cpp/src/lance/io/exec/scan.cc
+++ b/cpp/src/lance/io/exec/scan.cc
@@ -69,6 +69,13 @@ Scan::Scan(std::shared_ptr<FileReader> reader,
   };
 }
 
+::arrow::Status Scan::Seek(int32_t offset) {
+  ARROW_ASSIGN_OR_RAISE(auto batch_and_offset, reader_->metadata().LocateBatch(offset));
+  current_batch_id_ = std::get<0>(batch_and_offset);
+  current_offset_ = std::get<1>(batch_and_offset);
+  return ::arrow::Status::OK();
+}
+
 std::string Scan::ToString() const { return "Scan"; }
 
 }  // namespace lance::io::exec

--- a/cpp/src/lance/io/exec/scan.cc
+++ b/cpp/src/lance/io/exec/scan.cc
@@ -59,7 +59,7 @@ Scan::Scan(std::shared_ptr<FileReader> reader,
   fmt::print("Batch id: {} total batches={}\n", batch_id, reader_->metadata().num_batches());
   if (batch_id >= reader_->metadata().num_batches()) {
     // Reach EOF
-    return ScanBatch();
+    return ScanBatch::Null();
   }
 
   ARROW_ASSIGN_OR_RAISE(auto batch, reader_->ReadBatch(*schema_, batch_id, offset, batch_size_));

--- a/cpp/src/lance/io/exec/scan.cc
+++ b/cpp/src/lance/io/exec/scan.cc
@@ -1,0 +1,32 @@
+//  Copyright 2022 Lance Authors
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+
+#include "lance/io/exec/scan.h"
+
+#include <memory>
+
+#include "lance/io/reader.h"
+
+namespace lance::io::exec {
+
+Scan::Scan(std::shared_ptr<FileReader> reader,
+           std::shared_ptr<lance::format::Schema> schema,
+           int64_t batch_size)
+    : reader_(std::move(reader)), schema_(std::move(schema)), batch_size_(batch_size) {}
+
+::arrow::Result<std::shared_ptr<::arrow::RecordBatch>> Scan::Next() {
+  return reader_->ReadBatch(*schema_, current_batch_id_, current_offset_, batch_size_);
+}
+
+}  // namespace lance::io::exec

--- a/cpp/src/lance/io/exec/scan.cc
+++ b/cpp/src/lance/io/exec/scan.cc
@@ -14,6 +14,8 @@
 
 #include "lance/io/exec/scan.h"
 
+#include <fmt/format.h>
+
 #include <memory>
 
 #include "lance/format/metadata.h"
@@ -54,6 +56,7 @@ Scan::Scan(std::shared_ptr<FileReader> reader,
       }
     }
   }
+  fmt::print("Batch id: {} total batches={}\n", batch_id, reader_->metadata().num_batches());
   if (batch_id >= reader_->metadata().num_batches()) {
     // Reach EOF
     return ScanBatch();

--- a/cpp/src/lance/io/exec/scan.cc
+++ b/cpp/src/lance/io/exec/scan.cc
@@ -55,7 +55,7 @@ Scan::Scan(std::shared_ptr<FileReader> reader,
     }
   }
   if (batch_id >= reader_->metadata().num_batches()) {
-    // EOF
+    // Reach EOF
     return ScanBatch();
   }
 

--- a/cpp/src/lance/io/exec/scan.h
+++ b/cpp/src/lance/io/exec/scan.h
@@ -48,6 +48,8 @@ class Scan : public ExecNode {
   /// Returns the next available batch in the file. Or returns nullptr if EOF.
   ::arrow::Result<ScanBatch> Next() override;
 
+  const lance::format::Schema& schema();
+
   std::string ToString() const override;
 
  private:
@@ -61,9 +63,8 @@ class Scan : public ExecNode {
        int64_t batch_size);
 
   const std::shared_ptr<FileReader> reader_;
-  /// The projected schema to scan.
   const std::shared_ptr<lance::format::Schema> schema_;
-  int64_t batch_size_;
+  const int64_t batch_size_;
 
   /// Keep track of the progress.
   std::mutex lock_;

--- a/cpp/src/lance/io/exec/scan.h
+++ b/cpp/src/lance/io/exec/scan.h
@@ -36,6 +36,21 @@ namespace lance::io::exec {
 /// Leaf scan node.
 class Scan : public ExecNode {
  public:
+  /// Factory method.
+  static ::arrow::Result<std::unique_ptr<Scan>> Make(std::shared_ptr<FileReader> reader,
+                                                     std::shared_ptr<lance::format::Schema> schema,
+                                                     int64_t batch_size);
+
+  Scan() = delete;
+
+  virtual ~Scan() = default;
+
+  /// Returns the next available batch in the file. Or returns nullptr if EOF.
+  ::arrow::Result<ScanBatch> Next() override;
+
+  std::string ToString() const override;
+
+ private:
   /// Constructor
   ///
   /// \param reader An opened file reader.
@@ -45,12 +60,6 @@ class Scan : public ExecNode {
        std::shared_ptr<lance::format::Schema> schema,
        int64_t batch_size);
 
-  virtual ~Scan() = default;
-
-  /// Returns the next available batch. Or returns nullptr if EOF.
-  ::arrow::Result<std::shared_ptr<::arrow::RecordBatch>> Next() override;
-
- private:
   const std::shared_ptr<FileReader> reader_;
   /// The projected schema to scan.
   const std::shared_ptr<lance::format::Schema> schema_;
@@ -61,6 +70,8 @@ class Scan : public ExecNode {
   int32_t current_batch_id_ = 0;
   /// Offset in the batch.
   int32_t current_offset_ = 0;
+  ///
+  int32_t current_batch_page_length_ = 0;
 };
 
 }  // namespace lance::io::exec

--- a/cpp/src/lance/io/exec/scan.h
+++ b/cpp/src/lance/io/exec/scan.h
@@ -45,12 +45,20 @@ class Scan : public ExecNode {
 
   virtual ~Scan() = default;
 
+  constexpr Type type() const override { return Type::kScan; }
   /// Returns the next available batch in the file. Or returns nullptr if EOF.
   ::arrow::Result<ScanBatch> Next() override;
 
   const lance::format::Schema& schema();
 
   std::string ToString() const override;
+
+  /// Seek to a particular row.
+  ///
+  /// It is used by LIMIT to advance the starting offset, allows to skip IOs.
+  ///
+  /// \param offset the number of rows to seek forward.
+  ::arrow::Status Seek(int32_t offset);
 
  private:
   /// Constructor

--- a/cpp/src/lance/io/exec/scan.h
+++ b/cpp/src/lance/io/exec/scan.h
@@ -1,0 +1,66 @@
+//  Copyright 2022 Lance Authors
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+
+#pragma once
+
+#include <arrow/dataset/scanner.h>
+#include <arrow/record_batch.h>
+#include <arrow/result.h>
+
+#include <memory>
+#include <mutex>
+
+#include "lance/io/exec/base.h"
+
+namespace lance::format {
+class Schema;
+}
+
+namespace lance::io {
+class FileReader;
+}
+
+namespace lance::io::exec {
+
+/// Leaf scan node.
+class Scan : public ExecNode {
+ public:
+  /// Constructor
+  ///
+  /// \param reader An opened file reader.
+  /// \param schema The scan schema, used to select column to scan.
+  /// \param batch_size scan batch size.
+  Scan(std::shared_ptr<FileReader> reader,
+       std::shared_ptr<lance::format::Schema> schema,
+       int64_t batch_size);
+
+  virtual ~Scan() = default;
+
+  /// Returns the next available batch. Or returns nullptr if EOF.
+  ::arrow::Result<std::shared_ptr<::arrow::RecordBatch>> Next() override;
+
+ private:
+  const std::shared_ptr<FileReader> reader_;
+  /// The projected schema to scan.
+  const std::shared_ptr<lance::format::Schema> schema_;
+  int64_t batch_size_;
+
+  /// Keep track of the progress.
+  std::mutex lock_;
+  int32_t current_batch_id_ = 0;
+  /// Offset in the batch.
+  int32_t current_offset_ = 0;
+};
+
+}  // namespace lance::io::exec

--- a/cpp/src/lance/io/exec/scan_test.cc
+++ b/cpp/src/lance/io/exec/scan_test.cc
@@ -1,0 +1,56 @@
+//  Copyright 2022 Lance Authors
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+
+#include "lance/io/exec/scan.h"
+
+#include <arrow/table.h>
+
+#include <catch2/catch_test_macros.hpp>
+#include <numeric>
+#include <vector>
+
+#include "lance/arrow/stl.h"
+#include "lance/format/schema.h"
+#include "lance/io/exec/base.h"
+#include "lance/testing/io.h"
+
+using lance::format::Schema;
+using lance::io::exec::Scan;
+using lance::testing::MakeReader;
+
+TEST_CASE("Test Scan::Next") {
+  std::vector<int32_t> ints(20);
+  std::iota(ints.begin(), ints.end(), 0);
+  auto schema = ::arrow::schema({
+      ::arrow::field("ints", ::arrow::int32()),
+  });
+  auto chunked_arrs = ::arrow::ChunkedArray::Make({lance::arrow::ToArray(ints).ValueOrDie(),
+                                                   lance::arrow::ToArray(ints).ValueOrDie()})
+                          .ValueOrDie();
+  auto tab = ::arrow::Table::Make(schema, {chunked_arrs});
+
+  CHECK(tab->column(0)->num_chunks() == 2);
+  auto reader = MakeReader(tab).ValueOrDie();
+
+  auto scan = Scan::Make(reader, std::make_shared<Schema>(reader->schema()), 8).ValueOrDie();
+  auto batch = scan->Next().ValueOrDie();
+  CHECK(batch.batch_id == 0);
+  CHECK(batch.batch->num_rows() == 8);
+  batch = scan->Next().ValueOrDie();
+  CHECK(batch.batch_id == 0);
+  CHECK(batch.batch->num_rows() == 8);
+  batch = scan->Next().ValueOrDie();
+  CHECK(batch.batch_id == 0);
+  CHECK(batch.batch->num_rows() == 4);
+}

--- a/cpp/src/lance/io/exec/take.cc
+++ b/cpp/src/lance/io/exec/take.cc
@@ -45,6 +45,7 @@ Take::Take(std::shared_ptr<FileReader> reader,
   auto values = std::reinterpret_pointer_cast<::arrow::StructArray>(vals);
   if (!schema_) {
     return ScanBatch{::arrow::RecordBatch::FromStructArray(vals).ValueOrDie(), filtered.batch_id};
+  } else {
   }
   return child_->Next();
 }

--- a/cpp/src/lance/io/exec/take.cc
+++ b/cpp/src/lance/io/exec/take.cc
@@ -1,0 +1,54 @@
+//  Copyright 2022 Lance Authors
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+
+#include "lance/io/exec/take.h"
+
+namespace lance::io::exec {
+
+Take::Take(std::shared_ptr<FileReader> reader,
+           std::shared_ptr<lance::format::Schema> schema,
+           std::unique_ptr<ExecNode> child)
+    : reader_(std::move(reader)), schema_(std::move(schema)), child_(std::move(child)) {
+  assert(child_);
+}
+
+::arrow::Result<std::unique_ptr<Take>> Take::Make(std::shared_ptr<FileReader> reader,
+                                                  std::shared_ptr<lance::format::Schema> schema,
+                                                  std::unique_ptr<ExecNode> child) {
+  if (!child) {
+    return ::arrow::Status::Invalid("Take::Make: child can not be null");
+  }
+  return std::unique_ptr<Take>(new Take(reader, schema, std::move(child)));
+}
+
+::arrow::Result<ScanBatch> Take::Next() {
+  ARROW_ASSIGN_OR_RAISE(auto filtered, child_->Next());
+  if (filtered.eof()) {
+    return ScanBatch{};
+  }
+  auto indices = filtered.batch->GetColumnByName("indices");
+  auto vals = filtered.batch->GetColumnByName("values");
+  if (!indices || !vals || vals->type_id() != ::arrow::Type::STRUCT) {
+    return ::arrow::Status::Invalid("Invalid data from filter");
+  }
+  auto values = std::reinterpret_pointer_cast<::arrow::StructArray>(vals);
+  if (!schema_) {
+    return ScanBatch{::arrow::RecordBatch::FromStructArray(vals).ValueOrDie(), filtered.batch_id};
+  }
+  return child_->Next();
+}
+
+std::string Take::ToString() const { return "Take"; }
+
+}  // namespace lance::io::exec

--- a/cpp/src/lance/io/exec/take.h
+++ b/cpp/src/lance/io/exec/take.h
@@ -58,6 +58,8 @@ class Take : public ExecNode {
   /// \return ScanBatch if succeed.
   ::arrow::Result<ScanBatch> Next() override;
 
+  constexpr Type type() const override { return kTake; }
+
   std::string ToString() const override;
 
  private:

--- a/cpp/src/lance/io/exec/take.h
+++ b/cpp/src/lance/io/exec/take.h
@@ -1,0 +1,78 @@
+//  Copyright 2022 Lance Authors
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+
+#pragma once
+
+#include <arrow/record_batch.h>
+#include <arrow/result.h>
+
+#include <memory>
+
+#include "lance/format/schema.h"
+#include "lance/io/exec/base.h"
+#include "lance/io/reader.h"
+
+namespace lance::io::exec {
+
+/// \brief Take Node
+///
+/// Take node takes the filtered results from child node, and uses the indices to
+/// conduct random access to fetch the result of columns.
+///
+/// For example, "SELECT col1, col2 FROM dataet WHERE col3 = 123",
+///   Take.child -> Filter.child -> Scan
+///
+/// If limit / offsets are presented in the statement. The Limit node will be placed
+/// in front of the filter node.
+///
+///  Take.child -> Limit.child -> Filter.child -> Scan
+class Take : public ExecNode {
+ public:
+  /// Factory method.
+  ///
+  /// \param reader An opened lance file reader.
+  /// \param schema Schema for the takers.
+  /// \param child the child filter node.
+  /// \return a take node if success.
+  static ::arrow::Result<std::unique_ptr<Take>> Make(std::shared_ptr<FileReader> reader,
+                                                     std::shared_ptr<lance::format::Schema> schema,
+                                                     std::unique_ptr<ExecNode> child);
+
+  /// Returns the next batch.
+  ///
+  /// It reads the filtered data from child_, run FileReader::take(indices) to fetch
+  /// the remaining columns, and rebuild ScanBatch, i.e., remove the indices column from the
+  /// batch.
+  ///
+  /// \return ScanBatch if succeed.
+  ::arrow::Result<ScanBatch> Next() override;
+
+  std::string ToString() const override;
+
+ private:
+  /// Constructor.
+  ///
+  /// \param reader An opened lance file reader.
+  /// \param schema Schema for the takers.
+  /// \param child the child filter node.
+  Take(std::shared_ptr<FileReader> reader,
+       std::shared_ptr<lance::format::Schema> schema,
+       std::unique_ptr<ExecNode> child);
+
+  std::shared_ptr<FileReader> reader_;
+  std::shared_ptr<lance::format::Schema> schema_;
+  std::unique_ptr<ExecNode> child_;
+};
+
+}  // namespace lance::io::exec

--- a/cpp/src/lance/io/project.cc
+++ b/cpp/src/lance/io/project.cc
@@ -20,7 +20,7 @@
 #include <fmt/ranges.h>
 
 #include "lance/arrow/utils.h"
-#include "lance/io/filter.h"
+#include "lance/io/exec/filter.h"
 #include "lance/io/limit.h"
 #include "lance/io/reader.h"
 
@@ -57,8 +57,6 @@ Project::Project(std::shared_ptr<format::Schema> projected_schema,
 }
 
 const std::shared_ptr<format::Schema>& Project::schema() const { return projected_schema_; }
-
-bool Project::CanParallelScan() const { return limit_.operator bool(); }
 
 ::arrow::Result<std::shared_ptr<::arrow::RecordBatch>> Project::Execute(
     std::shared_ptr<FileReader> reader, int32_t batch_id) {

--- a/cpp/src/lance/io/project.h
+++ b/cpp/src/lance/io/project.h
@@ -59,14 +59,6 @@ class Project {
   /// Project schema
   const std::shared_ptr<format::Schema>& schema() const;
 
-  /// \brief Can the plan support parallel scan.
-  ///
-  /// \note Once Projection has limit / offset clause, parallel reads are limited.
-  ///
-  /// \todo GH-43. should we remove this LIMIT / OFFSET logic, and the decision about parallel scan
-  /// out of the format spec?
-  bool CanParallelScan() const;
-
  private:
   Project(std::shared_ptr<format::Schema> projected_schema,
           std::shared_ptr<format::Schema> scan_schema,

--- a/cpp/src/lance/io/project_test.cc
+++ b/cpp/src/lance/io/project_test.cc
@@ -26,7 +26,7 @@
 #include "lance/arrow/scanner.h"
 #include "lance/arrow/stl.h"
 #include "lance/format/schema.h"
-#include "lance/io/filter.h"
+#include "lance/io/exec/filter.h"
 #include "lance/io/limit.h"
 #include "lance/io/reader.h"
 #include "lance/testing/io.h"

--- a/cpp/src/lance/io/reader.cc
+++ b/cpp/src/lance/io/reader.cc
@@ -251,8 +251,11 @@ const lance::format::Metadata& FileReader::metadata() const { return *metadata_;
 }
 
 ::arrow::Result<std::shared_ptr<::arrow::RecordBatch>> FileReader::ReadBatch(
-    const lance::format::Schema& schema, int32_t batch_id, std::optional<int32_t> length) const {
-  return ReadBatch(schema, batch_id, ArrayReadParams(0, length));
+    const lance::format::Schema& schema,
+    int32_t batch_id,
+    int32_t offset,
+    std::optional<int32_t> length) const {
+  return ReadBatch(schema, batch_id, ArrayReadParams(offset, length));
 }
 
 ::arrow::Result<std::shared_ptr<::arrow::RecordBatch>> FileReader::ReadBatch(

--- a/cpp/src/lance/io/reader.h
+++ b/cpp/src/lance/io/reader.h
@@ -49,18 +49,16 @@ class FileReader {
   ::arrow::Result<std::shared_ptr<::arrow::Table>> ReadTable(
       const std::vector<std::string>& columns);
 
-  /// Read a RecordBatch at the offset.
+  /// Read a RecordBatch at the file offset.
   ::arrow::Result<std::shared_ptr<::arrow::RecordBatch>> ReadAt(const lance::format::Schema& schema,
                                                                 int32_t offset,
                                                                 int32_t length) const;
 
-  /// Read a Batch.
-  ///
-  /// While ReadAt can read at any arbitrary offset within a batch, ReadBatch always
-  /// starts at the batch boundary.
+  /// Read a Batch
   ::arrow::Result<std::shared_ptr<::arrow::RecordBatch>> ReadBatch(
       const lance::format::Schema& schema,
       int32_t batch_id,
+      int32_t offset = 0,
       std::optional<int32_t> length = std::nullopt) const;
 
   /// Read a Batch with indices.

--- a/cpp/src/lance/io/record_batch_reader.cc
+++ b/cpp/src/lance/io/record_batch_reader.cc
@@ -28,8 +28,8 @@
 #include "lance/format/metadata.h"
 #include "lance/format/schema.h"
 #include "lance/io/exec/filter.h"
-#include "lance/io/limit.h"
-#include "lance/io/project.h"
+#include "lance/io/exec/limit.h"
+#include "lance/io/exec/project.h"
 #include "lance/io/reader.h"
 
 namespace lance::io {
@@ -67,7 +67,8 @@ RecordBatchReader::RecordBatchReader(RecordBatchReader&& other) noexcept
       readahead_queue_(std::move(other.readahead_queue_)) {}
 
 ::arrow::Status RecordBatchReader::Open() {
-  ARROW_ASSIGN_OR_RAISE(project_, Project::Make(reader_->schema(), options_, limit_, offset_));
+  ARROW_ASSIGN_OR_RAISE(project_,
+                        exec::Project::Make(reader_->schema(), options_, limit_, offset_));
   return ::arrow::Status::OK();
 }
 

--- a/cpp/src/lance/io/record_batch_reader.cc
+++ b/cpp/src/lance/io/record_batch_reader.cc
@@ -72,7 +72,7 @@ RecordBatchReader::RecordBatchReader(RecordBatchReader&& other) noexcept
 }
 
 std::shared_ptr<::arrow::Schema> RecordBatchReader::schema() const {
-  return project_->schema()->ToArrow();
+  return options_->projected_schema;
 }
 
 ::arrow::Status RecordBatchReader::ReadNext(std::shared_ptr<::arrow::RecordBatch>* batch) {

--- a/cpp/src/lance/io/record_batch_reader.cc
+++ b/cpp/src/lance/io/record_batch_reader.cc
@@ -76,20 +76,15 @@ std::shared_ptr<::arrow::Schema> RecordBatchReader::schema() const {
 }
 
 ::arrow::Status RecordBatchReader::ReadNext(std::shared_ptr<::arrow::RecordBatch>* batch) {
-  int32_t batch_id = current_batch_++;
-  ARROW_ASSIGN_OR_RAISE(auto batch_read, ReadBatch(batch_id));
-  if (batch_read) {
-    *batch = std::move(batch_read);
-  }
+  ARROW_ASSIGN_OR_RAISE(auto scan_batch, project_->Next());
+  *batch = std::move(scan_batch.batch);
   return ::arrow::Status::OK();
 }
 
 ::arrow::Result<std::shared_ptr<::arrow::RecordBatch>> RecordBatchReader::ReadBatch(
-    int32_t batch_id) const {
-  if (batch_id < reader_->metadata().num_batches()) {
-    return project_->Execute(reader_, batch_id);
-  }
-  return nullptr;
+    [[maybe_unused]] int32_t batch_id) const {
+  ARROW_ASSIGN_OR_RAISE(auto batch, project_->Next());
+  return batch.batch;
 }
 
 ::arrow::Future<std::shared_ptr<::arrow::RecordBatch>> RecordBatchReader::operator()() {

--- a/cpp/src/lance/io/record_batch_reader.cc
+++ b/cpp/src/lance/io/record_batch_reader.cc
@@ -27,7 +27,7 @@
 
 #include "lance/format/metadata.h"
 #include "lance/format/schema.h"
-#include "lance/io/filter.h"
+#include "lance/io/exec/filter.h"
 #include "lance/io/limit.h"
 #include "lance/io/project.h"
 #include "lance/io/reader.h"

--- a/cpp/src/lance/io/record_batch_reader.cc
+++ b/cpp/src/lance/io/record_batch_reader.cc
@@ -67,8 +67,7 @@ RecordBatchReader::RecordBatchReader(RecordBatchReader&& other) noexcept
       readahead_queue_(std::move(other.readahead_queue_)) {}
 
 ::arrow::Status RecordBatchReader::Open() {
-  ARROW_ASSIGN_OR_RAISE(project_,
-                        exec::Project::Make(reader_->schema(), options_, limit_, offset_));
+  ARROW_ASSIGN_OR_RAISE(project_, exec::Project::Make(reader_, options_, limit_, offset_));
   return ::arrow::Status::OK();
 }
 

--- a/cpp/src/lance/io/record_batch_reader.h
+++ b/cpp/src/lance/io/record_batch_reader.h
@@ -35,7 +35,10 @@ class Schema;
 namespace lance::io {
 
 class FileReader;
+
+namespace exec {
 class Project;
+}
 
 /// Lance RecordBatchReader
 class RecordBatchReader : ::arrow::RecordBatchReader {
@@ -75,7 +78,7 @@ class RecordBatchReader : ::arrow::RecordBatchReader {
   std::optional<int64_t> limit_ = std::nullopt;
   int64_t offset_ = 0;
   /// Projection over the dataset.
-  std::shared_ptr<Project> project_;
+  std::shared_ptr<exec::Project> project_;
 
   ::arrow::internal::ThreadPool* thread_pool_;
   std::atomic_int32_t current_batch_ = 0;

--- a/cpp/src/lance/io/writer.cc
+++ b/cpp/src/lance/io/writer.cc
@@ -183,7 +183,7 @@ FileWriter::~FileWriter() {}
 ::arrow::Status FileWriter::WriteFooter() {
   // Write dictionary values first.
   auto visitor = format::WriteDictionaryVisitor(destination_);
-  ARROW_RETURN_NOT_OK(visitor.VisitSchema(lance_schema_));
+  ARROW_RETURN_NOT_OK(visitor.VisitSchema(*lance_schema_));
 
   ARROW_ASSIGN_OR_RAISE(auto pos, lookup_table_.Write(destination_));
   metadata_->SetPageTablePosition(pos);

--- a/cpp/src/lance/testing/io.h
+++ b/cpp/src/lance/testing/io.h
@@ -38,7 +38,9 @@ class DummyNode : lance::io::exec::ExecNode {
 
   DummyNode(DummyNode&&) = default;
 
-  static std::unique_ptr<DummyNode> Make() { return std::make_unique<DummyNode>(); }
+  static std::unique_ptr<io::exec::ExecNode> Make() {
+    return std::unique_ptr<io::exec::ExecNode>(new DummyNode());
+  }
 
   ::arrow::Result<io::exec::ScanBatch> Next() override {
     return ::arrow::Status::NotImplemented("DummyNode::Next not implemented");

--- a/cpp/src/lance/testing/io.h
+++ b/cpp/src/lance/testing/io.h
@@ -18,7 +18,9 @@
 #include <arrow/table.h>
 
 #include <memory>
+#include <string>
 
+#include "lance/io/exec/base.h"
 #include "lance/io/reader.h"
 
 namespace lance::testing {
@@ -26,5 +28,23 @@ namespace lance::testing {
 /// Make lance::io::FileReader from an Arrow Table.
 ::arrow::Result<std::shared_ptr<lance::io::FileReader>> MakeReader(
     const std::shared_ptr<::arrow::Table>& table);
+
+/// A Dummy ExecNode.
+///
+/// Used as place holder to replace ExecNode.child.
+class DummyNode : lance::io::exec::ExecNode {
+ public:
+  DummyNode() = default;
+
+  DummyNode(DummyNode&&) = default;
+
+  static std::unique_ptr<DummyNode> Make() { return std::make_unique<DummyNode>(); }
+
+  ::arrow::Result<io::exec::ScanBatch> Next() override {
+    return ::arrow::Status::NotImplemented("DummyNode::Next not implemented");
+  }
+
+  std::string ToString() const override { return "Dummy"; }
+};
 
 }  // namespace lance::testing

--- a/cpp/src/lance/testing/io.h
+++ b/cpp/src/lance/testing/io.h
@@ -29,24 +29,31 @@ namespace lance::testing {
 ::arrow::Result<std::shared_ptr<lance::io::FileReader>> MakeReader(
     const std::shared_ptr<::arrow::Table>& table);
 
-/// A Dummy ExecNode.
+/// A ExecNode that scans a Table in memory.
 ///
-/// Used as place holder to replace ExecNode.child.
-class DummyNode : lance::io::exec::ExecNode {
+/// This node can be used in test without creating files.
+class TableScan : lance::io::exec::ExecNode {
  public:
-  DummyNode() = default;
+  TableScan() = default;
 
-  DummyNode(DummyNode&&) = default;
+  TableScan(const ::arrow::Table& table, int64_t batch_size);
 
-  static std::unique_ptr<io::exec::ExecNode> Make() {
-    return std::unique_ptr<io::exec::ExecNode>(new DummyNode());
+  TableScan(TableScan&&) = default;
+
+  static std::unique_ptr<io::exec::ExecNode> Make(const ::arrow::Table& table,
+                                                  int64_t batch_size = 1024) {
+    return std::unique_ptr<io::exec::ExecNode>(new TableScan(table, batch_size));
   }
 
-  ::arrow::Result<io::exec::ScanBatch> Next() override {
-    return ::arrow::Status::NotImplemented("DummyNode::Next not implemented");
-  }
+  /// Make an empty table scanner.
+  static std::unique_ptr<io::exec::ExecNode> MakeEmpty();
+
+  ::arrow::Result<io::exec::ScanBatch> Next() override;
 
   std::string ToString() const override { return "Dummy"; }
+
+ private:
+  std::unique_ptr<::arrow::TableBatchReader> reader_;
 };
 
 }  // namespace lance::testing

--- a/cpp/src/lance/testing/io.h
+++ b/cpp/src/lance/testing/io.h
@@ -50,6 +50,8 @@ class TableScan : lance::io::exec::ExecNode {
 
   ::arrow::Result<io::exec::ScanBatch> Next() override;
 
+  constexpr Type type() const override { return kTableScan; }
+
   std::string ToString() const override { return "Dummy"; }
 
  private:


### PR DESCRIPTION
* Reconstruct the I/O execute node to a more standard physical plan, represented by an ExecNode tree.
* Make the Scan node (leaf node) own the logic of batch read.
* Add `Take` node that do random reads based on the indices returned from the `Filter` node.