### PR TITLE
Add lance.util.duckdb to help install the extension transparently

### DIFF
--- a/.github/workflows/build_mac_wheel/action.yml
+++ b/.github/workflows/build_mac_wheel/action.yml
@@ -14,6 +14,7 @@ runs:
       uses: pypa/cibuildwheel@v2.8.1
       env:
         CIBW_BUILD: cp3${{ inputs.python-minor-version }}*
+        CIBW_TEST_SKIP: "*"
       with:
         package-dir: python
         output-dir: python/wheels

--- a/python/lance/tests/util/test_duckdb.py
+++ b/python/lance/tests/util/test_duckdb.py
@@ -1,0 +1,13 @@
+"""Test duckdb extension install"""
+from pathlib import Path
+
+import duckdb
+import torch
+
+from lance.util.duckdb import install_duckdb_extension
+
+
+def test_ext(tmp_path: Path):
+    install_duckdb_extension()
+    con = duckdb.connect(config={'allow_unsigned_extensions': True})
+    con.load_extension('lance')  # make sure this works

--- a/python/lance/tests/util/test_duckdb_ext.py
+++ b/python/lance/tests/util/test_duckdb_ext.py
@@ -1,12 +1,17 @@
 """Test duckdb extension install"""
+import os
 from pathlib import Path
+import platform
 
 import duckdb
+import pytest
 import torch
 
 from lance.util.duckdb_ext import install_duckdb_extension
 
 
+@pytest.mark.skipif(platform.system() == 'Darwin' and os.environ["GITHUB_ACTIONS"] == "true",
+                    reason="virtualization issue")
 def test_ext(tmp_path: Path):
     install_duckdb_extension()
     con = duckdb.connect(config={'allow_unsigned_extensions': True})

--- a/python/lance/tests/util/test_duckdb_ext.py
+++ b/python/lance/tests/util/test_duckdb_ext.py
@@ -10,7 +10,7 @@ import torch
 from lance.util.duckdb_ext import install_duckdb_extension
 
 
-@pytest.mark.skipif(platform.system() == 'Darwin' and os.environ["GITHUB_ACTIONS"] == "true",
+@pytest.mark.skipif(platform.system() == 'Darwin' and os.environ.get("GITHUB_ACTIONS") == "true",
                     reason="virtualization issue")
 def test_ext(tmp_path: Path):
     install_duckdb_extension()

--- a/python/lance/tests/util/test_duckdb_ext.py
+++ b/python/lance/tests/util/test_duckdb_ext.py
@@ -4,7 +4,7 @@ from pathlib import Path
 import duckdb
 import torch
 
-from lance.util.duckdb import install_duckdb_extension
+from lance.util.duckdb_ext import install_duckdb_extension
 
 
 def test_ext(tmp_path: Path):

--- a/python/lance/util/duckdb.py
+++ b/python/lance/util/duckdb.py
@@ -1,0 +1,68 @@
+import duckdb
+import os
+import pathlib
+import platform
+import torch
+import urllib.request
+import zipfile
+
+
+def install_duckdb_extension(version='latest', unsigned=True):
+    """
+    Install the lance duckdb extension
+
+    Parameters
+    ----------
+    version: str, default 'latest'
+        The version of the extension to install
+    unsigned: bool, default True
+        Whether to turn on allow_unsigned_extensions in duckdb
+    """
+    if version == 'latest':
+        version = _get_latest_version('lance', 'lance_duckdb')
+    uri = _get_uri(version)
+    local_path = _download_and_unzip('lance', 'lance_duckdb', uri)
+    con = duckdb.connect(config={"allow_unsigned_extensions": unsigned})
+    con.install_extension(local_path, force_install=True)
+
+
+def _get_uri(version):
+    uname = platform.uname()
+    arch = uname.machine  # arm64, x86_64
+    system = uname.system
+    device = _get_device()
+    zip_name = f'lance.duckdb_extension.{system}.{arch}.{device}.zip'
+    uri_root = 'https://eto-public.s3.us-west-2.amazonaws.com/'
+    uri = os.path.join(uri_root, 'artifacts', 'lance', 'lance_duckdb',
+                       version, zip_name)
+    return uri
+
+
+def _get_device():
+    import torch
+    if torch.cuda.is_available():
+        return f"cu{torch.version.cuda.replace('.', '')}"
+    else:
+        return 'cpu'
+
+
+def _get_latest_version(org='lance', ext='lance_duckdb'):
+    uri_root = 'https://eto-public.s3.us-west-2.amazonaws.com/'
+    uri = os.path.join(uri_root, 'artifacts', org, ext, 'latest')
+    filehandle, _ = urllib.request.urlretrieve(uri)
+    with open(filehandle, 'r') as fh:
+        return fh.read().strip()
+
+
+def _download_and_unzip(org, ext, uri):
+    filehandle, _ = urllib.request.urlretrieve(uri)
+    zip_file_object = zipfile.ZipFile(filehandle, 'r')
+    first_file = zip_file_object.namelist()[0]
+    ext_path = f'/tmp/{org}/{ext}'
+    os.makedirs(ext_path, exist_ok=True)
+    output_path = f'{ext_path}/{pathlib.Path(first_file).name}'
+    with zip_file_object.open(first_file) as in_:
+        content = in_.read()
+        with open(output_path, 'wb') as out_:
+            out_.write(content)
+    return output_path

--- a/python/lance/util/duckdb_ext.py
+++ b/python/lance/util/duckdb_ext.py
@@ -28,12 +28,26 @@ def install_duckdb_extension(version='latest'):
     version: str, default 'latest'
         The version of the extension to install
     """
+    _check_duckdb_version()
     if version == 'latest':
         version = _get_latest_version('lance', 'lance_duckdb')
     uri = _get_uri(version)
     local_path = _download_and_unzip('lance', 'lance_duckdb', uri)
     con = duckdb.connect(config={"allow_unsigned_extensions": True})
     con.install_extension(local_path, force_install=True)
+
+
+def _check_duckdb_version():
+    """
+    Currently the extension is pre-built for v0.5.1 of duckdb and duckdb
+    does not support binary compatibility between patch versions
+    """
+    CURR_VER = "0.5.1"
+    if duckdb.__version__ != CURR_VER:
+        msg = (f"The lance extension is built against DuckDB version f{CURR_VER} but "
+               f"{duckdb.__version__} was found. Please `pip install --force-reinstall duckdb=={CURR_VER}` "
+               f"OR build the extension from source against your version of duckdb")
+        raise ImportError(msg)
 
 
 def _get_uri(version):

--- a/python/lance/util/duckdb_ext.py
+++ b/python/lance/util/duckdb_ext.py
@@ -1,3 +1,16 @@
+#  Copyright 2022 Lance Developers
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+
 import duckdb
 import os
 import pathlib
@@ -6,7 +19,7 @@ import urllib.request
 import zipfile
 
 
-def install_duckdb_extension(version='latest', unsigned=True):
+def install_duckdb_extension(version='latest'):
     """
     Install the lance duckdb extension
 
@@ -14,14 +27,12 @@ def install_duckdb_extension(version='latest', unsigned=True):
     ----------
     version: str, default 'latest'
         The version of the extension to install
-    unsigned: bool, default True
-        Whether to turn on allow_unsigned_extensions in duckdb
     """
     if version == 'latest':
         version = _get_latest_version('lance', 'lance_duckdb')
     uri = _get_uri(version)
     local_path = _download_and_unzip('lance', 'lance_duckdb', uri)
-    con = duckdb.connect(config={"allow_unsigned_extensions": unsigned})
+    con = duckdb.connect(config={"allow_unsigned_extensions": True})
     con.install_extension(local_path, force_install=True)
 
 

--- a/python/lance/util/duckdb_ext.py
+++ b/python/lance/util/duckdb_ext.py
@@ -2,7 +2,6 @@ import duckdb
 import os
 import pathlib
 import platform
-import torch
 import urllib.request
 import zipfile
 
@@ -30,6 +29,7 @@ def _get_uri(version):
     uname = platform.uname()
     arch = uname.machine  # arm64, x86_64
     system = uname.system
+    system = "osx" if system.lower() == "darwin" else system
     device = _get_device()
     zip_name = f'lance.duckdb_extension.{system}.{arch}.{device}.zip'
     uri_root = 'https://eto-public.s3.us-west-2.amazonaws.com/'


### PR DESCRIPTION
It's too complicated to make users go through the installation process themselves. Instead let's create a small python utility function. In a python-centric workflow, this will be the easiest method. Alternatives can also be considered like providing a torch-like website or a command line utility that the user needs to download.