### PR TITLE
[C++] [BUG] Adjust offset when the batch size is set for reading

### DIFF
--- a/cpp/src/lance/io/exec/base.h
+++ b/cpp/src/lance/io/exec/base.h
@@ -39,6 +39,9 @@ struct ScanBatch {
   /// The Id of the batch this result belongs to.
   int32_t batch_id = -1;
 
+  /// The offset in the batch to start read.
+  int32_t offset = 0;
+
   /// Indices returned from the filter.
   std::shared_ptr<::arrow::Int32Array> indices;
 
@@ -52,9 +55,11 @@ struct ScanBatch {
   ///
   /// \param records A record batch of values to return
   /// \param batch_id the id of the batch
+  /// \param offset the offset in the batch to start to read.
   /// \param indices the indices from filter. Optional
   ScanBatch(std::shared_ptr<::arrow::RecordBatch> records,
             int32_t batch_id,
+            int32_t offset,
             std::shared_ptr<::arrow::Int32Array> indices = nullptr);
 
   /// Returns True if the end of file is reached.

--- a/cpp/src/lance/io/exec/filter.cc
+++ b/cpp/src/lance/io/exec/filter.cc
@@ -46,7 +46,7 @@ bool Filter::HasFilter(const ::arrow::compute::Expression& filter) {
   ARROW_ASSIGN_OR_RAISE(auto indices_and_values, Apply(*batch.batch));
   auto [indices, values] = indices_and_values;
   ARROW_ASSIGN_OR_RAISE(auto values_arr, values->ToStructArray());
-  return ScanBatch(values, batch.batch_id, indices);
+  return ScanBatch(values, batch.batch_id, batch.offset, indices);
 }
 
 ::arrow::Result<

--- a/cpp/src/lance/io/exec/project.cc
+++ b/cpp/src/lance/io/exec/project.cc
@@ -77,13 +77,13 @@ Project::Project(std::unique_ptr<ExecNode> child,
 std::string Project::ToString() const { return "Project"; }
 
 ::arrow::Result<ScanBatch> Project::Next() {
-
   assert(child_);
   ARROW_ASSIGN_OR_RAISE(auto batch, child_->Next());
   if (batch.eof()) {
     return batch;
   }
-  return batch.Project(*projected_schema_);
+  return batch;
+//  return batch.Project(*projected_schema_);
 }
 
 }  // namespace lance::io::exec

--- a/cpp/src/lance/io/exec/project.cc
+++ b/cpp/src/lance/io/exec/project.cc
@@ -79,11 +79,7 @@ std::string Project::ToString() const { return "Project"; }
 ::arrow::Result<ScanBatch> Project::Next() {
   assert(child_);
   ARROW_ASSIGN_OR_RAISE(auto batch, child_->Next());
-  if (batch.eof()) {
-    return batch;
-  }
   return batch;
-//  return batch.Project(*projected_schema_);
 }
 
 }  // namespace lance::io::exec

--- a/cpp/src/lance/io/exec/scan.cc
+++ b/cpp/src/lance/io/exec/scan.cc
@@ -65,6 +65,7 @@ Scan::Scan(std::shared_ptr<FileReader> reader,
   return ScanBatch{
       batch,
       batch_id,
+      offset,
   };
 }
 

--- a/cpp/src/lance/testing/io.h
+++ b/cpp/src/lance/testing/io.h
@@ -37,10 +37,12 @@ namespace lance::testing {
 ///
 /// \param table The table to write
 /// \param partitions the column names of partitioning.
+/// \param max_rows_per_group the size of each batch group.
 /// \return a FileSystem Dataset with lance format.
 ::arrow::Result<std::shared_ptr<::arrow::dataset::Dataset>> MakeDataset(
     const std::shared_ptr<::arrow::Table>& table,
-    const std::vector<std::string>& partitions = {});
+    const std::vector<std::string>& partitions = {},
+    uint64_t max_rows_per_group = 0);
 
 /// A ExecNode that scans a Table in memory.
 ///


### PR DESCRIPTION
When the Scan node has a batch size smaller than the actual group size, `Take` needs to re-adjust the indices offset to align with the batch it reads. 

Closes #192 