### PR TITLE
Exclude filter columns from projection

### DIFF
--- a/cpp/src/lance/arrow/file_lance.cc
+++ b/cpp/src/lance/arrow/file_lance.cc
@@ -21,14 +21,13 @@
 #include <memory>
 
 #include "lance/arrow/file_lance_ext.h"
-#include "lance/format/schema.h"
 #include "lance/format/manifest.h"
+#include "lance/format/schema.h"
 #include "lance/io/exec/filter.h"
 #include "lance/io/exec/project.h"
 #include "lance/io/reader.h"
 #include "lance/io/record_batch_reader.h"
 #include "lance/io/writer.h"
-#include "lance/io/reader.h"
 
 const char kLanceFormatTypeName[] = "lance";
 
@@ -77,13 +76,10 @@ bool LanceFileFormat::Equals(const FileFormat& other) const {
     const std::shared_ptr<::arrow::dataset::FileFragment>& file) const {
   ARROW_ASSIGN_OR_RAISE(auto infile, file->source().Open());
   ARROW_ASSIGN_OR_RAISE(auto reader, lance::io::FileReader::Make(infile, impl_->manifest));
-
-  fmt::print("File reader schema: {}\n", reader->schema());
-  auto batch_reader =
-      lance::io::RecordBatchReader(std::move(reader), options, ::arrow::internal::GetCpuThreadPool());
+  auto batch_reader = lance::io::RecordBatchReader(
+      std::move(reader), options, ::arrow::internal::GetCpuThreadPool());
   ARROW_RETURN_NOT_OK(batch_reader.Open());
-  auto generator = ::arrow::RecordBatchGenerator(std::move(batch_reader));
-  return generator;
+  return ::arrow::RecordBatchGenerator(std::move(batch_reader));
 }
 
 ::arrow::Result<std::shared_ptr<::arrow::dataset::FileWriter>> LanceFileFormat::MakeWriter(

--- a/cpp/src/lance/arrow/file_lance.cc
+++ b/cpp/src/lance/arrow/file_lance.cc
@@ -78,6 +78,7 @@ bool LanceFileFormat::Equals(const FileFormat& other) const {
   ARROW_ASSIGN_OR_RAISE(auto infile, file->source().Open());
   ARROW_ASSIGN_OR_RAISE(auto reader, lance::io::FileReader::Make(infile, impl_->manifest));
 
+  fmt::print("File reader schema: {}\n", reader->schema());
   auto batch_reader =
       lance::io::RecordBatchReader(std::move(reader), options, ::arrow::internal::GetCpuThreadPool());
   ARROW_RETURN_NOT_OK(batch_reader.Open());

--- a/cpp/src/lance/arrow/scanner.cc
+++ b/cpp/src/lance/arrow/scanner.cc
@@ -69,6 +69,15 @@ ScannerBuilder::ScannerBuilder(std::shared_ptr<::arrow::dataset::Dataset> datase
     ARROW_ASSIGN_OR_RAISE(scanner->options()->filter,
                           scanner->options()->filter.Bind(*scanner->options()->dataset_schema));
     scanner->options()->projected_schema = projected_schema->ToArrow();
+
+    std::vector<std::string> top_names;
+    for (const auto& field : projected_schema->fields()) {
+      top_names.emplace_back(field->name());
+    }
+    ARROW_ASSIGN_OR_RAISE(auto project_desc,
+                          ::arrow::dataset::ProjectionDescr::FromNames(
+                              top_names, *scanner->options()->dataset_schema));
+    scanner->options()->projection = project_desc.expression;
   }
 
   if (scanner->options()->fragment_scan_options) {

--- a/cpp/src/lance/arrow/scanner.cc
+++ b/cpp/src/lance/arrow/scanner.cc
@@ -84,9 +84,9 @@ ScannerBuilder::ScannerBuilder(std::shared_ptr<::arrow::dataset::Dataset> datase
         }
       }
     }
-    ARROW_ASSIGN_OR_RAISE(auto project_desc,
-                          ::arrow::dataset::ProjectionDescr::FromNames(
-                              top_names, *projected_schema->ToArrow()));
+    ARROW_ASSIGN_OR_RAISE(
+        auto project_desc,
+        ::arrow::dataset::ProjectionDescr::FromNames(top_names, *projected_schema->ToArrow()));
     scanner->options()->projected_schema = project_desc.schema;
     scanner->options()->projection = project_desc.expression;
   }
@@ -101,6 +101,9 @@ ScannerBuilder::ScannerBuilder(std::shared_ptr<::arrow::dataset::Dataset> datase
     }
   }
 
+  fmt::print("Build scanner: dataset schema={}\nproject schema={}\n",
+             scanner->options()->dataset_schema,
+             scanner->options()->projected_schema);
   return scanner;
 }
 

--- a/cpp/src/lance/arrow/scanner_test.cc
+++ b/cpp/src/lance/arrow/scanner_test.cc
@@ -74,7 +74,6 @@ TEST_CASE("Build Scanner with nested struct") {
   auto result = scanner_builder.Finish();
   CHECK(result.ok());
   auto scanner = result.ValueOrDie();
-  fmt::print("Projected: {}\n", scanner->options()->projected_schema);
 
   auto expected_proj_schema = ::arrow::schema({::arrow::field(
       "objects", ::arrow::list(::arrow::struct_({::arrow::field("val", ::arrow::int64())})))});
@@ -268,4 +267,27 @@ TEST_CASE("Filter with limit") {
   auto actual = scanner->ToTable().ValueOrDie();
   CHECK(actual->num_rows() == 0);
   CHECK(t->schema()->Equals(actual->schema()));
+}
+
+TEST_CASE("Scanner projection should not include filter columns") {
+  auto ints_arr = ToArray({1, 2, 3}).ValueOrDie();
+  auto strings_arr = ToArray({"one", "two", "three"}).ValueOrDie();
+
+  auto schema = ::arrow::schema(
+      {::arrow::field("ints", ::arrow::int32()), ::arrow::field("strs", ::arrow::utf8())});
+  auto t = ::arrow::Table::Make(schema, {ints_arr, strings_arr});
+  auto dataset = lance::testing::MakeDataset(t).ValueOrDie();
+  auto scan_builder = lance::arrow::ScannerBuilder(dataset);
+  CHECK(scan_builder
+            .Filter(::arrow::compute::equal(::arrow::compute::field_ref("ints"),
+                                            ::arrow::compute::literal(2)))
+            .ok());
+  CHECK(scan_builder.Project({"strs"}).ok());
+
+  auto scanner = scan_builder.Finish().ValueOrDie();
+  auto actual = scanner->ToTable().ValueOrDie();
+  auto expected_schema = ::arrow::schema({::arrow::field("strs", ::arrow::utf8())});
+  INFO("Expected schema: " << expected_schema->ToString()
+                           << "\nGot: " << actual->schema()->ToString());
+  CHECK(actual->schema()->Equals(::arrow::schema({::arrow::field("strs", ::arrow::utf8())})));
 }

--- a/cpp/src/lance/arrow/scanner_test.cc
+++ b/cpp/src/lance/arrow/scanner_test.cc
@@ -118,7 +118,7 @@ std::shared_ptr<::arrow::dataset::Scanner> MakeScanner(std::shared_ptr<::arrow::
   auto result = scanner_builder.Finish();
   CHECK(result.ok());
   auto scanner = result.ValueOrDie();
-  fmt::print("Projected: {}\n", scanner->options()->projected_schema);
+  fmt::print("MakeScanner::Projected: {}\n", scanner->options()->projected_schema);
   return scanner;
 }
 
@@ -136,12 +136,12 @@ TEST_CASE("Scanner with extension") {
 
   auto expected_proj_schema = ::arrow::schema({::arrow::field("c2", ext_type)});
   INFO("Expected schema: " << expected_proj_schema->ToString());
-  INFO("Actual schema: " << scanner->options()->projected_schema->ToString());
+  INFO("Actual schema blabla: " << scanner->options()->projected_schema->ToString());
   CHECK(expected_proj_schema->Equals(scanner->options()->projected_schema));
 
-  auto actual_table = scanner->ToTable().ValueOrDie();
-  CHECK(actual_table->schema()->Equals(expected_proj_schema));
-  CHECK(actual_table->GetColumnByName("c2")->type()->Equals(ext_type));
+//  auto actual_table = scanner->ToTable().ValueOrDie();
+//  CHECK(actual_table->schema()->Equals(expected_proj_schema));
+//  CHECK(actual_table->GetColumnByName("c2")->type()->Equals(ext_type));
 }
 
 ::arrow::Result<std::shared_ptr<::arrow::dataset::Scanner>> MakeScannerForBatchScan(

--- a/cpp/src/lance/arrow/scanner_test.cc
+++ b/cpp/src/lance/arrow/scanner_test.cc
@@ -122,9 +122,9 @@ std::shared_ptr<::arrow::dataset::Scanner> MakeScanner(std::shared_ptr<::arrow::
 }
 
 TEST_CASE("Scanner with extension") {
-  auto table = MakeTable();
   auto ext_type = std::make_shared<::lance::testing::ParametricType>(1);
   CHECK(::arrow::RegisterExtensionType(ext_type).ok());
+  auto table = MakeTable();
   auto scanner = MakeScanner(table);
 
   auto dataset = std::make_shared<::arrow::dataset::InMemoryDataset>(table);

--- a/cpp/src/lance/arrow/scanner_test.cc
+++ b/cpp/src/lance/arrow/scanner_test.cc
@@ -118,7 +118,6 @@ std::shared_ptr<::arrow::dataset::Scanner> MakeScanner(std::shared_ptr<::arrow::
   auto result = scanner_builder.Finish();
   CHECK(result.ok());
   auto scanner = result.ValueOrDie();
-  fmt::print("MakeScanner::Projected: {}\n", scanner->options()->projected_schema);
   return scanner;
 }
 
@@ -136,12 +135,12 @@ TEST_CASE("Scanner with extension") {
 
   auto expected_proj_schema = ::arrow::schema({::arrow::field("c2", ext_type)});
   INFO("Expected schema: " << expected_proj_schema->ToString());
-  INFO("Actual schema blabla: " << scanner->options()->projected_schema->ToString());
+  INFO("Actual schema: " << scanner->options()->projected_schema->ToString());
   CHECK(expected_proj_schema->Equals(scanner->options()->projected_schema));
 
-//  auto actual_table = scanner->ToTable().ValueOrDie();
-//  CHECK(actual_table->schema()->Equals(expected_proj_schema));
-//  CHECK(actual_table->GetColumnByName("c2")->type()->Equals(ext_type));
+  auto actual_table = scanner->ToTable().ValueOrDie();
+  CHECK(actual_table->schema()->Equals(expected_proj_schema));
+  CHECK(actual_table->GetColumnByName("c2")->type()->Equals(ext_type));
 }
 
 ::arrow::Result<std::shared_ptr<::arrow::dataset::Scanner>> MakeScannerForBatchScan(
@@ -289,5 +288,5 @@ TEST_CASE("Scanner projection should not include filter columns") {
   auto expected_schema = ::arrow::schema({::arrow::field("strs", ::arrow::utf8())});
   INFO("Expected schema: " << expected_schema->ToString()
                            << "\nGot: " << actual->schema()->ToString());
-  CHECK(actual->schema()->Equals(::arrow::schema({::arrow::field("strs", ::arrow::utf8())})));
+  CHECK(actual->schema()->Equals(expected_schema));
 }

--- a/cpp/src/lance/arrow/utils.cc
+++ b/cpp/src/lance/arrow/utils.cc
@@ -16,6 +16,7 @@
 
 #include <arrow/result.h>
 #include <fmt/format.h>
+#include <fmt/ranges.h>
 
 #include <string>
 #include <vector>

--- a/cpp/src/lance/arrow/utils.cc
+++ b/cpp/src/lance/arrow/utils.cc
@@ -123,4 +123,43 @@ std::string ColumnNameFromFieldRef(const ::arrow::FieldRef& ref) {
   return name;
 }
 
+::arrow::Result<std::shared_ptr<::arrow::StructArray>> ApplyProjection(
+    const ::arrow::StructArray& arr, const format::Field& field) {
+  assert(is_struct(field.type()->id()));
+
+  std::vector<std::shared_ptr<::arrow::Array>> columns;
+  std::vector<std::string> names;
+  for (auto& child : field.fields()) {
+    auto col = arr.GetFieldByName(child->name());
+    if (!col) {
+      return ::arrow::Status::Invalid(fmt::format("Column {} not found", child->name()));
+    }
+    if (is_struct(col->type_id())) {
+      ARROW_ASSIGN_OR_RAISE(
+          col, ApplyProjection(*std::dynamic_pointer_cast<::arrow::StructArray>(col), *child));
+    }
+    names.emplace_back(child->name());
+    columns.emplace_back(col);
+  }
+  return ::arrow::StructArray::Make(columns, names);
+};
+
+::arrow::Result<std::shared_ptr<::arrow::RecordBatch>> ApplyProjection(
+    const std::shared_ptr<::arrow::RecordBatch>& batch, const format::Schema& projected_schema) {
+  std::vector<std::shared_ptr<::arrow::Array>> columns;
+  for (const auto& field : projected_schema.fields()) {
+    auto col = batch->GetColumnByName(field->name());
+    if (!col) {
+      continue;
+    }
+    if (is_struct(col->type_id())) {
+      ARROW_ASSIGN_OR_RAISE(
+          col, ApplyProjection(*std::dynamic_pointer_cast<::arrow::StructArray>(col), *field));
+    }
+
+    columns.emplace_back(col);
+  }
+  return ::arrow::RecordBatch::Make(projected_schema.ToArrow(), batch->num_rows(), columns);
+}
+
 }  // namespace lance::arrow

--- a/cpp/src/lance/arrow/utils.h
+++ b/cpp/src/lance/arrow/utils.h
@@ -20,6 +20,8 @@
 
 #include <memory>
 
+#include "lance/format/schema.h"
+
 namespace lance::arrow {
 
 /// Merge two same-length record batches into one.
@@ -32,6 +34,9 @@ namespace lance::arrow {
     const std::shared_ptr<::arrow::StructArray>& lhs,
     const std::shared_ptr<::arrow::StructArray>& rhs,
     ::arrow::MemoryPool* pool = ::arrow::default_memory_pool());
+
+::arrow::Result<std::shared_ptr<::arrow::RecordBatch>> ApplyProjection(
+    const std::shared_ptr<::arrow::RecordBatch>& batch, const format::Schema& projected_schema);
 
 std::string ColumnNameFromFieldRef(const ::arrow::FieldRef& ref);
 

--- a/cpp/src/lance/io/exec/base.cc
+++ b/cpp/src/lance/io/exec/base.cc
@@ -14,9 +14,9 @@
 
 #include "lance/io/exec/base.h"
 
-#include <arrow/array.h>
-
 #include <memory>
+
+#include "lance/arrow/utils.h"
 
 namespace lance::io::exec {
 
@@ -41,6 +41,12 @@ int64_t ScanBatch::length() const {
     return 0;
   }
   return batch->num_rows();
+}
+
+::arrow::Result<ScanBatch> ScanBatch::Project(const lance::format::Schema& projected_schema) {
+  ARROW_ASSIGN_OR_RAISE(auto projected_batch,
+                        lance::arrow::ApplyProjection(batch, projected_schema));
+  return ScanBatch{projected_batch, batch_id, indices};
 }
 
 }  // namespace lance::io::exec

--- a/cpp/src/lance/io/exec/base.h
+++ b/cpp/src/lance/io/exec/base.h
@@ -21,6 +21,11 @@
 #include <string>
 #include <vector>
 
+/// Forward Declaration.
+namespace lance::format {
+class Schema;
+}
+
 namespace lance::io::exec {
 
 /// Emitted results from each ExecNode
@@ -60,6 +65,9 @@ struct ScanBatch {
 
   /// The length of this batch.
   int64_t length() const;
+
+  /// Project selected columns over the Scanned Batch.
+  ::arrow::Result<ScanBatch> Project(const lance::format::Schema& projected_schema);
 };
 
 /// I/O execute base node.

--- a/cpp/src/lance/io/exec/project.cc
+++ b/cpp/src/lance/io/exec/project.cc
@@ -44,6 +44,7 @@ Project::Project(std::unique_ptr<ExecNode> child,
              scan_options->projected_schema->ToString(),
              scan_options->dataset_schema->ToString());
   ARROW_ASSIGN_OR_RAISE(auto projected_schema, schema.Project(*projected_arrow_schema));
+  fmt::print("After project schema: schema={} projected={}\n", schema, projected_schema);
 
   std::optional<int64_t> limit;
   int64_t offset;
@@ -60,6 +61,7 @@ Project::Project(std::unique_ptr<ExecNode> child,
     ///
     /// Take -> (optionally) Limit -> Filter -> Scan
     ARROW_ASSIGN_OR_RAISE(auto filter_scan_schema, schema.Project(scan_options->filter));
+    fmt::print("Has filter: filter scan schema: {}\n", filter_scan_schema->ToString());
     ARROW_ASSIGN_OR_RAISE(auto filter_scan_node,
                           Scan::Make(reader, filter_scan_schema, scan_options->batch_size));
     ARROW_ASSIGN_OR_RAISE(child, Filter::Make(scan_options->filter, std::move(filter_scan_node)));
@@ -67,6 +69,7 @@ Project::Project(std::unique_ptr<ExecNode> child,
       ARROW_ASSIGN_OR_RAISE(child, Limit::Make(limit.value(), offset, std::move(child)));
     }
     ARROW_ASSIGN_OR_RAISE(auto take_schema, projected_schema->Exclude(*filter_scan_schema));
+    fmt::print("Take schema: {}\n", take_schema);
     ARROW_ASSIGN_OR_RAISE(child, Take::Make(reader, take_schema, std::move(child)));
   } else {
     /// (*optionally) Limit -> Scan
@@ -83,16 +86,18 @@ Project::Project(std::unique_ptr<ExecNode> child,
 std::string Project::ToString() const { return "Project"; }
 
 ::arrow::Result<ScanBatch> Project::Next() {
+
   assert(child_);
   ARROW_ASSIGN_OR_RAISE(auto batch, child_->Next());
   if (batch.eof()) {
     return batch;
   }
-  fmt::print("Projected schema: {}\n, data schema: {}\n",
+  fmt::print("After read, Projected schema: {}\n, actual dataset schema: {}\n",
              projected_schema_->ToString(),
              !batch.eof() ? batch.batch->schema()->ToString() : "{}");
   ARROW_ASSIGN_OR_RAISE(auto projected_batch,
                         lance::arrow::ApplyProjection(batch.batch, *projected_schema_));
+  fmt::print("Projected batch: {}\n", projected_batch->ToString());
   return ScanBatch(projected_batch, batch.batch_id, batch.indices);
 }
 

--- a/cpp/src/lance/io/exec/project.cc
+++ b/cpp/src/lance/io/exec/project.cc
@@ -19,7 +19,6 @@
 #include <fmt/format.h>
 
 #include "lance/arrow/file_lance_ext.h"
-#include "lance/arrow/utils.h"
 #include "lance/io/exec/filter.h"
 #include "lance/io/exec/limit.h"
 #include "lance/io/exec/scan.h"
@@ -84,9 +83,7 @@ std::string Project::ToString() const { return "Project"; }
   if (batch.eof()) {
     return batch;
   }
-  ARROW_ASSIGN_OR_RAISE(auto projected_batch,
-                        lance::arrow::ApplyProjection(batch.batch, *projected_schema_));
-  return ScanBatch(projected_batch, batch.batch_id, batch.indices);
+  return batch.Project(*projected_schema_);
 }
 
 }  // namespace lance::io::exec

--- a/cpp/src/lance/io/exec/project.h
+++ b/cpp/src/lance/io/exec/project.h
@@ -21,8 +21,8 @@
 #include <memory>
 #include <optional>
 
+#include "lance/format/schema.h"
 #include "lance/io/exec/base.h"
-
 
 namespace lance::io {
 class FileReader;
@@ -54,9 +54,11 @@ class Project : ExecNode {
   std::string ToString() const override;
 
  private:
-  Project(std::unique_ptr<ExecNode> child);
+  Project(std::unique_ptr<ExecNode> child, std::shared_ptr<lance::format::Schema> projected_schema);
 
   std::unique_ptr<ExecNode> child_;
+
+  std::shared_ptr<lance::format::Schema> projected_schema_;
 };
 
 }  // namespace lance::io::exec

--- a/cpp/src/lance/io/exec/take.cc
+++ b/cpp/src/lance/io/exec/take.cc
@@ -14,6 +14,10 @@
 
 #include "lance/io/exec/take.h"
 
+#include <arrow/result.h>
+
+#include <memory>
+
 #include "lance/arrow/utils.h"
 
 namespace lance::io::exec {
@@ -47,10 +51,8 @@ Take::Take(std::shared_ptr<FileReader> reader,
     ARROW_ASSIGN_OR_RAISE(auto rest_columns,
                           reader_->ReadBatch(*schema_, batch_id, filtered.indices));
     assert(filtered.batch->num_rows() == rest_columns->num_rows());
-    fmt::print("Rest columns: {}\n", rest_columns->ToString());
     ARROW_ASSIGN_OR_RAISE(auto merged_batch,
                           lance::arrow::MergeRecordBatches(filtered.batch, rest_columns));
-    fmt::print("Merged batch: {}\n", merged_batch->ToString());
     return ScanBatch(merged_batch, filtered.batch_id);
   }
 }

--- a/cpp/src/lance/io/exec/take.cc
+++ b/cpp/src/lance/io/exec/take.cc
@@ -47,8 +47,10 @@ Take::Take(std::shared_ptr<FileReader> reader,
     ARROW_ASSIGN_OR_RAISE(auto rest_columns,
                           reader_->ReadBatch(*schema_, batch_id, filtered.indices));
     assert(filtered.batch->num_rows() == rest_columns->num_rows());
+    fmt::print("Rest columns: {}\n", rest_columns->ToString());
     ARROW_ASSIGN_OR_RAISE(auto merged_batch,
                           lance::arrow::MergeRecordBatches(filtered.batch, rest_columns));
+    fmt::print("Merged batch: {}\n", merged_batch->ToString());
     return ScanBatch(merged_batch, filtered.batch_id);
   }
 }

--- a/cpp/src/lance/io/reader.cc
+++ b/cpp/src/lance/io/reader.cc
@@ -289,7 +289,9 @@ int32_t FileReader::num_batches() const { return metadata_->num_batches(); }
 
 ::arrow::Result<std::shared_ptr<::arrow::RecordBatch>> FileReader::ReadBatch(
     const lance::format::Schema& schema, int32_t batch_id, const ArrayReadParams& params) const {
-  assert(!schema.fields().empty());
+  if (schema.fields().empty()) {
+    return ::arrow::Status::Invalid("FileReader::ReadBatch: invalid schema: empty schema");
+  }
   std::vector<std::shared_ptr<::arrow::Array>> arrs;
   /// TODO: GH-43. Read field in parallel.
   for (auto& field : schema.fields()) {

--- a/cpp/src/lance/io/reader.cc
+++ b/cpp/src/lance/io/reader.cc
@@ -289,6 +289,7 @@ int32_t FileReader::num_batches() const { return metadata_->num_batches(); }
 
 ::arrow::Result<std::shared_ptr<::arrow::RecordBatch>> FileReader::ReadBatch(
     const lance::format::Schema& schema, int32_t batch_id, const ArrayReadParams& params) const {
+  assert(!schema.fields().empty());
   std::vector<std::shared_ptr<::arrow::Array>> arrs;
   /// TODO: GH-43. Read field in parallel.
   for (auto& field : schema.fields()) {

--- a/cpp/src/lance/io/record_batch_reader.cc
+++ b/cpp/src/lance/io/record_batch_reader.cc
@@ -19,11 +19,15 @@
 #include <arrow/status.h>
 #include <arrow/util/future.h>
 #include <arrow/util/thread_pool.h>
+#include <fmt/format.h>
+#include <fmt/ranges.h>
 
 #include <algorithm>
 #include <tuple>
 
 #include "lance/format/metadata.h"
+#include "lance/format/schema.h"
+#include "lance/io/exec/filter.h"
 #include "lance/io/exec/limit.h"
 #include "lance/io/exec/project.h"
 #include "lance/io/reader.h"
@@ -33,7 +37,7 @@ namespace lance::io {
 RecordBatchReader::RecordBatchReader(std::shared_ptr<FileReader> reader,
                                      std::shared_ptr<::arrow::dataset::ScanOptions> options,
                                      ::arrow::internal::ThreadPool* thread_pool) noexcept
-    : reader_(std::move(reader)), options_(std::move(options)), thread_pool_(thread_pool) {
+    : reader_(reader), options_(options), thread_pool_(thread_pool) {
   assert(thread_pool_);
 }
 
@@ -47,7 +51,7 @@ RecordBatchReader::RecordBatchReader(RecordBatchReader&& other) noexcept
     : reader_(std::move(other.reader_)),
       options_(std::move(other.options_)),
       project_(std::move(other.project_)),
-      thread_pool_(other.thread_pool_) {}
+      thread_pool_(std::move(other.thread_pool_)) {}
 
 ::arrow::Status RecordBatchReader::Open() {
   ARROW_ASSIGN_OR_RAISE(project_, exec::Project::Make(reader_, options_));

--- a/cpp/src/lance/io/record_batch_reader.cc
+++ b/cpp/src/lance/io/record_batch_reader.cc
@@ -70,6 +70,12 @@ std::shared_ptr<::arrow::Schema> RecordBatchReader::schema() const {
 
 ::arrow::Result<std::shared_ptr<::arrow::RecordBatch>> RecordBatchReader::ReadBatch() const {
   ARROW_ASSIGN_OR_RAISE(auto batch, project_->Next());
+  if (!batch.eof()) {
+    fmt::print("RecordBatchReader:: schema={}\ndataset={}\nbatch_schema={}\n",
+               options_->projected_schema,
+               options_->dataset_schema,
+               batch.batch->schema());
+  }
   return batch.batch;
 }
 


### PR DESCRIPTION
In the case for `dataset.scanner(columns=["foo"], filters=(col("bar") == 1)`, the result should only have column `foo`.