### PR TITLE
action to bump version for new release

### DIFF
--- a/.github/workflows/bump-version.yml
+++ b/.github/workflows/bump-version.yml
@@ -1,0 +1,54 @@
+name: Bump version for releases
+
+on:
+  workflow_dispatch:
+    inputs:
+      part:
+        description: 'What kind of release is this?'
+        required: true
+        default: 'release'
+        type: choice
+        options:
+          - release
+          - patch
+          - minor
+          - major
+
+jobs:
+  bump-version:
+    runs-on: ubuntu-latest
+    steps:
+    - name: Check out main
+      uses: actions/checkout@v3
+      with:
+        ref: main
+        persist-credentials: false
+        fetch-depth: 0
+    - name: Set git configs for bumpversion
+      run: |
+        git config user.name 'Lance Release'
+        git config user.email 'lance-dev@eto.ai'
+    - name: Set up Python 3.10
+      uses: actions/setup-python@v3
+      with:
+        python-version: 3.10
+    - name: Pip install
+      working-directory: python
+      run: |
+        python -m pip install bump2version
+    - name: Create release version and tags
+      working-directory: python
+      if: ${{ inputs.part != 'patch' }}
+      run: |
+        bumpversion ${{ inputs.part }}
+    - name: Create dev0 version without tags
+      working-directory: python
+      if: ${{ inputs.part == 'patch' }}
+      run: |
+        bumpversion ${{ inputs.part }} --no-tag
+    - name: Push new version and tag
+      uses: changhiskhan/github-push-action@master
+      with:
+        github_token: ${{ secrets.GITHUB_TOKEN }}
+        branch: main
+        tags: true


### PR DESCRIPTION
Proposed release process:

1. top of main should be green
2. manually trigger this action
3. make a github "Release" with the tag created from step 2 above
4. GH to release to pypi should automatically trigger
5. GH to create a new patch release (e.g., v0.1 -> v0.2.dev0) should trigger automatically