### PR TITLE
Exclude jupyter notebook from github language stats

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+python/notebooks -linguist-detectable


### PR DESCRIPTION
I *think* this does what we want based on linguist docs:

https://github.com/github/linguist/blob/master/docs/overrides.md