### PR TITLE
Move Expression based schema project to Schema class

### DIFF
--- a/cpp/src/lance/format/schema.cc
+++ b/cpp/src/lance/format/schema.cc
@@ -499,6 +499,19 @@ Schema::Schema(std::shared_ptr<::arrow::Schema> schema) {
   return projection;
 }
 
+::arrow::Result<std::shared_ptr<Schema>> Schema::Project(
+    const ::arrow::compute::Expression& expr) const {
+  if (!::arrow::compute::ExpressionHasFieldRefs(expr)) {
+    /// All scalar?
+    return nullptr;
+  }
+  std::vector<std::string> columns;
+  for (auto& ref : ::arrow::compute::FieldsInExpression(expr)) {
+    columns.emplace_back(std::string(*ref.name()));
+  }
+  return Project(columns);
+}
+
 ::arrow::Result<std::shared_ptr<Schema>> Schema::Exclude(std::shared_ptr<Schema> other) const {
   /// An visitor to remove fields in place.
   class SchemaExcludeVisitor : public FieldVisitor {

--- a/cpp/src/lance/format/schema.h
+++ b/cpp/src/lance/format/schema.h
@@ -14,7 +14,7 @@
 
 #pragma once
 
-#include <arrow/compute/exec/expression.h>
+#include <arrow/compute/api.h>
 #include <arrow/type.h>
 
 #include <map>

--- a/cpp/src/lance/format/schema.h
+++ b/cpp/src/lance/format/schema.h
@@ -14,6 +14,7 @@
 
 #pragma once
 
+#include <arrow/compute/exec/expression.h>
 #include <arrow/type.h>
 
 #include <map>
@@ -60,6 +61,12 @@ class Schema final {
 
   /// Use `arrow::Schema` to create a project over the current Lance schema.
   ::arrow::Result<std::shared_ptr<Schema>> Project(const ::arrow::Schema& arrow_schema) const;
+
+  /// Use `arrow::compute::Expression` to create a projected schema.
+  ///
+  /// \param expr the expression to compute projection.
+  /// \return the projected schema. Or nullptr if the expression does not contain any field.
+  ::arrow::Result<std::shared_ptr<Schema>> Project(const ::arrow::compute::Expression& expr) const;
 
   /// Exclude (subtract) the fields from the given schema.
   ///

--- a/cpp/src/lance/io/filter.cc
+++ b/cpp/src/lance/io/filter.cc
@@ -30,16 +30,10 @@ Filter::Filter(std::shared_ptr<lance::format::Schema> schema,
 
 ::arrow::Result<std::unique_ptr<Filter>> Filter::Make(const lance::format::Schema& schema,
                                                       const ::arrow::compute::Expression& filter) {
-  if (!::arrow::compute::ExpressionHasFieldRefs(filter)) {
-    /// All scalar?
+  ARROW_ASSIGN_OR_RAISE(auto filter_schema, schema.Project(filter));
+  if (!filter_schema) {
     return nullptr;
   }
-  auto field_refs = ::arrow::compute::FieldsInExpression(filter);
-  std::vector<std::string> columns;
-  for (auto& ref : field_refs) {
-    columns.emplace_back(std::string(*ref.name()));
-  }
-  ARROW_ASSIGN_OR_RAISE(auto filter_schema, schema.Project(columns));
   return std::unique_ptr<Filter>(new Filter(filter_schema, filter));
 }
 


### PR DESCRIPTION
Add `Schema::Project(const arrow::compute::Expression&)` method to project the fields based on the fields references in the expression.