### PR TITLE
Enable duckdb extension to build/run on CUDA-enabled pytorch

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -65,6 +65,7 @@ docs/notebooks
 
 
 integration/duckdb/manylinux-build
+integration/duckdb/cuda-build
 python/notebooks/lance.duckdb_extension
 
 wheelhouse

--- a/integration/duckdb/CMakeLists.txt
+++ b/integration/duckdb/CMakeLists.txt
@@ -105,26 +105,28 @@ if(LANCE_BUILD_PYTORCH)
 endif()
 
 include_directories(src)
+
+set(LANCE_EXT_SOURCE_COMMON
+    src/lance/duckdb/lance-extension.cc
+    src/lance/duckdb/list_functions.cc
+    src/lance/duckdb/list_functions.h
+    src/lance/duckdb/vector_functions.cc
+    src/lance/duckdb/vector_functions.h)
+
+set(LANCE_EXT_SOURCE_ML
+    src/lance/duckdb/ml/catalog.cc
+    src/lance/duckdb/ml/catalog.h
+    src/lance/duckdb/ml/pytorch.cc
+    src/lance/duckdb/ml/pytorch.h
+    src/lance/duckdb/ml/functions.cc
+    src/lance/duckdb/ml/functions.h)
+
 if(LANCE_BUILD_PYTORCH)
   set(LANCE_EXT_SOURCES
-      src/lance/duckdb/lance-extension.cc
-      src/lance/duckdb/list_functions.cc
-      src/lance/duckdb/list_functions.h
-      src/lance/duckdb/vector_functions.cc
-      src/lance/duckdb/vector_functions.h
-      src/lance/duckdb/ml/catalog.cc
-      src/lance/duckdb/ml/catalog.h
-      src/lance/duckdb/ml/pytorch.cc
-      src/lance/duckdb/ml/pytorch.h
-      src/lance/duckdb/ml/functions.cc
-      src/lance/duckdb/ml/functions.h)
+      ${LANCE_EXT_SOURCE_COMMON}
+      ${LANCE_EXT_SOURCE_ML})
 else()
-  set(LANCE_EXT_SOURCES
-      src/lance/duckdb/lance-extension.cc
-      src/lance/duckdb/list_functions.cc
-      src/lance/duckdb/list_functions.h
-      src/lance/duckdb/vector_functions.cc
-      src/lance/duckdb/vector_functions.h)
+  set(LANCE_EXT_SOURCES ${LANCE_EXT_SOURCE_COMMON})
 endif()
 
 build_loadable_extension(lance ${LANCE_EXT_SOURCES})

--- a/integration/duckdb/CMakeLists.txt
+++ b/integration/duckdb/CMakeLists.txt
@@ -5,7 +5,6 @@ if(POLICY CMP0135)
 endif()
 
 project(lance_duckdb CXX)
-
 option(LANCE_BUILD_PYTORCH "Build with PyTorch" TRUE)
 
 set(OS_ARCH "amd64")
@@ -66,17 +65,26 @@ if(LANCE_BUILD_PYTORCH)
       set(torch_SOURCE_DIR ${CMAKE_BINARY_DIR}/thirdparty/torch/)
     endif()
   else()
-    FetchContent_Declare(
-      Torch
-      URL https://download.pytorch.org/libtorch/cpu/libtorch-cxx11-abi-shared-with-deps-1.12.1%2Bcpu.zip
-    )
+    if(LANCE_BUILD_CUDA)
+      FetchContent_Declare(
+        Torch
+        URL https://download.pytorch.org/libtorch/cu117/libtorch-cxx11-abi-shared-with-deps-1.13.0%2Bcu117.zip
+      )
+      enable_language(CUDA)
+      find_package(CUDAToolkit)
+    else()
+      FetchContent_Declare(
+        Torch
+        URL https://download.pytorch.org/libtorch/cpu/libtorch-cxx11-abi-shared-with-deps-1.13.0%2Bcpu.zip
+      )
+    endif()
     list(APPEND available_contents Torch)
   endif()
 endif()
 
 FetchContent_MakeAvailable(${available_contents})
 
-set(CMAKE_CXX_STANDARD 20)
+set(CMAKE_CXX_STANDARD 17)
 set(CMAKE_CXX_STANDARD_REQUIRED True)
 
 include_directories(${duckdb_SOURCE_DIR}/src/include)
@@ -97,18 +105,27 @@ if(LANCE_BUILD_PYTORCH)
 endif()
 
 include_directories(src)
-set(LANCE_EXT_SOURCES
-    src/lance/duckdb/lance-extension.cc
-    src/lance/duckdb/list_functions.cc
-    src/lance/duckdb/list_functions.h
-    src/lance/duckdb/vector_functions.cc
-    src/lance/duckdb/vector_functions.h
-    src/lance/duckdb/ml/catalog.cc
-    src/lance/duckdb/ml/catalog.h
-    src/lance/duckdb/ml/pytorch.cc
-    src/lance/duckdb/ml/pytorch.h
-    src/lance/duckdb/ml/functions.cc
-    src/lance/duckdb/ml/functions.h)
+if(LANCE_BUILD_PYTORCH)
+  set(LANCE_EXT_SOURCES
+      src/lance/duckdb/lance-extension.cc
+      src/lance/duckdb/list_functions.cc
+      src/lance/duckdb/list_functions.h
+      src/lance/duckdb/vector_functions.cc
+      src/lance/duckdb/vector_functions.h
+      src/lance/duckdb/ml/catalog.cc
+      src/lance/duckdb/ml/catalog.h
+      src/lance/duckdb/ml/pytorch.cc
+      src/lance/duckdb/ml/pytorch.h
+      src/lance/duckdb/ml/functions.cc
+      src/lance/duckdb/ml/functions.h)
+else()
+  set(LANCE_EXT_SOURCES
+      src/lance/duckdb/lance-extension.cc
+      src/lance/duckdb/list_functions.cc
+      src/lance/duckdb/list_functions.h
+      src/lance/duckdb/vector_functions.cc
+      src/lance/duckdb/vector_functions.h)
+endif()
 
 build_loadable_extension(lance ${LANCE_EXT_SOURCES})
 if(APPLE)
@@ -118,4 +135,8 @@ endif()
 if(LANCE_BUILD_PYTORCH)
   target_link_libraries(lance_loadable_extension "${TORCH_LIBRARIES}"
                         opencv_imgcodecs)
+  if(LANCE_BUILD_CUDA)
+    set_target_properties(lance_loadable_extension PROPERTIES CUDA_ARCHITECTURES native)
+  endif()
 endif()
+

--- a/integration/duckdb/Makefile
+++ b/integration/duckdb/Makefile
@@ -3,3 +3,6 @@
 release-linux:
 	docker run --rm -v ${CURDIR}:/code -w /code quay.io/pypa/manylinux2014_x86_64 \
 		/bin/bash -c "cmake -B manylinux-build && cd manylinux-build && make -j $(JOBS)"
+
+release-cuda:
+	cd cuda && docker compose run cuda /code/cuda/build_lance.sh && cd ..

--- a/integration/duckdb/README.md
+++ b/integration/duckdb/README.md
@@ -1,6 +1,6 @@
 # Lance DuckDB Extension
 
-*Linux and macOS only for now*.
+*Linux and Mac only for now*. Windows support forthcoming
 
 Lance DuckDB extension allows user to run Machine Learning tasks via DuckDB + Lance.
 
@@ -20,8 +20,10 @@ Machine Learning functions
 | `predict(model, blob)`            | Run model inference over image |
 | `ml_models()`                     | Show all ML models             |
 
+Currently the Lance duckdb extension is compiled against pytorch 1.13
+
 ```sql
-CALL create_pytorch_model('resnet', './resnet.pth')
+CALL create_pytorch_model('resnet', './resnet.pth', 'cpu')
 SELECT * FROM ml_models();
 // Run inference
 SELECT predict('resnet', image) as pred FROM images
@@ -43,9 +45,17 @@ To build the extension, run:
 make release-linux
 ```
 
+If you want to use GPU-enabled models, run:
+
+```shell
+make release-cuda
+```
+
+
 Load extension in Python
+
 ```python
 import duckdb
-duckdb.install_extension("./path/to/lance.duckdb_extension")
+duckdb.install_extension("./path/to/lance.duckdb_extension", force_install=True)
 duckdb.load_extension("lance")
 ```

--- a/integration/duckdb/cuda/Dockerfile
+++ b/integration/duckdb/cuda/Dockerfile
@@ -1,0 +1,11 @@
+FROM pytorch/manylinux-cuda117 AS builder
+
+RUN rm -f /usr/local/cuda && ln -s /usr/local/cuda-11.7 /usr/local/cuda
+
+# Upgrade cmake
+RUN cd /tmp && \
+    wget https://github.com/Kitware/CMake/releases/download/v3.24.2/cmake-3.24.2-linux-x86_64.sh && \
+    mkdir -p /usr/local/cmake && \
+    sh cmake-3.24.2-linux-x86_64.sh --skip-license --prefix=/usr/local/cmake
+
+RUN yum install -y devtoolset-11-gcc-c++

--- a/integration/duckdb/cuda/README.md
+++ b/integration/duckdb/cuda/README.md
@@ -1,0 +1,2 @@
+# Build duckdb with pytorch cuda
+

--- a/integration/duckdb/cuda/build_lance.sh
+++ b/integration/duckdb/cuda/build_lance.sh
@@ -5,6 +5,5 @@ export PATH=/usr/local/cmake/bin:/opt/rh/devtoolset-11/root/usr/bin:/opt/python/
 gcc --version
 
 pushd /code
-rm -rf /code/cuda-build
 cmake -B cuda-build -DLANCE_BUILD_CUDA=TRUE
 make -C cuda-build -j

--- a/integration/duckdb/cuda/build_lance.sh
+++ b/integration/duckdb/cuda/build_lance.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+
+export LD_LIBRARY_PATH=/usr/local/lib
+export PATH=/usr/local/cmake/bin:/opt/rh/devtoolset-11/root/usr/bin:/opt/python/cp310-cp310/bin:$PATH
+gcc --version
+
+pushd /code
+rm -rf /code/cuda-build
+cmake -B cuda-build -DLANCE_BUILD_CUDA=TRUE
+make -C cuda-build -j

--- a/integration/duckdb/cuda/docker-compose.yml
+++ b/integration/duckdb/cuda/docker-compose.yml
@@ -1,0 +1,11 @@
+# Docker-compose to bring up a test cluster.
+version: "3.9"
+services:
+  cuda:
+    build:
+      context: ..
+      dockerfile: cuda/Dockerfile
+      target: builder
+    working_dir: /code
+    volumes:
+      - ../:/code

--- a/integration/duckdb/src/lance/duckdb/ml/catalog.cc
+++ b/integration/duckdb/src/lance/duckdb/ml/catalog.cc
@@ -38,7 +38,8 @@ ModelCatalog* ModelCatalog::Get() {
 }
 
 bool ModelCatalog::Load(const std::string& name, const std::string& uri) {
-  if (models_.contains(name)) {
+  // nvcc doesn't support C++20 yet so can't use std::map::contains()
+  if (models_.find(name) != models_.end()) {
     return false;
   }
   auto entry = PyTorchModelEntry::Make(name, uri);

--- a/integration/duckdb/src/lance/duckdb/ml/catalog.cc
+++ b/integration/duckdb/src/lance/duckdb/ml/catalog.cc
@@ -21,8 +21,8 @@
 
 namespace lance::duckdb::ml {
 
-ModelEntry::ModelEntry(std::string name, std::string uri)
-    : name_(std::move(name)), uri_(std::move(uri)) {}
+ModelEntry::ModelEntry(std::string name, std::string uri, std::string device)
+    : name_(std::move(name)), uri_(std::move(uri)), device_(std::move(device)) {}
 
 std::unique_ptr<ModelCatalog> ModelCatalog::catalog_;
 std::mutex ModelCatalog::mutex_;
@@ -37,12 +37,12 @@ ModelCatalog* ModelCatalog::Get() {
   return catalog_.get();
 }
 
-bool ModelCatalog::Load(const std::string& name, const std::string& uri) {
+bool ModelCatalog::Load(const std::string& name, const std::string& uri, const std::string& device) {
   // nvcc doesn't support C++20 yet so can't use std::map::contains()
   if (models_.find(name) != models_.end()) {
     return false;
   }
-  auto entry = PyTorchModelEntry::Make(name, uri);
+  auto entry = PyTorchModelEntry::Make(name, uri, device);
   models_.emplace(name, std::move(entry));
   return true;
 }

--- a/integration/duckdb/src/lance/duckdb/ml/catalog.h
+++ b/integration/duckdb/src/lance/duckdb/ml/catalog.h
@@ -31,6 +31,9 @@ class ModelEntry {
   /// Model URL
   const std::string& uri() const { return uri_; }
 
+  /// Target model device
+  const std::string& device() const { return device_; }
+
   /// Returns the type of the model.
   virtual std::string type() const = 0;
 
@@ -41,10 +44,11 @@ class ModelEntry {
 
  protected:
   /// Construct model entry
-  ModelEntry(std::string name, std::string uri);
+  ModelEntry(std::string name, std::string uri, std::string device);
 
   std::string name_;
   std::string uri_;
+  std::string device_;
 };
 
 /// Machine Learning Model Catalog.
@@ -56,7 +60,7 @@ class ModelCatalog {
   static ModelCatalog* Get();
 
   /// Load a Model from URI.
-  bool Load(const std::string& name, const std::string& uri);
+  bool Load(const std::string& name, const std::string& uri, const std::string& device);
 
   /// Get the model by name. Return `nullptr` if not found.
   [[nodiscard]] ModelEntry* Get(const std::string& name) const;

--- a/integration/duckdb/src/lance/duckdb/ml/pytorch.cc
+++ b/integration/duckdb/src/lance/duckdb/ml/pytorch.cc
@@ -21,6 +21,8 @@
 #include <memory>
 #include <opencv2/opencv.hpp>
 #include <string>
+#include <optional>
+
 
 namespace lance::duckdb::ml {
 
@@ -72,48 +74,60 @@ std::unique_ptr<ModelEntry> PyTorchModelEntry::Make(const std::string& name,
   return std::unique_ptr<ModelEntry>(new PyTorchModelEntry{name, uri, device, module});
 }
 
+/// Create an opencv image matrix from the image bytes in the duckdb value (also do BGR=>RGB)
+std::optional<cv::Mat> ReadImageFromDuckDBValue(::duckdb::Value image_bytes) {
+  auto img_bytes = ::duckdb::StringValue::Get(image_bytes);
+  cv::Mat1b buf(img_bytes.size(), 1, (unsigned char*)(img_bytes.data()));
+  auto mat = cv::imdecode(buf, cv::IMREAD_UNCHANGED);
+  if (mat.data == nullptr) {
+    std::cerr << "Failed to parse image: image size=" << img_bytes.size()
+              << " buf=" << buf.size().width << "\n";
+    return std::nullopt;
+  }
+  cv::Mat rgb_mat;
+  cv::cvtColor(mat, rgb_mat, cv::COLOR_BGR2RGB);
+  // Convert to float matrix.
+  cv::Mat fmat;
+  rgb_mat.convertTo(fmat, cv::DataType<float>::type);
+  return fmat;
+}
+
+/// Convert the input image to torch::Tensor and run it through the model (on the model's target device)
+torch::Tensor PyTorchModelEntry::RunInference(cv::Mat fmat) {
+  auto input_tensor = ToTensor(fmat);
+  input_tensor = normalize(input_tensor);
+  if (device_ == "cuda") {
+    input_tensor = input_tensor.to(at::kCUDA);
+  } else if (device_ == "cpu") {
+    input_tensor = input_tensor.to(at::kCPU);
+  }
+  std::vector<torch::jit::IValue> inputs;
+  inputs.push_back(input_tensor);
+  return module_.forward(inputs).toTensor();
+}
+
+/// Read the images from input data, run model inference, and return probabilities
 void PyTorchModelEntry::Execute(::duckdb::DataChunk& args,
                                 ::duckdb::ExpressionState& state,
                                 ::duckdb::Vector& result) {
   result.SetVectorType(::duckdb::VectorType::FLAT_VECTOR);
   for (int i = 0; i < args.size(); i++) {
-    auto img_bytes = ::duckdb::StringValue::Get(args.data[1].GetValue(i));
-    cv::Mat1b buf(img_bytes.size(), 1, (unsigned char*)(img_bytes.data()));
-    auto mat = cv::imdecode(buf, cv::IMREAD_UNCHANGED);
-    if (mat.data == nullptr) {
-      std::cerr << "Failed to parse image: image size=" << img_bytes.size()
-                << " buf=" << buf.size().width << "\n";
-      continue;
-    }
-    cv::Mat rgb_mat;
-    cv::cvtColor(mat, rgb_mat, cv::COLOR_BGR2RGB);
-    // Convert to float matrix.
-    cv::Mat fmat;
-    rgb_mat.convertTo(fmat, cv::DataType<float>::type);
-
     // TODO: support batch mode
-
-    auto input_tensor = ToTensor(fmat);
-    input_tensor = normalize(input_tensor);
-    if (device_ == "cuda") {
-      input_tensor = input_tensor.to(at::kCUDA);
-    } else if (device_ == "cpu") {
-      input_tensor = input_tensor.to(at::kCPU);
+    auto fmat = ReadImageFromDuckDBValue(args.data[1].GetValue(i));
+    if(fmat.has_value()) {
+      auto output = RunInference(fmat.value());
+      // OMG this copying is painfully slow.
+      std::vector<::duckdb::Value> values;
+      auto softmax = output[0].softmax(0).to(at::kCPU);
+      for (int i = 0; i < softmax.size(0); i++) {
+        values.emplace_back(::duckdb::Value::FLOAT(*softmax[i].data_ptr<float>()));
+      }
+      result.SetValue(i, ::duckdb::Value::LIST(values));
     }
-    std::vector<torch::jit::IValue> inputs;
-    inputs.push_back(input_tensor);
-    auto output = module_.forward(inputs).toTensor().to(at::kCPU);
-
-    // OMG this copying is painfully slow.
-    std::vector<::duckdb::Value> values;
-    auto softmax = output[0].softmax(0);
-    for (int i = 0; i < softmax.size(0); i++) {
-      values.emplace_back(::duckdb::Value::FLOAT(*softmax[i].data_ptr<float>()));
-    }
-    result.SetValue(i, ::duckdb::Value::LIST(values));
   }
 }
 
+/// The `predict('model', image_col)` function
 void Predict(::duckdb::DataChunk& args,
              ::duckdb::ExpressionState& state,
              ::duckdb::Vector& result) {

--- a/integration/duckdb/src/lance/duckdb/ml/pytorch.h
+++ b/integration/duckdb/src/lance/duckdb/ml/pytorch.h
@@ -43,13 +43,9 @@ class PyTorchModelEntry : ModelEntry {
                     torch::jit::script::Module module)
       : ModelEntry(name, uri, device), module_(std::move(module)) {
     module_.eval();
-    auto params = module_.named_parameters();
-    for (const auto &item : params) {
-
-    }
   }
 
-  torch::Tensor RunInference(cv::Mat fmat);
+  torch::Tensor MatToTensor(const cv::Mat& fmat);
 
   std::string name_;
   std::string uri_;

--- a/integration/duckdb/src/lance/duckdb/ml/pytorch.h
+++ b/integration/duckdb/src/lance/duckdb/ml/pytorch.h
@@ -29,7 +29,7 @@ namespace lance::duckdb::ml {
 /// PyTorch / TorchScript model entry
 class PyTorchModelEntry : ModelEntry {
  public:
-  static std::unique_ptr<ModelEntry> Make(const std::string &name, const std::string &uri);
+  static std::unique_ptr<ModelEntry> Make(const std::string &name, const std::string &uri, const std::string &device);
 
   std::string type() const override { return "torchscript"; }
 
@@ -38,9 +38,14 @@ class PyTorchModelEntry : ModelEntry {
                ::duckdb::Vector &result) override;
 
  private:
-  PyTorchModelEntry(std::string name, std::string uri, torch::jit::script::Module module)
-      : ModelEntry(name, uri), module_(std::move(module)) {
+  PyTorchModelEntry(std::string name, std::string uri, std::string device,
+                    torch::jit::script::Module module)
+      : ModelEntry(name, uri, device), module_(std::move(module)) {
     module_.eval();
+    auto params = module_.named_parameters();
+    for (const auto &item : params) {
+
+    }
   }
 
   std::string name_;

--- a/integration/duckdb/src/lance/duckdb/ml/pytorch.h
+++ b/integration/duckdb/src/lance/duckdb/ml/pytorch.h
@@ -20,6 +20,7 @@
 #include <duckdb/parser/parsed_data/create_function_info.hpp>
 #include <duckdb/parser/parsed_data/create_table_function_info.hpp>
 #include <memory>
+#include <opencv2/opencv.hpp>
 #include <vector>
 
 #include "lance/duckdb/ml/catalog.h"
@@ -47,6 +48,8 @@ class PyTorchModelEntry : ModelEntry {
 
     }
   }
+
+  torch::Tensor RunInference(cv::Mat fmat);
 
   std::string name_;
   std::string uri_;

--- a/integration/duckdb/tests/conftest.py
+++ b/integration/duckdb/tests/conftest.py
@@ -4,6 +4,7 @@ from pathlib import Path
 
 import duckdb
 import pytest
+import torch
 
 
 @pytest.fixture
@@ -11,7 +12,9 @@ def db() -> duckdb.DuckDBPyConnection:
     """Initialize duckdb with lance extension"""
     db = duckdb.connect(config={"allow_unsigned_extensions": True})
 
+    build_dir = "cuda-build" if torch.cuda.is_available() else "manylinux-build"
+
     cur_path = Path(__file__).parent
-    db.install_extension(str(cur_path.parent / "manylinux-build" / "lance.duckdb_extension"), force_install=True)
+    db.install_extension(str(cur_path.parent / build_dir / "lance.duckdb_extension"), force_install=True)
     db.load_extension("lance")
     return db

--- a/integration/duckdb/tests/test_pytorch.py
+++ b/integration/duckdb/tests/test_pytorch.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python3
 
 from pathlib import Path
+import pytest
 
 import pandas as pd
 import torch
@@ -9,24 +10,31 @@ import pyarrow as pa
 from PIL import Image
 from duckdb import DuckDBPyConnection
 from torchvision import transforms
-from torchvision.models import resnet50, ResNet50_Weights
+from torchvision.models import resnet18, ResNet18_Weights
 
 
-def test_resnet(db: DuckDBPyConnection, tmp_path: Path):
-    resnet = resnet50(weights=ResNet50_Weights.IMAGENET1K_V2)
+def download_model(tmp_path: Path, device: str):
+    resnet = resnet18(weights=ResNet18_Weights.IMAGENET1K_V1)
+    resnet.to(device)
+    resnet.eval()
     m = torch.jit.script(resnet)
     model_path = tmp_path / "resnet.pth"
     torch.jit.save(m, str(model_path))
+    return resnet, model_path
 
-    db.execute(f"CALL create_pytorch_model('resnet', '{str(model_path)}');")
 
+def create_model(db, model_path, device):
+    db.execute(f"CALL create_pytorch_model('resnet', '{str(model_path)}', '{device}');")
     expected_models = pd.DataFrame([{
         "name": "resnet",
         "uri": str(model_path),
         "type": "torchscript",
+        "device": device,
     }])
     pd.testing.assert_frame_equal(db.query("SELECT * FROM ml_models()").to_df(), expected_models)
 
+
+def run_model(db, resnet, device):
     cat_path = Path(__file__).parent / "testdata" / "cat.jpg"
     cat = cat_path.read_bytes()
     tbl = pa.Table.from_pylist([{"img": cat}])
@@ -35,6 +43,7 @@ def test_resnet(db: DuckDBPyConnection, tmp_path: Path):
     actual_prob = torch.tensor(df["prob"].iloc[0])
     actual_class = torch.argmax(actual_prob)
 
+    resnet.to(device)
     resnet.eval()
 
     preprocess = transforms.Compose([
@@ -45,7 +54,7 @@ def test_resnet(db: DuckDBPyConnection, tmp_path: Path):
     ])
     image: Image = Image.open(cat_path)
     image_tensor = preprocess(image)
-    batch: torch.Tensor = image_tensor.unsqueeze(0)
+    batch: torch.Tensor = image_tensor.unsqueeze(0).to(device)
     with torch.no_grad():
         output = resnet(batch)
     probabilities = torch.nn.functional.softmax(output[0], dim=0)
@@ -56,5 +65,25 @@ def test_resnet(db: DuckDBPyConnection, tmp_path: Path):
               .to_df().pred)
     assert (argmax.values == torch.argmax(probabilities).numpy()).all()
 
-    db.execute("CALL drop_model('resnet')")
-    assert db.query("SELECT * FROM ml_models()").to_df().size == 0
+
+def _test_model(db, device, model, model_path):
+    try:
+        create_model(db, model_path, device)
+        run_model(db, model, device)
+    finally:
+        db.execute("CALL drop_model('resnet')")
+        assert db.query("SELECT * FROM ml_models()").to_df().size == 0
+
+
+def test_resnet(db: DuckDBPyConnection, tmp_path: Path):
+    device = 'cpu'
+    model, model_path = download_model(tmp_path, device)
+    _test_model(db, device, model, model_path)
+
+
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="requires cuda")
+def test_resnet_cuda(db: DuckDBPyConnection, tmp_path: Path):
+    device = 'cuda'
+    model, model_path = download_model(tmp_path, device)
+    _test_model(db, device, model, model_path)
+


### PR DESCRIPTION
create_pytorch('name', '/path/to/model.pth', 'cuda')
OR
create_pytorch('name', '/path/to/model.pth', 'cpu')

inputs are automatically moved to corresopnding device