### PR TITLE
[C++] Scan Node reads multiple files

### DIFF
--- a/.github/workflows/cpp.yml
+++ b/.github/workflows/cpp.yml
@@ -14,7 +14,7 @@ jobs:
       run:
         working-directory: ./cpp
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: ccache
         uses: hendrikmuhs/ccache-action@v1
       - name: Run lint
@@ -40,7 +40,7 @@ jobs:
       run:
         working-directory: ./cpp
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: Install dependencies
         run: |
           brew update

--- a/cpp/src/lance/arrow/utils.cc
+++ b/cpp/src/lance/arrow/utils.cc
@@ -40,6 +40,18 @@ namespace lance::arrow {
   return ::arrow::RecordBatch::FromStructArray(struct_arr);
 }
 
+::arrow::Result<std::shared_ptr<::arrow::RecordBatch>> MergeRecordBatches(
+    const std::vector<std::shared_ptr<::arrow::RecordBatch>>& batches, ::arrow::MemoryPool* pool) {
+  if (batches.empty()) {
+    return nullptr;
+  }
+  auto batch = batches[0];
+  for (std::size_t i = 1; i < batches.size(); ++i) {
+    ARROW_ASSIGN_OR_RAISE(batch, MergeRecordBatches(batch, batches[i], pool));
+  }
+  return batch;
+}
+
 ::arrow::Result<std::shared_ptr<::arrow::Array>> MergeListArrays(
     const std::shared_ptr<::arrow::Array>& lhs,
     const std::shared_ptr<::arrow::Array>& rhs,

--- a/cpp/src/lance/arrow/utils.cc
+++ b/cpp/src/lance/arrow/utils.cc
@@ -112,10 +112,9 @@ namespace lance::arrow {
     arrays.emplace_back(left_arr);
   }
 
-  for (auto& field : rhs->struct_type()->fields() | views::filter([&lhs](auto& f) {
-                       return !lhs->GetFieldByName(f->name());
-                     })) {
-    auto& name = field->name();
+  for (auto name : rhs->struct_type()->fields() | views::filter([&lhs](auto& f) {
+                     return !lhs->GetFieldByName(f->name());
+                   }) | views::transform([](auto& f) { return f->name(); })) {
     names.emplace_back(name);
     arrays.emplace_back(rhs->GetFieldByName(name));
   }

--- a/cpp/src/lance/arrow/utils.cc
+++ b/cpp/src/lance/arrow/utils.cc
@@ -122,6 +122,7 @@ namespace lance::arrow {
   return ::arrow::StructArray::Make(arrays, names);
 }
 
+/// Concept of a class that has ".fields()" method.
 template <typename T>
 concept HasFields = (std::same_as<T, ::arrow::Schema> || std::same_as<T, ::arrow::StructType>);
 

--- a/cpp/src/lance/arrow/utils.cc
+++ b/cpp/src/lance/arrow/utils.cc
@@ -50,6 +50,13 @@ namespace lance::arrow {
   }
   auto batch = batches[0];
   for (auto& b : batches | views::drop(1)) {
+    if (b->num_rows() != batch->num_rows()) {
+      return ::arrow::Status::Invalid(
+          "MergeRecordBatches: attempt to merge batches with different length: ",
+          b->num_rows(),
+          " != ",
+          batch->num_rows());
+    }
     ARROW_ASSIGN_OR_RAISE(batch, MergeRecordBatches(batch, b, pool));
   }
   return batch;

--- a/cpp/src/lance/arrow/utils.cc
+++ b/cpp/src/lance/arrow/utils.cc
@@ -49,7 +49,7 @@ namespace lance::arrow {
     return nullptr;
   }
   auto batch = batches[0];
-  for (auto& b : batches | ranges::views::drop(1)) {
+  for (auto& b : batches | views::drop(1)) {
     ARROW_ASSIGN_OR_RAISE(batch, MergeRecordBatches(batch, b, pool));
   }
   return batch;

--- a/cpp/src/lance/arrow/utils.cc
+++ b/cpp/src/lance/arrow/utils.cc
@@ -112,9 +112,10 @@ namespace lance::arrow {
     arrays.emplace_back(left_arr);
   }
 
-  for (auto name : rhs->struct_type()->fields() | views::filter([&lhs](auto& f) {
-                     return !lhs->GetFieldByName(f->name());
-                   }) | views::transform([](auto& f) { return f->name(); })) {
+  for (auto name :
+       rhs->struct_type()->fields()                                                      //
+           | views::filter([&lhs](auto& f) { return !lhs->GetFieldByName(f->name()); })  //
+           | views::transform([](auto& f) { return f->name(); })) {
     names.emplace_back(name);
     arrays.emplace_back(rhs->GetFieldByName(name));
   }
@@ -141,12 +142,11 @@ template <HasFields T>
       fields.emplace_back(merged);
     }
   }
-  for (const auto& field : rhs.fields()) {
-    auto left_field = lhs.GetFieldByName(field->name());
-    if (!left_field) {
-      fields.emplace_back(field);
-    }
-  }
+  ranges::actions::insert(
+      fields,
+      std::end(fields),  //
+      rhs.fields()       //
+          | views::filter([&lhs](auto& f) { return !lhs.GetFieldByName(f->name()); }));
   return fields;
 };
 

--- a/cpp/src/lance/arrow/utils.h
+++ b/cpp/src/lance/arrow/utils.h
@@ -32,9 +32,10 @@ namespace lance::arrow {
     const std::shared_ptr<::arrow::RecordBatch>& rhs,
     ::arrow::MemoryPool* pool = ::arrow::default_memory_pool());
 
-/// Merge a list of record batches into one.
+/// Merge a list of record batches that represent the different columns of the same rows,
+/// into a single record batch.
 ///
-/// \param batches A list of record batches.
+/// \param batches A list of record batches. Must have the same length.
 /// \param pool memory pool.
 /// \return the merged record batch. Or nullptr if batches is empty.
 ::arrow::Result<std::shared_ptr<::arrow::RecordBatch>> MergeRecordBatches(

--- a/cpp/src/lance/arrow/utils.h
+++ b/cpp/src/lance/arrow/utils.h
@@ -20,6 +20,7 @@
 #include <arrow/result.h>
 
 #include <memory>
+#include <vector>
 
 #include "lance/format/schema.h"
 
@@ -29,6 +30,11 @@ namespace lance::arrow {
 ::arrow::Result<std::shared_ptr<::arrow::RecordBatch>> MergeRecordBatches(
     const std::shared_ptr<::arrow::RecordBatch>& lhs,
     const std::shared_ptr<::arrow::RecordBatch>& rhs,
+    ::arrow::MemoryPool* pool = ::arrow::default_memory_pool());
+
+/// Merge a list of record batches into one.
+::arrow::Result<std::shared_ptr<::arrow::RecordBatch>> MergeRecordBatches(
+    const std::vector<std::shared_ptr<::arrow::RecordBatch>>& batches,
     ::arrow::MemoryPool* pool = ::arrow::default_memory_pool());
 
 ::arrow::Result<std::shared_ptr<::arrow::StructArray>> MergeStructArrays(

--- a/cpp/src/lance/arrow/utils.h
+++ b/cpp/src/lance/arrow/utils.h
@@ -33,6 +33,10 @@ namespace lance::arrow {
     ::arrow::MemoryPool* pool = ::arrow::default_memory_pool());
 
 /// Merge a list of record batches into one.
+///
+/// \param batches A list of record batches.
+/// \param pool memory pool.
+/// \return the merged record batch. Or nullptr if batches is empty.
 ::arrow::Result<std::shared_ptr<::arrow::RecordBatch>> MergeRecordBatches(
     const std::vector<std::shared_ptr<::arrow::RecordBatch>>& batches,
     ::arrow::MemoryPool* pool = ::arrow::default_memory_pool());

--- a/cpp/src/lance/arrow/utils_test.cc
+++ b/cpp/src/lance/arrow/utils_test.cc
@@ -207,3 +207,34 @@ TEST_CASE("Test merge extension types") {
                             *::arrow::schema({::arrow::field("ann", lance::testing::image())}));
   CHECK(result.status().IsInvalid());
 }
+
+TEST_CASE("Merge record batches") {
+  const int kNumRows = 3;
+  auto batch1 =
+      ::arrow::RecordBatch::Make(::arrow::schema({::arrow::field("col1", ::arrow::int32())}),
+                                 kNumRows,
+                                 {ToArray({1, 2, 3}).ValueOrDie()});
+  auto batch2 =
+      ::arrow::RecordBatch::Make(::arrow::schema({::arrow::field("col2", ::arrow::uint32())}),
+                                 kNumRows,
+                                 {ToArray({10, 20, 30}).ValueOrDie()});
+  auto batch3 =
+      ::arrow::RecordBatch::Make(::arrow::schema({::arrow::field("col3", ::arrow::utf8())}),
+                                 kNumRows,
+                                 {ToArray({"1", "2", "3"}).ValueOrDie()});
+  std::vector<std::shared_ptr<::arrow::RecordBatch>> batches({batch1, batch2, batch3});
+
+  auto merged = lance::arrow::MergeRecordBatches(batches).ValueOrDie();
+  CHECK(merged->num_rows() == kNumRows);
+
+  auto expected =
+      ::arrow::RecordBatch::Make(::arrow::schema({::arrow::field("col1", ::arrow::int32()),
+                                                  ::arrow::field("col2", ::arrow::uint32()),
+                                                  ::arrow::field("col3", ::arrow::utf8())}),
+                                 kNumRows,
+                                 {ToArray({1, 2, 3}).ValueOrDie(),
+                                  ToArray({10, 20, 30}).ValueOrDie(),
+                                  ToArray({"1", "2", "3"}).ValueOrDie()});
+  fmt::print("Merge : {}\n", merged->ToString());
+  CHECK(merged->Equals(*expected));
+}

--- a/cpp/src/lance/arrow/utils_test.cc
+++ b/cpp/src/lance/arrow/utils_test.cc
@@ -235,6 +235,5 @@ TEST_CASE("Merge record batches") {
                                  {ToArray({1, 2, 3}).ValueOrDie(),
                                   ToArray({10, 20, 30}).ValueOrDie(),
                                   ToArray({"1", "2", "3"}).ValueOrDie()});
-  fmt::print("Merge : {}\n", merged->ToString());
   CHECK(merged->Equals(*expected));
 }

--- a/cpp/src/lance/io/exec/limit_test.cc
+++ b/cpp/src/lance/io/exec/limit_test.cc
@@ -49,8 +49,9 @@ TEST_CASE("Read limit multiple times") {
   auto infile = make_shared<arrow::io::BufferReader>(sink->Finish().ValueOrDie());
   auto reader = std::make_shared<lance::io::FileReader>(infile);
   CHECK(reader->Open().ok());
-  auto scan = lance::io::exec::Scan::Make(reader, std::make_shared<Schema>(reader->schema()), 100)
-                  .ValueOrDie();
+  auto scan =
+      lance::io::exec::Scan::Make({{reader, std::make_shared<Schema>(reader->schema())}}, 100)
+          .ValueOrDie();
   auto counter = std::make_shared<Counter>(5, 10);
   auto limit = Limit(counter, std::move(scan));
   auto batch = limit.Next().ValueOrDie();

--- a/cpp/src/lance/io/exec/project.cc
+++ b/cpp/src/lance/io/exec/project.cc
@@ -55,7 +55,7 @@ Project::Project(std::unique_ptr<ExecNode> child,
     /// Take -> (optionally) Limit -> Filter -> Scan
     ARROW_ASSIGN_OR_RAISE(auto filter_scan_schema, schema.Project(scan_options->filter));
     ARROW_ASSIGN_OR_RAISE(auto filter_scan_node,
-                          Scan::Make(reader, filter_scan_schema, scan_options->batch_size));
+                          Scan::Make({{reader, filter_scan_schema}}, scan_options->batch_size));
     ARROW_ASSIGN_OR_RAISE(child, Filter::Make(scan_options->filter, std::move(filter_scan_node)));
     if (counter) {
       ARROW_ASSIGN_OR_RAISE(child, Limit::Make(counter, std::move(child)));
@@ -64,7 +64,8 @@ Project::Project(std::unique_ptr<ExecNode> child,
     ARROW_ASSIGN_OR_RAISE(child, Take::Make(reader, take_schema, std::move(child)));
   } else {
     /// (*optionally) Limit -> Scan
-    ARROW_ASSIGN_OR_RAISE(child, Scan::Make(reader, projected_schema, scan_options->batch_size));
+    ARROW_ASSIGN_OR_RAISE(
+        child, Scan::Make({{std::move(reader), projected_schema}}, scan_options->batch_size));
     if (counter) {
       ARROW_ASSIGN_OR_RAISE(child, Limit::Make(counter, std::move(child)));
     }

--- a/cpp/src/lance/io/exec/scan.cc
+++ b/cpp/src/lance/io/exec/scan.cc
@@ -87,7 +87,7 @@ Scan::Scan(const std::vector<FileReaderWithSchema>& readers, int64_t batch_size)
   std::vector<std::shared_ptr<::arrow::RecordBatch>> batches;
   for (auto& fut : futs) {
     ARROW_ASSIGN_OR_RAISE(auto& b, fut.result());
-    batches.emplace_back(std::move(b));
+    batches.emplace_back(b);
   }
 
   ARROW_ASSIGN_OR_RAISE(auto batch, lance::arrow::MergeRecordBatches(batches));

--- a/cpp/src/lance/io/exec/scan.cc
+++ b/cpp/src/lance/io/exec/scan.cc
@@ -57,7 +57,9 @@ Scan::Scan(const std::vector<FileReaderWithSchema>& readers, int64_t batch_size)
         current_batch_page_length_ = first_reader->metadata().GetBatchLength(current_batch_id_);
       }
     }
+    // Lock released after scope.
   }
+  
   if (batch_id >= first_reader->metadata().num_batches()) {
     // Reach EOF
     return ScanBatch::Null();
@@ -83,10 +85,10 @@ Scan::Scan(const std::vector<FileReaderWithSchema>& readers, int64_t batch_size)
   }
 
   std::vector<std::shared_ptr<::arrow::RecordBatch>> batches;
-  for (auto& fut : futs) {
-    ARROW_ASSIGN_OR_RAISE(auto& b, fut.result());
-    batches.emplace_back(std::move(b));
-  }
+//  for (auto& fut : futs) {
+//    ARROW_ASSIGN_OR_RAISE(auto& b, fut.result());
+//    batches.emplace_back(std::move(b));
+//  }
 
   ARROW_ASSIGN_OR_RAISE(auto batch, lance::arrow::MergeRecordBatches(batches));
   return ScanBatch{

--- a/cpp/src/lance/io/exec/scan.cc
+++ b/cpp/src/lance/io/exec/scan.cc
@@ -84,7 +84,6 @@ Scan::Scan(const std::vector<FileReaderWithSchema>& readers, int64_t batch_size)
 
   std::vector<std::shared_ptr<::arrow::RecordBatch>> batches;
   for (auto& fut : futs) {
-    fut.Wait();
     ARROW_ASSIGN_OR_RAISE(auto b, fut.MoveResult());
     batches.emplace_back(b);
   }

--- a/cpp/src/lance/io/exec/scan.cc
+++ b/cpp/src/lance/io/exec/scan.cc
@@ -68,7 +68,7 @@ Scan::Scan(const std::vector<FileReaderWithSchema>& readers, int64_t batch_size)
     // Reach EOF
     return ScanBatch::Null();
   }
-  
+
   auto executor = ::arrow::internal::GetCpuThreadPool();
   std::vector<::arrow::Future<std::shared_ptr<::arrow::RecordBatch>>> futs;
   for (auto& [reader, schema] : readers_) {

--- a/cpp/src/lance/io/exec/scan.cc
+++ b/cpp/src/lance/io/exec/scan.cc
@@ -22,12 +22,6 @@
 
 namespace lance::io::exec {
 
-::arrow::Result<std::unique_ptr<Scan>> Scan::Make(std::shared_ptr<FileReader> reader,
-                                                  std::shared_ptr<lance::format::Schema> schema,
-                                                  int64_t batch_size) {
-  return Make({{reader, schema}}, batch_size);
-}
-
 ::arrow::Result<std::unique_ptr<Scan>> Scan::Make(const std::vector<FileReaderWithSchema>& readers,
                                                   int64_t batch_size) {
   if (readers.empty()) {
@@ -72,20 +66,19 @@ Scan::Scan(const std::vector<FileReaderWithSchema>& readers, int64_t batch_size)
   auto executor = ::arrow::internal::GetCpuThreadPool();
   std::vector<::arrow::Future<std::shared_ptr<::arrow::RecordBatch>>> futs;
   for (auto& [reader, schema] : readers_) {
-    ARROW_ASSIGN_OR_RAISE(
-        auto fut,
-        executor->Submit(
-            [](auto& r, auto& s, auto batch_id, auto offset, auto batch_size)
-                -> ::arrow::Result<std::shared_ptr<::arrow::RecordBatch>> {
-              ARROW_ASSIGN_OR_RAISE(auto batch,
-                                    r->ReadBatch(*s, batch_id, offset, batch_size));
-              return batch;
-            },
-            reader,
-            schema,
-            batch_id,
-            offset,
-            batch_size_));
+    ARROW_ASSIGN_OR_RAISE(auto fut,
+                          executor->Submit(
+                              [](auto& r, auto& s, auto batch_id, auto offset, auto batch_size)
+                                  -> ::arrow::Result<std::shared_ptr<::arrow::RecordBatch>> {
+                                ARROW_ASSIGN_OR_RAISE(
+                                    auto batch, r->ReadBatch(*s, batch_id, offset, batch_size));
+                                return batch;
+                              },
+                              reader,
+                              schema,
+                              batch_id,
+                              offset,
+                              batch_size_));
     futs.emplace_back(std::move(fut));
   }
 

--- a/cpp/src/lance/io/exec/scan.cc
+++ b/cpp/src/lance/io/exec/scan.cc
@@ -76,16 +76,16 @@ Scan::Scan(const std::vector<FileReaderWithSchema>& readers, int64_t batch_size)
               ARROW_ASSIGN_OR_RAISE(auto batch, r->ReadBatch(*s, batch_id, offset, batch_size));
               return batch;
             },
-            std::move(reader),
-            std::move(schema),
+            reader,
+            schema,
             batch_size_));
     futs.emplace_back(std::move(fut));
   }
 
   std::vector<std::shared_ptr<::arrow::RecordBatch>> batches;
-  for (auto& fut : futs) {
-    ARROW_ASSIGN_OR_RAISE(auto b, fut.MoveResult());
-    batches.emplace_back(b);
+  for (auto fut : futs) {
+    ARROW_ASSIGN_OR_RAISE(auto b, fut.result());
+    batches.emplace_back(std::move(b));
   }
 
   ARROW_ASSIGN_OR_RAISE(auto batch, lance::arrow::MergeRecordBatches(batches));

--- a/cpp/src/lance/io/exec/scan.cc
+++ b/cpp/src/lance/io/exec/scan.cc
@@ -59,7 +59,7 @@ Scan::Scan(const std::vector<FileReaderWithSchema>& readers, int64_t batch_size)
     }
     // Lock released after scope.
   }
-  
+
   if (batch_id >= first_reader->metadata().num_batches()) {
     // Reach EOF
     return ScanBatch::Null();
@@ -85,10 +85,10 @@ Scan::Scan(const std::vector<FileReaderWithSchema>& readers, int64_t batch_size)
   }
 
   std::vector<std::shared_ptr<::arrow::RecordBatch>> batches;
-//  for (auto& fut : futs) {
-//    ARROW_ASSIGN_OR_RAISE(auto& b, fut.result());
-//    batches.emplace_back(std::move(b));
-//  }
+  for (auto& fut : futs) {
+    ARROW_ASSIGN_OR_RAISE(auto& b, fut.result());
+    batches.emplace_back(std::move(b));
+  }
 
   ARROW_ASSIGN_OR_RAISE(auto batch, lance::arrow::MergeRecordBatches(batches));
   return ScanBatch{

--- a/cpp/src/lance/io/exec/scan.cc
+++ b/cpp/src/lance/io/exec/scan.cc
@@ -67,12 +67,12 @@ Scan::Scan(const std::vector<FileReaderWithSchema>& readers, int64_t batch_size)
     return ScanBatch::Null();
   }
 
-  auto executor = ::arrow::internal::GetCpuThreadPool();
   if (::arrow::GetCpuThreadPoolCapacity() < kMinimalIOThreads) {
     // Keep a minimal number of threads, preventing live lock on low CPU count (<=2) machines,
     // i.e., Github Action runners.
     ARROW_RETURN_NOT_OK(::arrow::SetCpuThreadPoolCapacity(kMinimalIOThreads));
   }
+  auto executor = ::arrow::internal::GetCpuThreadPool();
   std::vector<::arrow::Future<std::shared_ptr<::arrow::RecordBatch>>> futs;
   for (auto [reader, schema] : readers_) {
     ARROW_ASSIGN_OR_RAISE(

--- a/cpp/src/lance/io/exec/scan.cc
+++ b/cpp/src/lance/io/exec/scan.cc
@@ -84,7 +84,7 @@ Scan::Scan(const std::vector<FileReaderWithSchema>& readers, int64_t batch_size)
 
   std::vector<std::shared_ptr<::arrow::RecordBatch>> batches;
   for (auto& fut : futs) {
-    ARROW_ASSIGN_OR_RAISE(auto b, fut.result());
+    ARROW_ASSIGN_OR_RAISE(auto& b, fut.result());
     batches.emplace_back(std::move(b));
   }
 

--- a/cpp/src/lance/io/exec/scan.cc
+++ b/cpp/src/lance/io/exec/scan.cc
@@ -83,7 +83,7 @@ Scan::Scan(const std::vector<FileReaderWithSchema>& readers, int64_t batch_size)
   }
 
   std::vector<std::shared_ptr<::arrow::RecordBatch>> batches;
-  for (auto fut : futs) {
+  for (auto& fut : futs) {
     ARROW_ASSIGN_OR_RAISE(auto b, fut.result());
     batches.emplace_back(std::move(b));
   }

--- a/cpp/src/lance/io/exec/scan.h
+++ b/cpp/src/lance/io/exec/scan.h
@@ -20,6 +20,8 @@
 
 #include <memory>
 #include <mutex>
+#include <tuple>
+#include <vector>
 
 #include "lance/io/exec/base.h"
 
@@ -36,20 +38,27 @@ namespace lance::io::exec {
 /// Leaf scan node.
 class Scan : public ExecNode {
  public:
+  using FileReaderWithSchema =
+      std::tuple<std::shared_ptr<FileReader>, std::shared_ptr<lance::format::Schema>>;
+
   /// Factory method.
   static ::arrow::Result<std::unique_ptr<Scan>> Make(std::shared_ptr<FileReader> reader,
                                                      std::shared_ptr<lance::format::Schema> schema,
                                                      int64_t batch_size);
+
+  /// Factory method.
+  ///
+  static ::arrow::Result<std::unique_ptr<Scan>> Make(
+      const std::vector<FileReaderWithSchema>& readers, int64_t batch_size);
 
   Scan() = delete;
 
   virtual ~Scan() = default;
 
   constexpr Type type() const override { return Type::kScan; }
+
   /// Returns the next available batch in the file. Or returns nullptr if EOF.
   ::arrow::Result<ScanBatch> Next() override;
-
-  const lance::format::Schema& schema();
 
   std::string ToString() const override;
 
@@ -63,15 +72,12 @@ class Scan : public ExecNode {
  private:
   /// Constructor
   ///
-  /// \param reader An opened file reader.
-  /// \param schema The scan schema, used to select column to scan.
+  /// \param readers A vector of opened readers with the projected schema.
   /// \param batch_size scan batch size.
-  Scan(std::shared_ptr<FileReader> reader,
-       std::shared_ptr<lance::format::Schema> schema,
+  Scan(const std::vector<FileReaderWithSchema>& readers,
        int64_t batch_size);
 
-  const std::shared_ptr<FileReader> reader_;
-  const std::shared_ptr<lance::format::Schema> schema_;
+  std::vector<FileReaderWithSchema> readers_;
   const int64_t batch_size_;
 
   /// Keep track of the progress.

--- a/cpp/src/lance/io/exec/scan.h
+++ b/cpp/src/lance/io/exec/scan.h
@@ -48,18 +48,23 @@ class Scan : public ExecNode {
 
   /// Factory method.
   ///
+  /// \param readers a vector of the tuples of `[reader, schema]`, including opened file reader
+  ///                and projection schema.
+  /// \param batch_size batch size.
+  /// \return a Scan node if succeed.
   static ::arrow::Result<std::unique_ptr<Scan>> Make(
       const std::vector<FileReaderWithSchema>& readers, int64_t batch_size);
 
   Scan() = delete;
 
-  virtual ~Scan() = default;
+  ~Scan() override = default;
 
   constexpr Type type() const override { return Type::kScan; }
 
   /// Returns the next available batch in the file. Or returns nullptr if EOF.
   ::arrow::Result<ScanBatch> Next() override;
 
+  /// Debug String
   std::string ToString() const override;
 
   /// Seek to a particular row.

--- a/cpp/src/lance/io/exec/scan.h
+++ b/cpp/src/lance/io/exec/scan.h
@@ -42,11 +42,6 @@ class Scan : public ExecNode {
       std::tuple<std::shared_ptr<FileReader>, std::shared_ptr<lance::format::Schema>>;
 
   /// Factory method.
-  static ::arrow::Result<std::unique_ptr<Scan>> Make(std::shared_ptr<FileReader> reader,
-                                                     std::shared_ptr<lance::format::Schema> schema,
-                                                     int64_t batch_size);
-
-  /// Factory method.
   ///
   /// \param readers a vector of the tuples of `[reader, schema]`, including opened file reader
   ///                and projection schema.

--- a/cpp/src/lance/io/exec/scan_test.cc
+++ b/cpp/src/lance/io/exec/scan_test.cc
@@ -30,8 +30,6 @@ using lance::io::exec::Scan;
 using lance::testing::MakeReader;
 
 TEST_CASE("Test Scan::Next") {
-  CHECK(::arrow::SetCpuThreadPoolCapacity(8).ok());
-
   std::vector<int32_t> ints(20);
   std::iota(ints.begin(), ints.end(), 0);
   auto schema = ::arrow::schema({
@@ -75,8 +73,6 @@ TEST_CASE("Test Scan::Next") {
 }
 
 TEST_CASE("Scan move to the next batch") {
-  CHECK(::arrow::SetCpuThreadPoolCapacity(8).ok());
-  
   const auto kNumBatches = 3;
   const auto kPageLength = 20;
   ::arrow::ArrayVector arrs;

--- a/cpp/src/lance/io/exec/scan_test.cc
+++ b/cpp/src/lance/io/exec/scan_test.cc
@@ -30,6 +30,8 @@ using lance::io::exec::Scan;
 using lance::testing::MakeReader;
 
 TEST_CASE("Test Scan::Next") {
+  CHECK(::arrow::SetCpuThreadPoolCapacity(8).ok());
+
   std::vector<int32_t> ints(20);
   std::iota(ints.begin(), ints.end(), 0);
   auto schema = ::arrow::schema({
@@ -73,6 +75,8 @@ TEST_CASE("Test Scan::Next") {
 }
 
 TEST_CASE("Scan move to the next batch") {
+  CHECK(::arrow::SetCpuThreadPoolCapacity(8).ok());
+  
   const auto kNumBatches = 3;
   const auto kPageLength = 20;
   ::arrow::ArrayVector arrs;

--- a/cpp/src/lance/io/exec/scan_test.cc
+++ b/cpp/src/lance/io/exec/scan_test.cc
@@ -118,10 +118,8 @@ TEST_CASE("Scan with multiple readers") {
   auto strs_reader = MakeReader(strs_table).ValueOrDie();
   auto strs_schema = std::make_shared<lance::format::Schema>(strs_table->schema());
 
-  auto scan = Scan::Make({{std::move(ints_reader), std::move(ints_schema)},
-                          {std::move(strs_reader), std::move(strs_schema)}},
-                         100)
-                  .ValueOrDie();
+  auto scan =
+      Scan::Make({{ints_reader, ints_schema}, {strs_reader, strs_schema}}, 100).ValueOrDie();
   auto expected = arrow::RecordBatch::Make(
       arrow::schema({arrow::field("ints", arrow::int32()), arrow::field("strs", arrow::utf8())}),
       5,

--- a/cpp/src/lance/io/exec/scan_test.cc
+++ b/cpp/src/lance/io/exec/scan_test.cc
@@ -45,7 +45,7 @@ TEST_CASE("Test Scan::Next") {
 
   const int32_t kBatchSize = 8;
   auto scan =
-      Scan::Make(reader, std::make_shared<Schema>(reader->schema()), kBatchSize).ValueOrDie();
+      Scan::Make({{reader, std::make_shared<Schema>(reader->schema())}}, kBatchSize).ValueOrDie();
   auto batch = scan->Next().ValueOrDie();
   CHECK(batch.batch_id == 0);
   CHECK(batch.batch->num_rows() == kBatchSize);
@@ -91,7 +91,7 @@ TEST_CASE("Scan move to the next batch") {
   // A batch size that is aligned with the page boundary.
   const int32_t kBatchSize = 4;
   auto scan =
-      Scan::Make(reader, std::make_shared<Schema>(reader->schema()), kBatchSize).ValueOrDie();
+      Scan::Make({{reader, std::make_shared<Schema>(reader->schema())}}, kBatchSize).ValueOrDie();
   auto num_batches = 0;
   while (true) {
     auto batch = scan->Next().ValueOrDie();


### PR DESCRIPTION
As the leaf execution node, allows ScanNode to reads multiple files within the same fragment, thus the DataFragment / schema evolution details are hidden from the rest of the I/O execution stack (other than Take probably.)