### PR TITLE
Fix read boolean and PyTorch does not return empty array.

### DIFF
--- a/cpp/src/lance/encodings/plain.cc
+++ b/cpp/src/lance/encodings/plain.cc
@@ -224,9 +224,13 @@ class BooleanPlainDecoderImpl : public PlainDecoderImpl<::arrow::BooleanType> {
       return MakeEmpty();
     }
 
-    int64_t byte_length = ::arrow::bit_util::BytesForBits(len);
+    // The length after calculating byte alignment of the start.
+    int32_t storage_length = start % 8 + len;
+    int64_t byte_length = ::arrow::bit_util::BytesForBits(storage_length);
+
     ARROW_ASSIGN_OR_RAISE(auto buf, infile_->ReadAt(position_ + start / 8, byte_length));
-    return std::make_shared<::arrow::BooleanArray>(len, buf);
+    auto storage_arr = std::make_shared<::arrow::BooleanArray>(storage_length, buf);
+    return storage_arr->Slice(start % 8, len);
   }
 };
 

--- a/python/lance/pytorch/data.py
+++ b/python/lance/pytorch/data.py
@@ -168,6 +168,8 @@ class LanceDataset(IterableDataset):
             )
             for batch in scan.to_reader():
                 if self.mode == "batch":
+                    if batch.num_rows == 0:
+                        continue
                     tensors = [to_tensor(arr) for arr in batch.columns]
                     if self.transform is not None:
                         tensors = self.transform(*tensors)

--- a/python/lance/tests/test_pytorch.py
+++ b/python/lance/tests/test_pytorch.py
@@ -91,6 +91,7 @@ def test_data_loader_with_filter(tmp_path: Path):
         assert (value - 10) % 2 == 0
         assert torch.is_tensor(value)
 
+
 def test_data_loader_projection(tmp_path: Path):
     ids = pa.array(range(10))
     values = pa.array([f"num-{i}" for i in ids])
@@ -101,3 +102,15 @@ def test_data_loader_projection(tmp_path: Path):
     for elem, expected_id in zip(dataset, range(5, 10)):
         assert elem == f"num-{expected_id}"
 
+
+def test_filter_resulted_empty_return(tmp_path: Path):
+    ids = pa.array(range(10))
+    values = pa.array([i.as_py() > 5 for i in ids])
+    table = pa.Table.from_arrays([ids, values], names=["id", "bignum"])
+    lance.write_table(table, tmp_path / "lance")
+    print(table)
+
+    dataset = LanceDataset(tmp_path / "lance", columns=["id"], filter=pc.field("bignum") == True, mode="batch",
+                           batch_size=2)
+    actual_ids = list(dataset)
+    print(actual_ids)

--- a/python/lance/tests/test_pytorch.py
+++ b/python/lance/tests/test_pytorch.py
@@ -108,9 +108,8 @@ def test_filter_resulted_empty_return(tmp_path: Path):
     values = pa.array([i.as_py() > 5 for i in ids])
     table = pa.Table.from_arrays([ids, values], names=["id", "bignum"])
     lance.write_table(table, tmp_path / "lance")
-    print(table)
 
     dataset = LanceDataset(tmp_path / "lance", columns=["id"], filter=pc.field("bignum") == True, mode="batch",
                            batch_size=2)
-    actual_ids = list(dataset)
-    print(actual_ids)
+    actual_ids = torch.stack(list(dataset))
+    assert torch.equal(actual_ids, torch.stack([torch.tensor([6, 7]), torch.tensor([8, 9])]))


### PR DESCRIPTION
Closes #240.
Also in the process, fixes a bug that read boolean values from the middle of a byte