### PR TITLE
[DUCKDB] Fix build on intel and apple silicon Mac

### DIFF
--- a/integration/duckdb/CMakeLists.txt
+++ b/integration/duckdb/CMakeLists.txt
@@ -7,8 +7,14 @@ endif()
 project(lance_duckdb CXX)
 
 option(LANCE_BUILD_PYTORCH "Build with PyTorch")
-if(UNIX AND NOT APPLE)
-  set(LANCE_BUILD_PYTORCH TRUE)
+# if(UNIX AND NOT APPLE)
+set(LANCE_BUILD_PYTORCH TRUE)
+# endif()
+
+set(OS_ARCH "amd64")
+string(REGEX MATCH "(arm64|aarch64)" IS_ARM "${CMAKE_SYSTEM_PROCESSOR}")
+if(IS_ARM)
+  set(OS_ARCH "arm64")
 endif()
 
 # Default to Debug build if not specified if (NOT DEFINED CMAKE_BUILD_TYPE OR
@@ -24,7 +30,7 @@ else()
   set(EXTENSION_STATIC_BUILD 1)
 endif()
 
-set(BUILD_UNITTESTS FALSE)  # For duckdb
+set(BUILD_UNITTESTS FALSE) # For duckdb
 FetchContent_Declare(
   DuckDB
   GIT_REPOSITORY https://github.com/duckdb/duckdb.git
@@ -34,29 +40,35 @@ list(APPEND available_contents duckdb)
 
 if(LANCE_BUILD_PYTORCH)
 
-  if(APPLE)
-    message(FATAL_ERROR "PyTorch integration is only supported on Linux now")
+  # if(APPLE) message(FATAL_ERROR "PyTorch integration is only supported on
+  # Linux now") endif()
+
+  if (OS_ARCH STREQUAL "amd64")
+    set(CPU_BASELINE AVX2)
   endif()
 
-  set(CPU_BASELINE AVX2)
   set(BUILD_LIST
       imgcodecs
       CACHE INTERNAL "Do not build static duckdb extension")
   set(BUILD_SHARED_LIBS OFF)
   FetchContent_Declare(
-    OpenCV URL https://github.com/opencv/opencv/archive/refs/tags/4.5.5.tar.gz
-               CMAKE_ARGS -DBUILD_UNITTESTS=imgcodecs)
+    OpenCV URL https://github.com/opencv/opencv/archive/refs/tags/4.5.5.tar.gz)
   list(APPEND available_contents OpenCV)
 
-  FetchContent_Declare(
-    Torch
-    URL https://download.pytorch.org/libtorch/cpu/libtorch-cxx11-abi-shared-with-deps-1.12.1%2Bcpu.zip
-  )
-  list(APPEND available_contents Torch)
+  if(APPLE)
+    FetchContent_Declare(
+            Torch
+            GIT_REPOSITORY https://github.com/pytorch/pytorch)
+  else()
+    FetchContent_Declare(
+      Torch
+      URL https://download.pytorch.org/libtorch/cpu/libtorch-cxx11-abi-shared-with-deps-1.12.1%2Bcpu.zip
+    )
+    list(APPEND available_contents Torch)
+  endif()
 endif()
 
 FetchContent_MakeAvailable(${available_contents})
-unset(BUILD_UNITTEST)
 
 set(CMAKE_CXX_STANDARD 20)
 set(CMAKE_CXX_STANDARD_REQUIRED True)
@@ -90,8 +102,7 @@ set(LANCE_EXT_SOURCES
     src/lance/duckdb/ml/pytorch.cc
     src/lance/duckdb/ml/pytorch.h
     src/lance/duckdb/ml/functions.cc
-    src/lance/duckdb/ml/functions.h
-    )
+    src/lance/duckdb/ml/functions.h)
 
 build_loadable_extension(lance ${LANCE_EXT_SOURCES})
 if(APPLE)

--- a/integration/duckdb/CMakeLists.txt
+++ b/integration/duckdb/CMakeLists.txt
@@ -40,7 +40,7 @@ list(APPEND available_contents duckdb)
 
 if(LANCE_BUILD_PYTORCH)
 
-  if (OS_ARCH STREQUAL "amd64")
+  if(OS_ARCH STREQUAL "amd64")
     set(CPU_BASELINE AVX2)
   endif()
 
@@ -48,21 +48,28 @@ if(LANCE_BUILD_PYTORCH)
       imgcodecs
       CACHE INTERNAL "Do not build static duckdb extension")
   set(BUILD_SHARED_LIBS OFF)
+  set(BUILD_ZLIB OFF)
   FetchContent_Declare(
     OpenCV URL https://github.com/opencv/opencv/archive/refs/tags/4.5.5.tar.gz)
   list(APPEND available_contents OpenCV)
 
   if(APPLE)
-    if (OS_ARCH STREQUAL "amd64")
+    if(OS_ARCH STREQUAL "amd64")
       FetchContent_Declare(
         Torch
-        URL https://download.pytorch.org/libtorch/cpu/libtorch-macos-1.12.1.zip
-      )
+        URL https://download.pytorch.org/libtorch/cpu/libtorch-macos-1.12.1.zip)
       list(APPEND available_contents Torch)
     else()
-      FetchContent_Declare(
-            Torch
-            GIT_REPOSITORY https://github.com/pytorch/pytorch)
+      # libtorch does not have apple silicon release yet. Temporary solution.
+      file(
+        DOWNLOAD
+        https://files.pythonhosted.org/packages/5a/e8/82c14c28360dafe02877b28c70218c8b6ca8a0f2fbb0515b2abd027ca251/torch-1.12.0-cp310-none-macosx_11_0_arm64.whl
+        ${CMAKE_BINARY_DIR}/torch.zip)
+      file(ARCHIVE_EXTRACT INPUT torch.zip DESTINATION
+           ${CMAKE_BINARY_DIR}/thirdparty)
+      file(REMOVE ${CMAKE_BINARY_DIR}/torch.zip)
+
+      set(Torch_DIR "${CMAKE_BINARY_DIR}/thirdparty/torch/share/cmake/Torch")
     endif()
   else()
     FetchContent_Declare(
@@ -81,7 +88,7 @@ set(CMAKE_CXX_STANDARD_REQUIRED True)
 include_directories(${duckdb_SOURCE_DIR}/src/include)
 
 if(LANCE_BUILD_PYTORCH)
-  set(Torch_DIR "${torch_SOURCE_DIR}/share/cmake/Torch")
+  # set(Torch_DIR "${torch_SOURCE_DIR}/share/cmake/Torch")
   set(OpenCV_DIR ${CMAKE_CURRENT_BINARY_DIR})
   include_directories(${OpenCV_INCLUDE_DIRS})
 
@@ -90,8 +97,7 @@ if(LANCE_BUILD_PYTORCH)
     ${OpenCV_SOURCE_DIR}/modules/imgcodecs/include
     ${OpenCV_SOURCE_DIR}/modules/imgproc/include ${CMAKE_CURRENT_BINARY_DIR})
 
-  # TODO: it is CPU version for now.
-  find_package(Torch REQUIRED)
+  find_package(torch REQUIRED)
   include_directories(${OpenCV_INCLUDE_DIRS})
 endif()
 

--- a/integration/duckdb/CMakeLists.txt
+++ b/integration/duckdb/CMakeLists.txt
@@ -24,6 +24,7 @@ else()
   set(EXTENSION_STATIC_BUILD 1)
 endif()
 
+set(BUILD_UNITTESTS FALSE)  # For duckdb
 FetchContent_Declare(
   DuckDB
   GIT_REPOSITORY https://github.com/duckdb/duckdb.git
@@ -55,6 +56,7 @@ if(LANCE_BUILD_PYTORCH)
 endif()
 
 FetchContent_MakeAvailable(${available_contents})
+unset(BUILD_UNITTEST)
 
 set(CMAKE_CXX_STANDARD 20)
 set(CMAKE_CXX_STANDARD_REQUIRED True)
@@ -91,7 +93,6 @@ set(LANCE_EXT_SOURCES
     src/lance/duckdb/ml/functions.h
     )
 
-set(EXTENSION_STATIC_BUILD 1)
 build_loadable_extension(lance ${LANCE_EXT_SOURCES})
 if(APPLE)
   target_link_libraries(lance_loadable_extension duckdb)

--- a/integration/duckdb/CMakeLists.txt
+++ b/integration/duckdb/CMakeLists.txt
@@ -59,11 +59,11 @@ if(LANCE_BUILD_PYTORCH)
         DOWNLOAD
         https://files.pythonhosted.org/packages/5a/e8/82c14c28360dafe02877b28c70218c8b6ca8a0f2fbb0515b2abd027ca251/torch-1.12.0-cp310-none-macosx_11_0_arm64.whl
         ${CMAKE_BINARY_DIR}/torch.zip)
-      file(ARCHIVE_EXTRACT INPUT torch.zip DESTINATION
+      file(ARCHIVE_EXTRACT INPUT ${CMAKE_BINARY_DIR}/torch.zip DESTINATION
            ${CMAKE_BINARY_DIR}/thirdparty)
       file(REMOVE ${CMAKE_BINARY_DIR}/torch.zip)
 
-      set(Torch_DIR "${CMAKE_BINARY_DIR}/thirdparty/torch/share/cmake/Torch")
+      set(torch_SOURCE_DIR ${CMAKE_BINARY_DIR}/thirdparty/torch/)
     endif()
   else()
     FetchContent_Declare(
@@ -82,9 +82,7 @@ set(CMAKE_CXX_STANDARD_REQUIRED True)
 include_directories(${duckdb_SOURCE_DIR}/src/include)
 
 if(LANCE_BUILD_PYTORCH)
-  if("${Torch_DIR}" STREQUAL "")
-    set(Torch_DIR "${torch_SOURCE_DIR}/share/cmake/Torch")
-  endif()
+  set(Torch_DIR "${torch_SOURCE_DIR}/share/cmake/Torch")
 
   set(OpenCV_DIR ${CMAKE_CURRENT_BINARY_DIR})
   include_directories(${OpenCV_INCLUDE_DIRS})

--- a/integration/duckdb/CMakeLists.txt
+++ b/integration/duckdb/CMakeLists.txt
@@ -6,19 +6,13 @@ endif()
 
 project(lance_duckdb CXX)
 
-option(LANCE_BUILD_PYTORCH "Build with PyTorch")
-# if(UNIX AND NOT APPLE)
-set(LANCE_BUILD_PYTORCH TRUE)
-# endif()
+option(LANCE_BUILD_PYTORCH "Build with PyTorch" TRUE)
 
 set(OS_ARCH "amd64")
 string(REGEX MATCH "(arm64|aarch64)" IS_ARM "${CMAKE_SYSTEM_PROCESSOR}")
 if(IS_ARM)
   set(OS_ARCH "arm64")
 endif()
-
-# Default to Debug build if not specified if (NOT DEFINED CMAKE_BUILD_TYPE OR
-# CMAKE_BUILD_TYPE STREQUAL "") set(CMAKE_BUILD_TYPE Debug) endif ()
 
 include(FetchContent)
 
@@ -34,8 +28,7 @@ set(BUILD_UNITTESTS FALSE) # For duckdb
 FetchContent_Declare(
   DuckDB
   GIT_REPOSITORY https://github.com/duckdb/duckdb.git
-  GIT_TAG v0.5.1
-  CMAKE_ARGS -DBUILD_UNITTESTS=FALSE)
+  GIT_TAG v0.5.1)
 list(APPEND available_contents duckdb)
 
 if(LANCE_BUILD_PYTORCH)
@@ -60,6 +53,7 @@ if(LANCE_BUILD_PYTORCH)
         URL https://download.pytorch.org/libtorch/cpu/libtorch-macos-1.12.1.zip)
       list(APPEND available_contents Torch)
     else()
+      # Apple Silicon
       # libtorch does not have apple silicon release yet. Temporary solution.
       file(
         DOWNLOAD
@@ -88,7 +82,10 @@ set(CMAKE_CXX_STANDARD_REQUIRED True)
 include_directories(${duckdb_SOURCE_DIR}/src/include)
 
 if(LANCE_BUILD_PYTORCH)
-  # set(Torch_DIR "${torch_SOURCE_DIR}/share/cmake/Torch")
+  if("${Torch_DIR}" STREQUAL "")
+    set(Torch_DIR "${torch_SOURCE_DIR}/share/cmake/Torch")
+  endif()
+
   set(OpenCV_DIR ${CMAKE_CURRENT_BINARY_DIR})
   include_directories(${OpenCV_INCLUDE_DIRS})
 
@@ -97,7 +94,7 @@ if(LANCE_BUILD_PYTORCH)
     ${OpenCV_SOURCE_DIR}/modules/imgcodecs/include
     ${OpenCV_SOURCE_DIR}/modules/imgproc/include ${CMAKE_CURRENT_BINARY_DIR})
 
-  find_package(torch REQUIRED)
+  find_package(Torch REQUIRED)
   include_directories(${OpenCV_INCLUDE_DIRS})
 endif()
 

--- a/integration/duckdb/CMakeLists.txt
+++ b/integration/duckdb/CMakeLists.txt
@@ -40,9 +40,6 @@ list(APPEND available_contents duckdb)
 
 if(LANCE_BUILD_PYTORCH)
 
-  # if(APPLE) message(FATAL_ERROR "PyTorch integration is only supported on
-  # Linux now") endif()
-
   if (OS_ARCH STREQUAL "amd64")
     set(CPU_BASELINE AVX2)
   endif()
@@ -56,9 +53,17 @@ if(LANCE_BUILD_PYTORCH)
   list(APPEND available_contents OpenCV)
 
   if(APPLE)
-    FetchContent_Declare(
+    if (OS_ARCH STREQUAL "amd64")
+      FetchContent_Declare(
+        Torch
+        URL https://download.pytorch.org/libtorch/cpu/libtorch-macos-1.12.1.zip
+      )
+      list(APPEND available_contents Torch)
+    else()
+      FetchContent_Declare(
             Torch
             GIT_REPOSITORY https://github.com/pytorch/pytorch)
+    endif()
   else()
     FetchContent_Declare(
       Torch

--- a/integration/duckdb/README.md
+++ b/integration/duckdb/README.md
@@ -1,6 +1,6 @@
 # Lance DuckDB Extension
 
-*Linux Only for now*.
+*Linux and macOS only for now*.
 
 Lance DuckDB extension allows user to run Machine Learning tasks via DuckDB + Lance.
 
@@ -36,8 +36,6 @@ Vector functions
 
 
 ## Development
-
-Currently, Machine Learning functions only works on Linux.
 
 To build the extension, run:
 

--- a/integration/duckdb/src/lance/duckdb/list_functions.cc
+++ b/integration/duckdb/src/lance/duckdb/list_functions.cc
@@ -31,8 +31,8 @@ void ListArgMax(::duckdb::DataChunk &args,
     auto max_iter = std::max_element(std::begin(values), std::end(values), [](auto a, auto b) {
       return a.template GetValue<T>() < b.template GetValue<T>();
     });
-    auto idx_max = std::distance(std::begin(values), max_iter);
-    result.SetValue(i, idx_max);
+    auto idx_max = static_cast<int>(std::distance(std::begin(values), max_iter));
+    result.SetValue(i, ::duckdb::Value(idx_max));
   }
 }
 

--- a/integration/duckdb/src/lance/duckdb/ml/pytorch.cc
+++ b/integration/duckdb/src/lance/duckdb/ml/pytorch.cc
@@ -50,7 +50,7 @@ std::string ShapeString(const torch::Tensor& tensor) {
 /// Convert OpenCV image to PyTorch Tensor
 torch::Tensor ToTensor(const cv::Mat& image) {
   at::TensorOptions options(at::kFloat);
-  auto tensor = torch::from_blob(image.data, at::IntList({1, image.rows, image.cols, 3}), options);
+  auto tensor = torch::from_blob(image.data, {1, image.rows, image.cols, 3}, options);
   return tensor.permute({0, 3, 1, 2});
 }
 
@@ -97,7 +97,7 @@ void PyTorchModelEntry::Execute(::duckdb::DataChunk& args,
     std::vector<::duckdb::Value> values;
     auto softmax = output[0].softmax(0);
     for (int i = 0; i < softmax.size(0); i++) {
-      values.emplace_back(::duckdb::Value::FLOAT(*softmax[i].data<float>()));
+      values.emplace_back(::duckdb::Value::FLOAT(*softmax[i].data_ptr<float>()));
     }
     result.SetValue(i, ::duckdb::Value::LIST(values));
   }


### PR DESCRIPTION
Be able to build duckdb extension with opencv + pytorch on Intel and Apple Silicon Mac. 

Closes #246 