### PR TITLE
pytorch dataset fix

### DIFF
--- a/python/lance/tests/test_pytorch.py
+++ b/python/lance/tests/test_pytorch.py
@@ -11,7 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-
+import lance
 import pytest
 
 torch = pytest.importorskip("torch")
@@ -35,7 +35,7 @@ def test_data_loader(tmp_path: Path):
     values = pa.array(range(10, 20))
     tab = pa.Table.from_arrays([ids, values], names=["id", "value"])
 
-    pa.dataset.write_dataset(tab, tmp_path / "lance", format=LanceFileFormat())
+    lance.write_dataset(tab, tmp_path / "lance", format=LanceFileFormat())
 
     dataset = LanceDataset(tmp_path / "lance", batch_size=4, mode="batch")
     id_batch, value_batch = next(iter(dataset))
@@ -61,7 +61,7 @@ def test_dataset_with_ext_types(tmp_path: Path):
     labels_arr = pa.DictionaryArray.from_pandas(pd.Series(labels, dtype="category"))
 
     tab = pa.Table.from_arrays([image_arr, labels_arr], names=["image", "label"])
-    pa.dataset.write_dataset(tab, tmp_path / "lance", format=LanceFileFormat())
+    lance.write_dataset(tab, tmp_path / "lance", format=LanceFileFormat())
 
     dataset = LanceDataset(tmp_path / "lance", batch_size=4, mode="batch")
     batch = next(iter(dataset))
@@ -78,7 +78,7 @@ def test_data_loader_with_filter(tmp_path: Path):
     split = pa.array(["train", "val"] * 5)
     tab = pa.Table.from_arrays([ids, values, split], names=["id", "value", "split"])
 
-    pa.dataset.write_dataset(tab, tmp_path / "lance", format=LanceFileFormat())
+    lance.write_dataset(tab, tmp_path / "lance", format=LanceFileFormat())
 
     dataset = LanceDataset(tmp_path / "lance", filter=pc.field("split") == "train")
     for id, value, split in dataset:
@@ -93,7 +93,7 @@ def test_data_loader_projection(tmp_path: Path):
     ids = pa.array(range(10))
     values = pa.array([f"num-{i}" for i in ids])
     tab = pa.Table.from_arrays([ids, values], names=["id", "value"])
-    pa.dataset.write_dataset(tab, tmp_path / "lance", format=LanceFileFormat())
+    lance.write_dataset(tab, tmp_path / "lance", format=LanceFileFormat())
 
     dataset = LanceDataset(
         tmp_path / "lance", columns=["value"], filter=pc.field("id") >= 5
@@ -106,7 +106,7 @@ def test_filter_resulted_empty_return(tmp_path: Path):
     ids = pa.array(range(10))
     values = pa.array([i.as_py() > 5 for i in ids])
     table = pa.Table.from_arrays([ids, values], names=["id", "bignum"])
-    pa.dataset.write_dataset(table, tmp_path / "lance", format=LanceFileFormat())
+    lance.write_dataset(table, tmp_path / "lance", format=LanceFileFormat())
 
     dataset = LanceDataset(
         tmp_path / "lance",


### PR DESCRIPTION
new versioned FilesystemDataset does not have `.files` property so the pytorch dataset loader is failing.

the unit tests passed previously because it was still using pa.dataset.write_dataset.

What's the right strategy here? should we actually expose the FileSystemDataset => CLanceDataset => Manifest => Fragments => Files? Should the pytorch dataset use something else? 