### PR TITLE
GH release automation improvement

### DIFF
--- a/.github/workflows/make-patch-commit.yml
+++ b/.github/workflows/make-patch-commit.yml
@@ -1,16 +1,8 @@
 name: Create .dev0 version
 
 on:
-  workflow_dispatch:
-    inputs:
-      dry_run:
-        description: 'Just create the local commit/tags but do not push it'
-        required: true
-        default: "false"
-        type: choice
-        options:
-          - "true"
-          - "false"
+  release:
+    types: [published]
 
 jobs:
   bump-version:
@@ -38,7 +30,6 @@ jobs:
         cat lance/version.py
         git tag | cat
     - name: Push new version and tag
-      if: ${{ inputs.dry_run }} == "false"
       uses: changhiskhan/github-push-action@master
       with:
         github_token: ${{ secrets.RELEASE_TOKEN }}

--- a/.github/workflows/pypi-publish.yml
+++ b/.github/workflows/pypi-publish.yml
@@ -1,20 +1,8 @@
 name: Build and upload python wheels
 
 on:
-  workflow_dispatch:
-    inputs:
-      dry_run:
-        description: 'Just print the twine command'
-        required: true
-        default: "false"
-        type: choice
-        options:
-          - "true"
-          - "false"
-      ref:
-        description: 'Which release tag?'
-        required: true
-        type: string
+  release:
+    types: [published]
 
 jobs:
   linux:
@@ -26,7 +14,6 @@ jobs:
     steps:
     - uses: actions/checkout@v3
       with:
-        ref: ${{ inputs.ref }}
         fetch-depth: 0
         lfs: true
     - name: Set up Python
@@ -44,6 +31,9 @@ jobs:
   mac:
     timeout-minutes: 30
     runs-on: "macos-12"
+    strategy:
+      matrix:
+        python-minor-version: ["8", "9", "10"]
     steps:
     - uses: actions/checkout@v3
       with:
@@ -53,12 +43,12 @@ jobs:
     - name: Set up Python
       uses: actions/setup-python@v4
       with:
-        python-version: "3.10"
+        python-version: 3.${{ matrix.python-minor-version }}
     - uses: ./.github/workflows/build_mac_wheel
       with:
-        python-minor-version: "10"
+        python-minor-version: ${{ matrix.python-minor-version }}
     - uses: ./.github/workflows/upload_wheel
       with:
-        python-minor-version: "10"
+        python-minor-version: ${{ matrix.python-minor-version }}
         token: ${{ secrets.PYPI_TOKEN }}
         repo: "pypi"

--- a/python/setup.py
+++ b/python/setup.py
@@ -46,7 +46,7 @@ extensions = [
         library_dirs=[lance_libs] + arrow_library_dirs,
         language="c++",
         extra_compile_args=["-Wall", "-std=c++20", "-O3"],
-        extra_link_args=["-Wl,-rpath", lance_libs] #, "-Wl,-rpath", arrow_library_dirs[0]],
+        extra_link_args=["-Wl,-rpath", lance_libs]  # , "-Wl,-rpath", arrow_library_dirs[0]],
     )
 ]
 
@@ -70,8 +70,8 @@ setup(
     long_description_content_type="text/markdown",
     ext_modules=cythonize(extensions, language_level="3"),
     zip_safe=False,
-    install_requires=["numpy", "pillow", "pyarrow>=9,<10", "requests"],
-    extras_require={"test": ["pytest>=6.0", "pandas", "duckdb", "click", "requests_mock"]},
+    install_requires=["numpy", "pillow", "pyarrow>=9,<10", "requests", "pandas"],
+    extras_require={"test": ["pytest>=6.0", "duckdb", "click", "requests_mock"]},
     python_requires=">=3.8",
     packages=find_packages(),
     classifiers=[


### PR DESCRIPTION
Once the release is published, automatically build wheels and upload to pypi and also increment version to the next patch.dev0 version.