### PR TITLE
[CI] pin arrow 9.0 in GHA

### DIFF
--- a/.github/workflows/cpp.yml
+++ b/.github/workflows/cpp.yml
@@ -24,7 +24,7 @@ jobs:
           wget https://apache.jfrog.io/artifactory/arrow/$(lsb_release --id --short | tr 'A-Z' 'a-z')/apache-arrow-apt-source-latest-$(lsb_release --codename --short).deb
           sudo apt install -y -V ./apache-arrow-apt-source-latest-$(lsb_release --codename --short).deb
           sudo apt update
-          sudo apt install -y -V libarrow-dev libarrow-dataset-dev libparquet-dev
+          sudo apt install -y -V libarrow-dev=9.0.0-1 libarrow-dataset-dev=9.0.0-1 libparquet-dev=9.0.0-1
       - name: Cmake
         run: cmake -B build
       - name: Build

--- a/.github/workflows/cpp.yml
+++ b/.github/workflows/cpp.yml
@@ -8,6 +8,8 @@ jobs:
   build:
     runs-on: ubuntu-22.04
     timeout-minutes: 30
+    env:
+      ArrowVersion: 9.0.0-1
     defaults:
       run:
         working-directory: ./cpp
@@ -24,7 +26,7 @@ jobs:
           wget https://apache.jfrog.io/artifactory/arrow/$(lsb_release --id --short | tr 'A-Z' 'a-z')/apache-arrow-apt-source-latest-$(lsb_release --codename --short).deb
           sudo apt install -y -V ./apache-arrow-apt-source-latest-$(lsb_release --codename --short).deb
           sudo apt update
-          sudo apt install -y -V libarrow-dev=9.0.0-1 libarrow-dataset-dev=9.0.0-1 libparquet-dev=9.0.0-1
+          sudo apt install -y -V libarrow-dev=${ArrowVersion} libarrow-dataset-dev=${ArrowVersion} libparquet-dev=${ArrowVersion}
       - name: Cmake
         run: cmake -B build
       - name: Build
@@ -42,7 +44,7 @@ jobs:
       - name: Install dependencies
         run: |
           cd $(brew --repository)
-          git checkout cf629b1175f  # Arrow 9.0
+          git checkout 3.6.6  # Arrow 9.0
           brew install apache-arrow protobuf
       - name: Cmake
         run: cmake -B build

--- a/.github/workflows/cpp.yml
+++ b/.github/workflows/cpp.yml
@@ -42,7 +42,7 @@ jobs:
       - name: Install dependencies
         run: |
           brew update
-          brew install apache-arrow protobuf
+          brew install https://raw.githubusercontent.com/Homebrew/homebrew-core/f71673034b2618ed7b557ecaa3d47d87719b3df7/Formula/apache-arrow.rb protobuf
       - name: Cmake
         run: cmake -B build
       - name: Build

--- a/.github/workflows/cpp.yml
+++ b/.github/workflows/cpp.yml
@@ -42,7 +42,7 @@ jobs:
       - name: Install dependencies
         run: |
           cd $(brew --repository)
-          git checkout 560f5717a  # Arrow 9.0
+          git checkout cf629b1175f  # Arrow 9.0
           brew install apache-arrow protobuf
       - name: Cmake
         run: cmake -B build

--- a/.github/workflows/cpp.yml
+++ b/.github/workflows/cpp.yml
@@ -41,8 +41,9 @@ jobs:
       - uses: actions/checkout@v2
       - name: Install dependencies
         run: |
-          brew update
-          brew install https://raw.githubusercontent.com/Homebrew/homebrew-core/f71673034b2618ed7b557ecaa3d47d87719b3df7/Formula/apache-arrow.rb protobuf
+          cd $(brew --repository)
+          git checkout 560f5717a  # Arrow 9.0
+          brew install apache-arrow protobuf
       - name: Cmake
         run: cmake -B build
       - name: Build


### PR DESCRIPTION
Pin Apache Arrow to 9.x to fix CI breakage. 