### PR TITLE
Pickle Image

### DIFF
--- a/python/lance/tests/test_types.py
+++ b/python/lance/tests/test_types.py
@@ -11,7 +11,7 @@
 #  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 #  See the License for the specific language governing permissions and
 #  limitations under the License.
-
+import pickle
 import platform
 
 import numpy as np
@@ -19,9 +19,15 @@ import pyarrow as pa
 import pytest
 
 import lance
-from lance.types import Box2dType, ImageType, LabelType, Point2dType
-from lance.types.box import Box2dArray
-from lance.types.label import LabelArray
+from lance.types import (
+    Box2dArray,
+    Box2dType,
+    Image,
+    ImageType,
+    LabelArray,
+    LabelType,
+    Point2dType,
+)
 
 if platform.system() != "Linux":
     pytest.skip(allow_module_level=True)
@@ -123,3 +129,11 @@ def _test_extension_rt(tmp_path, ext_type, storage_arr):
     assert table["ext"].type == ext_type
     assert table["ext"].to_pylist() == arr.to_pylist()
     return table["ext"]
+
+
+def test_pickle(tmp_path):
+    img = Image("uri")
+    with (tmp_path / "image").open("wb") as fh:
+        pickle.dump(img, fh)
+    with (tmp_path / "image").open("rb") as fh:
+        assert img == pickle.load(fh)

--- a/python/lance/tests/test_types.py
+++ b/python/lance/tests/test_types.py
@@ -23,7 +23,9 @@ from lance.types import (
     Box2dArray,
     Box2dType,
     Image,
+    ImageBinary,
     ImageType,
+    ImageUri,
     LabelArray,
     LabelType,
     Point2dType,
@@ -132,7 +134,15 @@ def _test_extension_rt(tmp_path, ext_type, storage_arr):
 
 
 def test_pickle(tmp_path):
-    img = Image("uri")
+    img = Image.create("uri")
+    assert isinstance(img, ImageUri)
+    with (tmp_path / "image").open("wb") as fh:
+        pickle.dump(img, fh)
+    with (tmp_path / "image").open("rb") as fh:
+        assert img == pickle.load(fh)
+
+    img = Image.create(b"bytes")
+    assert isinstance(img, ImageBinary)
     with (tmp_path / "image").open("wb") as fh:
         pickle.dump(img, fh)
     with (tmp_path / "image").open("rb") as fh:

--- a/python/lance/types/__init__.py
+++ b/python/lance/types/__init__.py
@@ -18,9 +18,9 @@ import pyarrow as pa
 from pyarrow import ArrowKeyError
 
 from lance.types.base import Point2dType
-from lance.types.box import Box2dType
-from lance.types.image import ImageBinaryType, ImageType, ImageUriType
-from lance.types.label import LabelType
+from lance.types.box import Box2dArray, Box2dType
+from lance.types.image import Image, ImageBinaryType, ImageType, ImageUriType
+from lance.types.label import LabelArray, LabelType
 
 
 def register_extension_types():

--- a/python/lance/types/__init__.py
+++ b/python/lance/types/__init__.py
@@ -19,7 +19,14 @@ from pyarrow import ArrowKeyError
 
 from lance.types.base import Point2dType
 from lance.types.box import Box2dArray, Box2dType
-from lance.types.image import Image, ImageBinaryType, ImageType, ImageUriType
+from lance.types.image import (
+    Image,
+    ImageBinary,
+    ImageBinaryType,
+    ImageType,
+    ImageUri,
+    ImageUriType,
+)
 from lance.types.label import LabelArray, LabelType
 
 

--- a/python/lance/types/image.py
+++ b/python/lance/types/image.py
@@ -91,16 +91,16 @@ class Image(ABC):
     representations
     """
 
-    def __new__(cls, data: Union[bytes, str]):
+    @staticmethod
+    def create(data: Union[bytes, str]):
         if isinstance(data, bytes):
-            img = object.__new__(ImageBinary)
+            img = ImageBinary(data)
         elif isinstance(data, str):
-            img = object.__new__(ImageUri)
+            img = ImageUri(data)
         else:
             raise TypeError(
-                f"{cls.__name__} can only handle bytes or str " f"but got {type(data)}"
+                f"Image can only handle bytes or str " f"but got {type(data)}"
             )
-        img.__init__(data)
         return img
 
     @classmethod


### PR DESCRIPTION
closes #159 

Instead of custom `Image.__new__`, we just have `Image.create` instead