### PR TITLE
Improve VarBinaryDecoder::Take performance by accumulating small batches

### DIFF
--- a/cpp/src/lance/encodings/binary.h
+++ b/cpp/src/lance/encodings/binary.h
@@ -132,7 +132,7 @@ template <ArrowType T>
   const int64_t kMinimalBatchBytes = 128 * 1024;  // 128K
 
   typename ::arrow::TypeTraits<T>::BuilderType builder;
-  builder.Reserve(indices->length());
+  ARROW_RETURN_NOT_OK(builder.Reserve(indices->length()));
 
   // Read positions in batch
   std::vector<int32_t> batch_offsets;

--- a/cpp/src/lance/encodings/binary.h
+++ b/cpp/src/lance/encodings/binary.h
@@ -142,7 +142,7 @@ template <ArrowType T>
     int position_idx = cur_offset - start;
     int pos = positions->Value(position_idx);
     if (!batch_offsets.empty()) {
-      if (pos - positions->Value(batch_offsets[0]) > kMinimalBatchBytes) {
+      if (pos - positions->Value(batch_offsets[0] - start) > kMinimalBatchBytes) {
         // Read the batch now.
         auto batch_start = batch_offsets[0];
         auto batch_length = batch_offsets.back() - batch_start + 1;
@@ -166,7 +166,7 @@ template <ArrowType T>
       builder.Append(binary_arr->Value(offset - batch_start));
     }
   }
-  
+
   return builder.Finish();
 }
 

--- a/cpp/src/lance/encodings/encoder.cc
+++ b/cpp/src/lance/encodings/encoder.cc
@@ -97,4 +97,8 @@ void Decoder::Reset(int64_t position, int32_t length) {
   return builder->Finish();
 }
 
+::arrow::Result<std::shared_ptr<::arrow::Array>> Decoder::MakeEmpty() const {
+  return ::arrow::MakeEmptyArray(type_, pool_);
+}
+
 }  // namespace lance::encodings

--- a/cpp/src/lance/encodings/encoder.cc
+++ b/cpp/src/lance/encodings/encoder.cc
@@ -87,7 +87,6 @@ void Decoder::Reset(int64_t position, int32_t length) {
 
 ::arrow::Result<std::shared_ptr<::arrow::Array>> Decoder::Take(
     std::shared_ptr<::arrow::Int32Array> indices) const {
-  fmt::print("Decoder::Take: {}\n", indices->ToString());
   ARROW_ASSIGN_OR_RAISE(auto builder, ::lance::arrow::GetArrayBuilder(type_, pool_));
   ARROW_RETURN_NOT_OK(builder->Reserve(indices->length()));
   // TODO: use arrow thread pool

--- a/cpp/src/lance/encodings/encoder.cc
+++ b/cpp/src/lance/encodings/encoder.cc
@@ -87,6 +87,7 @@ void Decoder::Reset(int64_t position, int32_t length) {
 
 ::arrow::Result<std::shared_ptr<::arrow::Array>> Decoder::Take(
     std::shared_ptr<::arrow::Int32Array> indices) const {
+  fmt::print("Decoder::Take: {}\n", indices->ToString());
   ARROW_ASSIGN_OR_RAISE(auto builder, ::lance::arrow::GetArrayBuilder(type_, pool_));
   ARROW_RETURN_NOT_OK(builder->Reserve(indices->length()));
   // TODO: use arrow thread pool

--- a/cpp/src/lance/encodings/encoder.h
+++ b/cpp/src/lance/encodings/encoder.h
@@ -116,6 +116,9 @@ class Decoder {
       std::shared_ptr<::arrow::Int32Array> indices) const;
 
  protected:
+  /// Make empty array.
+  virtual ::arrow::Result<std::shared_ptr<::arrow::Array>> MakeEmpty() const;
+
   std::shared_ptr<::arrow::io::RandomAccessFile> infile_;
   std::shared_ptr<::arrow::DataType> type_;
   int64_t position_ = -1;

--- a/cpp/src/lance/encodings/plain.cc
+++ b/cpp/src/lance/encodings/plain.cc
@@ -191,10 +191,6 @@ class PlainDecoderImpl : public Decoder {
     return std::min(length.value_or(length_), length_ - start);
   }
 
-  ::arrow::Result<std::shared_ptr<::arrow::Array>> MakeEmpty() const {
-    return ::arrow::MakeEmptyArray(type_, pool_);
-  }
-
  private:
   using ArrayType = typename ::arrow::TypeTraits<T>::ArrayType;
   using BuilderType = typename ::arrow::TypeTraits<T>::BuilderType;


### PR DESCRIPTION
Improve query `SELECT external_image FROM oxford_pet WHERE class = 'pug'` by 6X  (12s -> 2s) on home computer. 