### PR TITLE
Modify notebook to download from S3 instead of build from source

### DIFF
--- a/python/notebooks/peeking_duck.ipynb
+++ b/python/notebooks/peeking_duck.ipynb
@@ -32,14 +32,10 @@
    "id": "7e0088ac",
    "metadata": {},
    "source": [
-    "This is made possible using DuckDB in conjunction with Lance, <br>\n",
-    "a new columnar data format for computer vision (CV). <br>\n",
-    "Lance is like Parquet but built with CV in mind, <br>\n",
-    "with fast point-access, partial reads and optimisations for nested annotation columns. \n",
+    "This is made possible using DuckDB in conjunction with Lance, a new columnar data format for computer vision (CV).<br>\n",
+    "Lance is like Parquet but built with CV in mind, with fast point-access, partial reads and optimisations for nested annotation columns. \n",
     "\n",
-    "tl;dr - Lance is a more performant and CV-specific parquet.\n",
-    "\n",
-    "Lance can be accessed by tools like Pandas and DuckDB via Apache Arrow. Let's see it in action."
+    "tl;dr - Lance is a more performant and CV-specific parquet and is accessible from DuckDB and pandas."
    ]
   },
   {
@@ -50,6 +46,29 @@
     "For reference:\n",
     "1. The Lance file format lives [here](https://github.com/eto-ai/lance)\n",
     "2. The Lance duckdb extension is under the [/integrations/duckdb](https://github.com/eto-ai/lance/tree/main/integration/duckdb) subdirectory in Lance"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "025bd345",
+   "metadata": {},
+   "source": [
+    "## Pre-requisites"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "5ebe562a",
+   "metadata": {},
+   "source": [
+    "Setup a virtual environment in python and start a jupyter notebook server\n",
+    "\n",
+    "```bash\n",
+    "python3 -m venv ~/.venv/lance\n",
+    "source ~/.venv/lance/bin/activate\n",
+    "pip install pylance duckdb jupyter torch torchvision\n",
+    "```\n",
+    "Then start a notebook server and run through this notebook"
    ]
   },
   {
@@ -73,7 +92,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 13,
+   "execution_count": 1,
    "id": "065e6cd3",
    "metadata": {},
    "outputs": [],
@@ -91,16 +110,76 @@
    "id": "bf16a2c4",
    "metadata": {},
    "source": [
-    "### Setup the duckdb extension\n",
+    "### Setup the duckdb extension"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "8535430a",
+   "metadata": {},
+   "source": [
+    "While we wait for duckdb extension registration mechanism,\n",
+    "you can grab pre-built extensions by executing the cell below"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "id": "da267a37",
+   "metadata": {
+    "scrolled": true
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current\n",
+      "                                 Dload  Upload   Total   Spent    Left  Speed\n",
+      "100 2281k  100 2281k    0     0   874k      0  0:00:02  0:00:02 --:--:--  875k\n",
+      "Archive:  lance.duckdb_extension.zip\n",
+      "  inflating: lance.duckdb_extension  \n"
+     ]
+    }
+   ],
+   "source": [
+    "import platform\n",
     "\n",
-    "For now, the extension should be [built from source](https://github.com/eto-ai/lance/tree/main/integration/duckdb#development).\n",
+    "def extension_uri():\n",
+    "    version = '0.0.1'\n",
+    "    uname = platform.uname()\n",
+    "    arch = uname.machine  # arm64, x86_64\n",
+    "    system = uname.system.lower()\n",
+    "    system = {'darwin': 'macosx'}.get(system, system)\n",
+    "    uri_root = 'https://eto-public.s3.us-west-2.amazonaws.com/repo/lance_duckdb'\n",
+    "    uri = f'{uri_root}/{version}/lance.duckdb_extension.{system}.{arch}.zip'\n",
+    "    return uri\n",
     "\n",
+    "\n",
+    "!curl {extension_uri()} --output lance.duckdb_extension.zip\n",
+    "!unzip -o lance.duckdb_extension.zip\n",
+    "!rm lance.duckdb_extension.zip"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "8b4c9849",
+   "metadata": {},
+   "source": [
+    "If you'd like the extension can be [built from source](https://github.com/eto-ai/lance/tree/main/integration/duckdb#development) as well."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "2cc52b6a",
+   "metadata": {},
+   "source": [
     "Once that's done, we can install and load the extensio. In this example we copied the artifact `lance.duckdb_extension` into the same directory as this notebook. Instead, you can also just supply it with a relative path in the `install_extension` call below."
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 9,
+   "execution_count": 3,
    "id": "f4a554ea",
    "metadata": {},
    "outputs": [],
@@ -126,7 +205,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 2,
+   "execution_count": 4,
    "id": "6a293bf7",
    "metadata": {},
    "outputs": [
@@ -172,7 +251,7 @@
        "0  resnet  /tmp/model.pth  torchscript"
       ]
      },
-     "execution_count": 2,
+     "execution_count": 4,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -220,7 +299,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 3,
+   "execution_count": 5,
    "id": "a19d5e1a",
    "metadata": {},
    "outputs": [
@@ -260,7 +339,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 4,
+   "execution_count": 6,
    "id": "06cc3e6c",
    "metadata": {},
    "outputs": [
@@ -273,7 +352,7 @@
        "Image(s3://eto-public/datasets/oxford_pet/images/samoyed_100.jpg)"
       ]
      },
-     "execution_count": 4,
+     "execution_count": 6,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -302,7 +381,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 8,
+   "execution_count": 7,
    "id": "367856f7",
    "metadata": {},
    "outputs": [
@@ -400,7 +479,7 @@
        "9  samoyed   258"
       ]
      },
-     "execution_count": 8,
+     "execution_count": 7,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -436,7 +515,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 11,
+   "execution_count": 8,
    "id": "f4bcb24d",
    "metadata": {},
    "outputs": [],
@@ -453,7 +532,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 12,
+   "execution_count": 9,
    "id": "2f150c09",
    "metadata": {},
    "outputs": [
@@ -551,7 +630,7 @@
        "9  samoyed    Samoyed"
       ]
      },
-     "execution_count": 12,
+     "execution_count": 9,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -589,7 +668,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "55ff5597",
+   "id": "cfbbe82f",
    "metadata": {},
    "outputs": [],
    "source": []
@@ -611,7 +690,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.10.4"
+   "version": "3.10.8"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
Added this section so users don't need to build the extension from source:

```python
import platform

def extension_uri():
    version = '0.0.1'
    uname = platform.uname()
    arch = uname.machine  # arm64, x86_64
    system = uname.system.lower()
    system = {'darwin': 'macosx'}.get(system, system)
    uri_root = 'https://eto-public.s3.us-west-2.amazonaws.com/repo/lance_duckdb'
    uri = f'{uri_root}/{version}/lance.duckdb_extension.{system}.{arch}.zip'
    return uri


!curl {extension_uri()} --output lance.duckdb_extension.zip
!unzip -o lance.duckdb_extension.zip
!rm lance.duckdb_extension.zip
```

I uploaded arm and linux zips:

```bash
lance on  changhiskhan/armed-duck [$?] via lance took 3.9s
➜ aws s3 ls s3://eto-public/repo/lance_duckdb/0.0.1/
2022-10-21 00:57:17   31464632 lance.duckdb_extension
2022-10-26 15:59:01   12303221 lance.duckdb_extension.linux.x86_64.zip
2022-10-26 15:23:25    2335989 lance.duckdb_extension.macosx.arm64.zip
```

@eddyxu can you help with 2 things when you get a chance?

1. test whether the arm64 extension i built locally actually works for you
2. build/upload the intel mac zip using the convention shown above ^ 