### PR TITLE
[C++] Use LanceFragment to build I/O exec plan

### DIFF
--- a/cpp/src/lance/arrow/CMakeLists.txt
+++ b/cpp/src/lance/arrow/CMakeLists.txt
@@ -21,6 +21,8 @@ add_library(
         dataset.cc
         file_lance.cc
         file_lance_ext.h
+        fragment.cc
+        fragment.h
         scanner.cc
         stl.h
         type.cc
@@ -34,6 +36,7 @@ target_include_directories(arrow SYSTEM PRIVATE ${Protobuf_INCLUDE_DIR})
 add_lance_test(api_test)
 add_lance_test(arrow_dataset_test)
 add_lance_test(dataset_test)
+add_lance_test(fragment_test)
 add_lance_test(scanner_test)
 add_lance_test(type_test)
 add_lance_test(utils_test)

--- a/cpp/src/lance/arrow/file_lance.cc
+++ b/cpp/src/lance/arrow/file_lance.cc
@@ -104,9 +104,8 @@ bool LanceFileFormat::Equals(const FileFormat& other) const {
     const std::shared_ptr<::arrow::dataset::FileFragment>& file) const {
   ARROW_ASSIGN_OR_RAISE(auto infile, file->source().Open());
   ARROW_ASSIGN_OR_RAISE(auto reader, lance::io::FileReader::Make(infile, impl_->manifest));
-  auto batch_reader = lance::io::RecordBatchReader(
-      std::move(reader), options, ::arrow::internal::GetCpuThreadPool());
-  ARROW_RETURN_NOT_OK(batch_reader.Open());
+  ARROW_ASSIGN_OR_RAISE(auto batch_reader,
+                        lance::io::RecordBatchReader::Make(std::move(reader), options));
   return ::arrow::RecordBatchGenerator(std::move(batch_reader));
 }
 

--- a/cpp/src/lance/arrow/file_lance.cc
+++ b/cpp/src/lance/arrow/file_lance.cc
@@ -23,6 +23,7 @@
 #include <utility>
 
 #include "lance/arrow/file_lance_ext.h"
+#include "lance/arrow/fragment.h"
 #include "lance/format/manifest.h"
 #include "lance/format/schema.h"
 #include "lance/io/exec/project.h"
@@ -102,10 +103,9 @@ bool LanceFileFormat::Equals(const FileFormat& other) const {
 ::arrow::Result<::arrow::RecordBatchGenerator> LanceFileFormat::ScanBatchesAsync(
     const std::shared_ptr<::arrow::dataset::ScanOptions>& options,
     const std::shared_ptr<::arrow::dataset::FileFragment>& file) const {
-  ARROW_ASSIGN_OR_RAISE(auto infile, file->source().Open());
-  ARROW_ASSIGN_OR_RAISE(auto reader, lance::io::FileReader::Make(infile, impl_->manifest));
+  ARROW_ASSIGN_OR_RAISE(auto fragment, LanceFragment::Make(*file, impl_->manifest->schema()));
   ARROW_ASSIGN_OR_RAISE(auto batch_reader,
-                        lance::io::RecordBatchReader::Make(std::move(reader), options));
+                        lance::io::RecordBatchReader::Make(*fragment, options));
   return ::arrow::RecordBatchGenerator(std::move(batch_reader));
 }
 

--- a/cpp/src/lance/arrow/file_lance_ext.h
+++ b/cpp/src/lance/arrow/file_lance_ext.h
@@ -23,31 +23,6 @@
 
 namespace lance::arrow {
 
-/// LanceFragment, a fragment of data.
-class LanceFragment : public ::arrow::dataset::Fragment {
- public:
-  LanceFragment(std::shared_ptr<::arrow::fs::FileSystem> fs,
-                std::string data_dir,
-                std::shared_ptr<lance::format::DataFragment> fragment,
-                const format::Schema& schema);
-
-  ~LanceFragment() override = default;
-
-  ::arrow::Result<::arrow::RecordBatchGenerator> ScanBatchesAsync(
-      const std::shared_ptr<::arrow::dataset::ScanOptions>& options) override;
-
-  std::string type_name() const override { return "lance"; }
-
- protected:
-  ::arrow::Result<std::shared_ptr<::arrow::Schema>> ReadPhysicalSchemaImpl() override;
-
- private:
-  std::shared_ptr<::arrow::fs::FileSystem> fs_;
-  std::string data_uri_;
-  std::shared_ptr<lance::format::DataFragment> fragment_;
-  const format::Schema& schema_;
-};
-
 /// Lance FragmentScanOptions.
 ///
 /// Extra lance scan options.

--- a/cpp/src/lance/arrow/fragment.cc
+++ b/cpp/src/lance/arrow/fragment.cc
@@ -45,9 +45,8 @@ LanceFragment::LanceFragment(std::shared_ptr<::arrow::fs::FileSystem> fs,
     const std::shared_ptr<::arrow::dataset::ScanOptions>& options) {
   for (std::size_t i = 0; i < fragment_->data_files().size(); ++i) {
     ARROW_ASSIGN_OR_RAISE(auto reader, OpenReader(i));
-    auto batch_reader = lance::io::RecordBatchReader(
-        std::move(reader), options, ::arrow::internal::GetCpuThreadPool());
-    ARROW_RETURN_NOT_OK(batch_reader.Open());
+    ARROW_ASSIGN_OR_RAISE(auto batch_reader,
+                          lance::io::RecordBatchReader::Make(std::move(reader), options));
     return ::arrow::RecordBatchGenerator(std::move(batch_reader));
   }
   return ::arrow::Status::IOError("Lance Fragment has zero file");

--- a/cpp/src/lance/arrow/fragment.cc
+++ b/cpp/src/lance/arrow/fragment.cc
@@ -43,13 +43,8 @@ LanceFragment::LanceFragment(std::shared_ptr<::arrow::fs::FileSystem> fs,
 
 ::arrow::Result<::arrow::RecordBatchGenerator> LanceFragment::ScanBatchesAsync(
     const std::shared_ptr<::arrow::dataset::ScanOptions>& options) {
-  for (std::size_t i = 0; i < fragment_->data_files().size(); ++i) {
-    ARROW_ASSIGN_OR_RAISE(auto reader, OpenReader(i));
-    ARROW_ASSIGN_OR_RAISE(auto batch_reader,
-                          lance::io::RecordBatchReader::Make(std::move(reader), options));
-    return ::arrow::RecordBatchGenerator(std::move(batch_reader));
-  }
-  return ::arrow::Status::IOError("Lance Fragment has zero file");
+  ARROW_ASSIGN_OR_RAISE(auto batch_reader, lance::io::RecordBatchReader::Make(*this, options));
+  return ::arrow::RecordBatchGenerator(std::move(batch_reader));
 }
 
 ::arrow::Result<std::shared_ptr<::arrow::Schema>> LanceFragment::ReadPhysicalSchemaImpl() {

--- a/cpp/src/lance/arrow/fragment.cc
+++ b/cpp/src/lance/arrow/fragment.cc
@@ -1,0 +1,77 @@
+//  Copyright 2022 Lance Authors
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+
+#include "lance/arrow/fragment.h"
+
+#include <arrow/array/concatenate.h>
+#include <arrow/chunked_array.h>
+#include <arrow/table.h>
+
+#include <filesystem>
+
+#include "lance/arrow/file_lance.h"
+#include "lance/arrow/utils.h"
+#include "lance/format/data_fragment.h"
+#include "lance/format/schema.h"
+#include "lance/io/reader.h"
+#include "lance/io/record_batch_reader.h"
+#include "lance/io/writer.h"
+
+namespace fs = std::filesystem;
+
+namespace lance::arrow {
+
+LanceFragment::LanceFragment(std::shared_ptr<::arrow::fs::FileSystem> fs,
+                             std::string data_dir,
+                             std::shared_ptr<lance::format::DataFragment> fragment,
+                             std::shared_ptr<format::Schema> schema)
+    : fs_(std::move(fs)),
+      data_uri_(std::move(data_dir)),
+      fragment_(std::move(fragment)),
+      schema_(std::move(schema)) {}
+
+::arrow::Result<::arrow::RecordBatchGenerator> LanceFragment::ScanBatchesAsync(
+    const std::shared_ptr<::arrow::dataset::ScanOptions>& options) {
+  fmt::print("Fragment data files: {}\n", fragment_->data_files().size());
+
+  for (std::size_t i = 0; i < fragment_->data_files().size(); ++i) {
+    ARROW_ASSIGN_OR_RAISE(auto reader, OpenReader(i));
+    auto batch_reader = lance::io::RecordBatchReader(
+        std::move(reader), options, ::arrow::internal::GetCpuThreadPool());
+    ARROW_RETURN_NOT_OK(batch_reader.Open());
+    return ::arrow::RecordBatchGenerator(std::move(batch_reader));
+  }
+  return ::arrow::Status::IOError("Lance Fragment has zero file");
+}
+
+::arrow::Result<std::shared_ptr<::arrow::Schema>> LanceFragment::ReadPhysicalSchemaImpl() {
+  return schema_->ToArrow();
+}
+
+::arrow::Result<int64_t> LanceFragment::FastCountRow() const {
+  assert(!fragment_->data_files().empty());
+  ARROW_ASSIGN_OR_RAISE(auto reader, OpenReader(0));
+  return reader->length();
+}
+
+::arrow::Result<std::unique_ptr<lance::io::FileReader>> LanceFragment::OpenReader(
+    std::size_t data_file_idx) const {
+  assert(data_file_idx < fragment_->data_files().size());
+  auto data_file = fragment_->data_files()[data_file_idx];
+  auto full_path = (fs::path(data_uri_) / data_file.path()).string();
+  ARROW_ASSIGN_OR_RAISE(auto infile, fs_->OpenInputFile(full_path));
+  return lance::io::FileReader::Make(infile);
+}
+
+}  // namespace lance::arrow

--- a/cpp/src/lance/arrow/fragment.cc
+++ b/cpp/src/lance/arrow/fragment.cc
@@ -43,8 +43,6 @@ LanceFragment::LanceFragment(std::shared_ptr<::arrow::fs::FileSystem> fs,
 
 ::arrow::Result<::arrow::RecordBatchGenerator> LanceFragment::ScanBatchesAsync(
     const std::shared_ptr<::arrow::dataset::ScanOptions>& options) {
-  fmt::print("Fragment data files: {}\n", fragment_->data_files().size());
-
   for (std::size_t i = 0; i < fragment_->data_files().size(); ++i) {
     ARROW_ASSIGN_OR_RAISE(auto reader, OpenReader(i));
     auto batch_reader = lance::io::RecordBatchReader(

--- a/cpp/src/lance/arrow/fragment.cc
+++ b/cpp/src/lance/arrow/fragment.cc
@@ -51,6 +51,20 @@ LanceFragment::LanceFragment(std::shared_ptr<::arrow::fs::FileSystem> fs,
   return schema_->ToArrow();
 }
 
+::arrow::Result<std::vector<LanceFragment::FileReaderWithSchema>> LanceFragment::Open(
+    const format::Schema& schema) const {
+  fmt::print("Filter by schema; {}\n", schema);
+  std::vector<LanceFragment::FileReaderWithSchema> readers;
+  for (auto& data_file : fragment_->data_files()) {
+//    auto data_file_schema = schema_->Project(data_file.fields());
+    auto full_path = (fs::path(data_uri_) / data_file.path()).string();
+    ARROW_ASSIGN_OR_RAISE(auto infile, fs_->OpenInputFile(full_path))
+    ARROW_ASSIGN_OR_RAISE(auto reader, lance::io::FileReader::Make(infile));
+    readers.emplace_back(std::make_tuple(std::move(reader), schema_));
+  }
+  return std::move(readers);
+}
+
 ::arrow::Result<int64_t> LanceFragment::FastCountRow() const {
   assert(!fragment_->data_files().empty());
   ARROW_ASSIGN_OR_RAISE(auto reader, OpenReader(0));

--- a/cpp/src/lance/arrow/fragment.h
+++ b/cpp/src/lance/arrow/fragment.h
@@ -1,0 +1,87 @@
+//  Copyright 2022 Lance Authors
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+
+#pragma once
+
+#include <arrow/dataset/api.h>
+
+#include <cstdint>
+#include <memory>
+#include <string>
+
+#include "lance/format/data_fragment.h"
+#include "lance/format/schema.h"
+
+namespace lance::io {
+class FileReader;
+}
+
+namespace lance::arrow {
+
+/// \brief LanceFragment. a fragment of data.
+///
+/// Physically, it contains a set of lance files, each of which represents subset of
+/// columns of the same rows in dataset.
+///
+class LanceFragment : public ::arrow::dataset::Fragment {
+ public:
+  /// Constructor
+  ///
+  /// \param fs a file system instance to conduct IOs.
+  /// \param data_dir the base directory to store data.
+  /// \param fragment data fragment, the metadata of the fragment.
+  /// \param schema the schema of the Fragment.
+  LanceFragment(std::shared_ptr<::arrow::fs::FileSystem> fs,
+                std::string data_dir,
+                std::shared_ptr<lance::format::DataFragment> fragment,
+                std::shared_ptr<format::Schema> schema);
+
+  /// Destructor.
+  ~LanceFragment() override = default;
+
+  /// Scan Batches.
+  ///
+  /// \param options ScanOptions.
+  /// \return `RecordBatchGenerator` if succeed. Otherwise, the error message.
+  ::arrow::Result<::arrow::RecordBatchGenerator> ScanBatchesAsync(
+      const std::shared_ptr<::arrow::dataset::ScanOptions>& options) override;
+
+  std::string type_name() const override { return "lance"; }
+
+  /// Access data fragment.
+  const std::shared_ptr<lance::format::DataFragment>& data_fragment() const { return fragment_; }
+
+  const std::shared_ptr<format::Schema>& schema() const { return schema_; }
+
+ protected:
+  ::arrow::Result<std::shared_ptr<::arrow::Schema>> ReadPhysicalSchemaImpl() override;
+
+ private:
+  /// Fast path `CountRow()`, it only reads the metadata of one data file.
+  ::arrow::Result<int64_t> FastCountRow() const;
+
+  /// Open file reader on a data file.
+  ///
+  /// \param data_file_idx the index of data file in `fragment_->data_files()`.
+  /// \return an Opened lance FileReader if success.
+  ::arrow::Result<std::unique_ptr<lance::io::FileReader>> OpenReader(
+      std::size_t data_file_idx) const;
+
+  std::shared_ptr<::arrow::fs::FileSystem> fs_;
+  std::string data_uri_;
+  std::shared_ptr<lance::format::DataFragment> fragment_;
+  std::shared_ptr<format::Schema> schema_;
+};
+
+}  // namespace lance::arrow

--- a/cpp/src/lance/arrow/fragment.h
+++ b/cpp/src/lance/arrow/fragment.h
@@ -19,6 +19,7 @@
 #include <cstdint>
 #include <memory>
 #include <string>
+#include <tuple>
 #include <vector>
 
 #include "lance/format/data_fragment.h"
@@ -37,6 +38,9 @@ namespace lance::arrow {
 ///
 class LanceFragment : public ::arrow::dataset::Fragment {
  public:
+  using FileReaderWithSchema =
+      std::tuple<std::shared_ptr<lance::io::FileReader>, std::shared_ptr<format::Schema>>;
+
   /// Constructor
   ///
   /// \param fs a file system instance to conduct IOs.
@@ -62,6 +66,8 @@ class LanceFragment : public ::arrow::dataset::Fragment {
 
   /// Access data fragment.
   const std::shared_ptr<lance::format::DataFragment>& data_fragment() const { return fragment_; }
+
+  ::arrow::Result<std::vector<FileReaderWithSchema>> Open(const format::Schema& schema) const;
 
   /// Data files.
   const std::vector<lance::format::DataFile>& data_files() const { return fragment_->data_files(); }

--- a/cpp/src/lance/arrow/fragment.h
+++ b/cpp/src/lance/arrow/fragment.h
@@ -19,6 +19,7 @@
 #include <cstdint>
 #include <memory>
 #include <string>
+#include <vector>
 
 #include "lance/format/data_fragment.h"
 #include "lance/format/schema.h"
@@ -62,6 +63,10 @@ class LanceFragment : public ::arrow::dataset::Fragment {
   /// Access data fragment.
   const std::shared_ptr<lance::format::DataFragment>& data_fragment() const { return fragment_; }
 
+  /// Data files.
+  const std::vector<lance::format::DataFile>& data_files() const { return fragment_->data_files(); }
+
+  /// Dataset schema.
   const std::shared_ptr<format::Schema>& schema() const { return schema_; }
 
  protected:

--- a/cpp/src/lance/arrow/fragment.h
+++ b/cpp/src/lance/arrow/fragment.h
@@ -41,6 +41,15 @@ class LanceFragment : public ::arrow::dataset::Fragment {
   using FileReaderWithSchema =
       std::tuple<std::shared_ptr<lance::io::FileReader>, std::shared_ptr<format::Schema>>;
 
+  /// Factory method & Adaptor to plain dataset.
+  ///
+  /// It creates a LanceFragment from `arrow.dataset.FileFragment`.
+  /// \param file_fragment plain dataset file fragment
+  /// \param schema the schema of dataset.
+  /// \return LanceFragment
+  static ::arrow::Result<std::shared_ptr<LanceFragment>> Make(
+      const ::arrow::dataset::FileFragment& file_fragment, std::shared_ptr<format::Schema> schema);
+
   /// Constructor
   ///
   /// \param fs a file system instance to conduct IOs.
@@ -64,15 +73,10 @@ class LanceFragment : public ::arrow::dataset::Fragment {
 
   std::string type_name() const override { return "lance"; }
 
-  /// Access data fragment.
-  const std::shared_ptr<lance::format::DataFragment>& data_fragment() const { return fragment_; }
-
+  /// Open Data files that contains the columns in the schema.
   ::arrow::Result<std::vector<FileReaderWithSchema>> Open(
       const format::Schema& schema,
       ::arrow::internal::Executor* executor = ::arrow::internal::GetCpuThreadPool()) const;
-
-  /// Data files.
-  const std::vector<lance::format::DataFile>& data_files() const { return fragment_->data_files(); }
 
   /// Dataset schema.
   const std::shared_ptr<format::Schema>& schema() const { return schema_; }

--- a/cpp/src/lance/arrow/fragment.h
+++ b/cpp/src/lance/arrow/fragment.h
@@ -67,7 +67,9 @@ class LanceFragment : public ::arrow::dataset::Fragment {
   /// Access data fragment.
   const std::shared_ptr<lance::format::DataFragment>& data_fragment() const { return fragment_; }
 
-  ::arrow::Result<std::vector<FileReaderWithSchema>> Open(const format::Schema& schema) const;
+  ::arrow::Result<std::vector<FileReaderWithSchema>> Open(
+      const format::Schema& schema,
+      ::arrow::internal::Executor* executor = ::arrow::internal::GetCpuThreadPool()) const;
 
   /// Data files.
   const std::vector<lance::format::DataFile>& data_files() const { return fragment_->data_files(); }

--- a/cpp/src/lance/arrow/fragment_test.cc
+++ b/cpp/src/lance/arrow/fragment_test.cc
@@ -1,0 +1,80 @@
+//  Copyright 2022 Lance Authors
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+
+#include "lance/arrow/fragment.h"
+
+#include <arrow/api.h>
+#include <arrow/filesystem/localfs.h>
+#include <arrow/table.h>
+#include <fmt/format.h>
+
+#include <catch2/catch_test_macros.hpp>
+#include <filesystem>
+#include <memory>
+#include <string>
+
+#include "lance/arrow/file_lance.h"
+#include "lance/arrow/stl.h"
+#include "lance/arrow/utils.h"
+#include "lance/io/writer.h"
+#include "lance/testing/io.h"
+
+using lance::arrow::ToArray;
+namespace fs = std::filesystem;
+
+/// Make one lance format from the table.
+std::shared_ptr<lance::arrow::LanceFragment> MakeFragment(
+    const std::shared_ptr<::arrow::Table>& table) {
+  auto data_dir = lance::testing::MakeTemporaryDir().ValueOrDie();
+  auto fs = std::make_shared<::arrow::fs::LocalFileSystem>();
+  std::string filename(fs::path(data_dir) / "12345-67890.lance");
+  auto output = fs->OpenOutputStream(filename).ValueOrDie();
+
+  {
+    auto write_options = lance::arrow::LanceFileFormat().DefaultWriteOptions();
+    auto writer = lance::io::FileWriter(table->schema(), write_options, output);
+    auto batch_reader = ::arrow::TableBatchReader(table);
+    std::shared_ptr<::arrow::RecordBatch> batch;
+    while (true) {
+      CHECK(batch_reader.ReadNext(&batch).ok());
+      if (batch == nullptr) {
+        break;
+      }
+      CHECK(writer.Write(batch).ok());
+    }
+    writer.Finish().Wait();
+  }
+
+  auto schema = std::make_shared<lance::format::Schema>(table->schema());
+  auto data_file = lance::format::DataFile(filename, schema->GetFieldIds());
+  auto fragment = std::make_shared<lance::format::DataFragment>(data_file);
+  return std::make_shared<lance::arrow::LanceFragment>(
+      fs, data_dir, std::move(fragment), std::move(schema));
+};
+
+TEST_CASE("Read fragment with one file") {
+  auto arr = ToArray({1, 2, 3, 4, 5}).ValueOrDie();
+  auto t = arrow::Table::Make(::arrow::schema({::arrow::field("int", arr->type())}), {arr});
+
+  auto fragment = MakeFragment(t);
+
+  auto scan_options = std::make_shared<::arrow::dataset::ScanOptions>();
+  scan_options->dataset_schema = t->schema();
+  scan_options->projected_schema = t->schema();
+  auto generator = fragment->ScanBatchesAsync(scan_options).ValueOrDie();
+  auto batch = generator().result().ValueOrDie();
+
+  CHECK(batch->schema()->Equals(*t->schema()));
+  CHECK(arr->Equals(batch->GetColumnByName("int")));
+}

--- a/cpp/src/lance/arrow/fragment_test.cc
+++ b/cpp/src/lance/arrow/fragment_test.cc
@@ -17,57 +17,24 @@
 #include <arrow/api.h>
 #include <arrow/filesystem/localfs.h>
 #include <arrow/table.h>
-#include <fmt/format.h>
 
 #include <catch2/catch_test_macros.hpp>
-#include <filesystem>
 #include <memory>
 #include <string>
 
 #include "lance/arrow/file_lance.h"
 #include "lance/arrow/stl.h"
-#include "lance/arrow/utils.h"
 #include "lance/io/writer.h"
 #include "lance/testing/io.h"
 
 using lance::arrow::ToArray;
-namespace fs = std::filesystem;
-
-/// Make one lance format from the table.
-std::shared_ptr<lance::arrow::LanceFragment> MakeFragment(
-    const std::shared_ptr<::arrow::Table>& table) {
-  auto data_dir = lance::testing::MakeTemporaryDir().ValueOrDie();
-  auto fs = std::make_shared<::arrow::fs::LocalFileSystem>();
-  std::string filename(fs::path(data_dir) / "12345-67890.lance");
-  auto output = fs->OpenOutputStream(filename).ValueOrDie();
-
-  {
-    auto write_options = lance::arrow::LanceFileFormat().DefaultWriteOptions();
-    auto writer = lance::io::FileWriter(table->schema(), write_options, output);
-    auto batch_reader = ::arrow::TableBatchReader(table);
-    std::shared_ptr<::arrow::RecordBatch> batch;
-    while (true) {
-      CHECK(batch_reader.ReadNext(&batch).ok());
-      if (batch == nullptr) {
-        break;
-      }
-      CHECK(writer.Write(batch).ok());
-    }
-    writer.Finish().Wait();
-  }
-
-  auto schema = std::make_shared<lance::format::Schema>(table->schema());
-  auto data_file = lance::format::DataFile(filename, schema->GetFieldIds());
-  auto fragment = std::make_shared<lance::format::DataFragment>(data_file);
-  return std::make_shared<lance::arrow::LanceFragment>(
-      fs, data_dir, std::move(fragment), std::move(schema));
-};
+using lance::testing::MakeFragment;
 
 TEST_CASE("Read fragment with one file") {
   auto arr = ToArray({1, 2, 3, 4, 5}).ValueOrDie();
   auto t = arrow::Table::Make(::arrow::schema({::arrow::field("int", arr->type())}), {arr});
 
-  auto fragment = MakeFragment(t);
+  auto fragment = MakeFragment(t).ValueOrDie();
 
   auto scan_options = std::make_shared<::arrow::dataset::ScanOptions>();
   scan_options->dataset_schema = t->schema();

--- a/cpp/src/lance/arrow/utils.h
+++ b/cpp/src/lance/arrow/utils.h
@@ -55,4 +55,7 @@ namespace lance::arrow {
 ::arrow::Result<std::shared_ptr<::arrow::dataset::FileSystemDataset>> OpenDataset(
     const std::string& uri, std::shared_ptr<::arrow::dataset::Partitioning> partitioning = nullptr);
 
+/// Get UUID string.
+std::string GetUUIDString();
+
 }  // namespace lance::arrow

--- a/cpp/src/lance/format/manifest.cc
+++ b/cpp/src/lance/format/manifest.cc
@@ -75,7 +75,7 @@ std::shared_ptr<Manifest> Manifest::BumpVersion(bool overwrite) {
   return new_manifest;
 }
 
-const Schema& Manifest::schema() const { return *schema_; }
+const std::shared_ptr<Schema>& Manifest::schema() const { return schema_; }
 
 uint64_t Manifest::version() const { return version_; }
 

--- a/cpp/src/lance/format/manifest.h
+++ b/cpp/src/lance/format/manifest.h
@@ -65,7 +65,7 @@ class Manifest final {
   std::shared_ptr<Manifest> BumpVersion(bool overwrite = false);
 
   /// Get schema of the dataset.
-  const Schema& schema() const;
+  const std::shared_ptr<Schema>& schema() const;
 
   /// Returns the version number.
   uint64_t version() const;

--- a/cpp/src/lance/io/exec/project.cc
+++ b/cpp/src/lance/io/exec/project.cc
@@ -79,15 +79,41 @@ Project::Project(std::unique_ptr<ExecNode> child,
     std::shared_ptr<::arrow::dataset::ScanOptions> scan_options) {
   auto& schema = fragment.schema();
   ARROW_ASSIGN_OR_RAISE(auto projected_schema, schema->Project(*scan_options->projected_schema));
-  if (Filter::HasFilter(scan_options->filter)) {
 
+  std::shared_ptr<Counter> counter;
+  if (scan_options->fragment_scan_options &&
+      lance::arrow::IsLanceFragmentScanOptions(*scan_options->fragment_scan_options)) {
+    auto fso = std::dynamic_pointer_cast<lance::arrow::LanceFragmentScanOptions>(
+        scan_options->fragment_scan_options);
+    counter = fso->counter;
+  }
+
+  std::unique_ptr<ExecNode> child;
+  if (Filter::HasFilter(scan_options->filter)) {
+    ARROW_ASSIGN_OR_RAISE(auto filter_scan_schema, schema->Project(scan_options->filter));
+    std::vector<Scan::FileReaderWithSchema> filter_readers;
+    for (auto& data_file : fragment.data_files()) {
+      fmt::print("Data file: {}\n", data_file.path());
+    }
+    ARROW_ASSIGN_OR_RAISE(auto filter_scan_node,
+                          Scan::Make(filter_readers, scan_options->batch_size));
+    ARROW_ASSIGN_OR_RAISE(child, Filter::Make(scan_options->filter, std::move(filter_scan_node)));
+    if (counter) {
+      ARROW_ASSIGN_OR_RAISE(child, Limit::Make(counter, std::move(child)));
+    }
+    ARROW_ASSIGN_OR_RAISE(auto take_schema, projected_schema->Exclude(*filter_scan_schema));
+//    ARROW_ASSIGN_OR_RAISE(child, Take::Make(reader, take_schema, std::move(child)))
   } else {
     std::vector<Scan::FileReaderWithSchema> readers;
     for (auto& data_file : fragment.data_files()) {
       fmt::print("Data file: {}\n", data_file.path());
     }
+    ARROW_ASSIGN_OR_RAISE(child, Scan::Make(readers, scan_options->batch_size))
+    if (counter) {
+      ARROW_ASSIGN_OR_RAISE(child, Limit::Make(counter, std::move(child)));
+    }
   }
-  return ::arrow::Status::NotImplemented("not implemented");
+  return std::unique_ptr<Project>(new Project(std::move(child), std::move(projected_schema)));
 }
 
 std::string Project::ToString() const { return "Project"; }

--- a/cpp/src/lance/io/exec/project.cc
+++ b/cpp/src/lance/io/exec/project.cc
@@ -19,6 +19,7 @@
 #include <fmt/format.h>
 
 #include "lance/arrow/file_lance_ext.h"
+#include "lance/arrow/fragment.h"
 #include "lance/io/exec/filter.h"
 #include "lance/io/exec/limit.h"
 #include "lance/io/exec/scan.h"
@@ -71,6 +72,22 @@ Project::Project(std::unique_ptr<ExecNode> child,
     }
   }
   return std::unique_ptr<Project>(new Project(std::move(child), std::move(projected_schema)));
+}
+
+::arrow::Result<std::unique_ptr<Project>> Project::Make(
+    const lance::arrow::LanceFragment& fragment,
+    std::shared_ptr<::arrow::dataset::ScanOptions> scan_options) {
+  auto& schema = fragment.schema();
+  ARROW_ASSIGN_OR_RAISE(auto projected_schema, schema->Project(*scan_options->projected_schema));
+  if (Filter::HasFilter(scan_options->filter)) {
+
+  } else {
+    std::vector<Scan::FileReaderWithSchema> readers;
+    for (auto& data_file : fragment.data_files()) {
+      fmt::print("Data file: {}\n", data_file.path());
+    }
+  }
+  return ::arrow::Status::NotImplemented("not implemented");
 }
 
 std::string Project::ToString() const { return "Project"; }

--- a/cpp/src/lance/io/exec/project.cc
+++ b/cpp/src/lance/io/exec/project.cc
@@ -56,7 +56,7 @@ Project::Project(std::unique_ptr<ExecNode> child,
     ARROW_ASSIGN_OR_RAISE(auto filter_scan_schema, schema->Project(scan_options->filter));
     ARROW_ASSIGN_OR_RAISE(auto filter_readers, fragment.Open(*filter_scan_schema, executor));
     ARROW_ASSIGN_OR_RAISE(auto filter_scan_node,
-                          Scan::Make(filter_readers, scan_options->batch_size));
+                          Scan::Make(filter_readers, scan_options->batch_size, executor));
     ARROW_ASSIGN_OR_RAISE(child, Filter::Make(scan_options->filter, std::move(filter_scan_node)));
     if (counter) {
       ARROW_ASSIGN_OR_RAISE(child, Limit::Make(counter, std::move(child)));
@@ -65,12 +65,12 @@ Project::Project(std::unique_ptr<ExecNode> child,
     ARROW_ASSIGN_OR_RAISE(auto take_readers, fragment.Open(*take_schema, executor));
     std::unique_ptr<Scan> take_scan_node;
     if (!take_schema->fields().empty() && !take_readers.empty()) {
-      ARROW_ASSIGN_OR_RAISE(take_scan_node, Scan::Make(take_readers, 1));
+      ARROW_ASSIGN_OR_RAISE(take_scan_node, Scan::Make(take_readers, 1, executor));
     };
     child = std::make_unique<Take>(std::move(child), std::move(take_scan_node));
   } else {
     ARROW_ASSIGN_OR_RAISE(auto readers, fragment.Open(*projected_schema, executor));
-    ARROW_ASSIGN_OR_RAISE(child, Scan::Make(readers, scan_options->batch_size))
+    ARROW_ASSIGN_OR_RAISE(child, Scan::Make(readers, scan_options->batch_size, executor));
     if (counter) {
       ARROW_ASSIGN_OR_RAISE(child, Limit::Make(counter, std::move(child)));
     }

--- a/cpp/src/lance/io/exec/project.cc
+++ b/cpp/src/lance/io/exec/project.cc
@@ -33,52 +33,6 @@ Project::Project(std::unique_ptr<ExecNode> child,
     : child_(std::move(child)), projected_schema_(std::move(projected_schema)) {}
 
 ::arrow::Result<std::unique_ptr<Project>> Project::Make(
-    std::shared_ptr<FileReader> reader,
-    std::shared_ptr<::arrow::dataset::ScanOptions> scan_options) {
-  auto& schema = reader->schema();
-  auto projected_arrow_schema = scan_options->projected_schema;
-  if (projected_arrow_schema->num_fields() == 0) {
-    projected_arrow_schema = scan_options->dataset_schema;
-  }
-  ARROW_ASSIGN_OR_RAISE(auto projected_schema, schema.Project(*projected_arrow_schema));
-
-  std::shared_ptr<Counter> counter;
-  if (scan_options->fragment_scan_options &&
-      lance::arrow::IsLanceFragmentScanOptions(*scan_options->fragment_scan_options)) {
-    auto fso = std::dynamic_pointer_cast<lance::arrow::LanceFragmentScanOptions>(
-        scan_options->fragment_scan_options);
-    counter = fso->counter;
-  }
-  std::unique_ptr<ExecNode> child;
-  if (Filter::HasFilter(scan_options->filter)) {
-    /// Build a chain of:
-    ///
-    /// Take -> (optionally) Limit -> Filter -> Scan
-    ARROW_ASSIGN_OR_RAISE(auto filter_scan_schema, schema.Project(scan_options->filter));
-    ARROW_ASSIGN_OR_RAISE(auto filter_scan_node,
-                          Scan::Make({{reader, filter_scan_schema}}, scan_options->batch_size));
-    ARROW_ASSIGN_OR_RAISE(child, Filter::Make(scan_options->filter, std::move(filter_scan_node)));
-    if (counter) {
-      ARROW_ASSIGN_OR_RAISE(child, Limit::Make(counter, std::move(child)));
-    }
-    ARROW_ASSIGN_OR_RAISE(auto take_schema, projected_schema->Exclude(*filter_scan_schema));
-    std::unique_ptr<Scan> take_scan_node;
-    if (!take_schema->fields().empty()) {
-      ARROW_ASSIGN_OR_RAISE(take_scan_node, Scan::Make({{std::move(reader), take_schema}}, 1));
-    }
-    child = std::make_unique<Take>(std::move(child), std::move(take_scan_node));
-  } else {
-    /// (*optionally) Limit -> Scan
-    ARROW_ASSIGN_OR_RAISE(
-        child, Scan::Make({{std::move(reader), projected_schema}}, scan_options->batch_size));
-    if (counter) {
-      ARROW_ASSIGN_OR_RAISE(child, Limit::Make(counter, std::move(child)));
-    }
-  }
-  return std::unique_ptr<Project>(new Project(std::move(child), std::move(projected_schema)));
-}
-
-::arrow::Result<std::unique_ptr<Project>> Project::Make(
     const lance::arrow::LanceFragment& fragment,
     std::shared_ptr<::arrow::dataset::ScanOptions> scan_options) {
   auto& schema = fragment.schema();
@@ -96,10 +50,11 @@ Project::Project(std::unique_ptr<ExecNode> child,
     counter = fso->counter;
   }
 
+  auto executor = scan_options->io_context.executor();
   std::unique_ptr<ExecNode> child;
   if (Filter::HasFilter(scan_options->filter)) {
     ARROW_ASSIGN_OR_RAISE(auto filter_scan_schema, schema->Project(scan_options->filter));
-    ARROW_ASSIGN_OR_RAISE(auto filter_readers, fragment.Open(*filter_scan_schema));
+    ARROW_ASSIGN_OR_RAISE(auto filter_readers, fragment.Open(*filter_scan_schema, executor));
     ARROW_ASSIGN_OR_RAISE(auto filter_scan_node,
                           Scan::Make(filter_readers, scan_options->batch_size));
     ARROW_ASSIGN_OR_RAISE(child, Filter::Make(scan_options->filter, std::move(filter_scan_node)));
@@ -107,14 +62,14 @@ Project::Project(std::unique_ptr<ExecNode> child,
       ARROW_ASSIGN_OR_RAISE(child, Limit::Make(counter, std::move(child)));
     }
     ARROW_ASSIGN_OR_RAISE(auto take_schema, projected_schema->Exclude(*filter_scan_schema))
-    ARROW_ASSIGN_OR_RAISE(auto take_readers, fragment.Open(*take_schema));
+    ARROW_ASSIGN_OR_RAISE(auto take_readers, fragment.Open(*take_schema, executor));
     std::unique_ptr<Scan> take_scan_node;
     if (!take_schema->fields().empty() && !take_readers.empty()) {
       ARROW_ASSIGN_OR_RAISE(take_scan_node, Scan::Make(take_readers, 1));
     };
     child = std::make_unique<Take>(std::move(child), std::move(take_scan_node));
   } else {
-    ARROW_ASSIGN_OR_RAISE(auto readers, fragment.Open(*projected_schema));
+    ARROW_ASSIGN_OR_RAISE(auto readers, fragment.Open(*projected_schema, executor));
     ARROW_ASSIGN_OR_RAISE(child, Scan::Make(readers, scan_options->batch_size))
     if (counter) {
       ARROW_ASSIGN_OR_RAISE(child, Limit::Make(counter, std::move(child)));

--- a/cpp/src/lance/io/exec/project.h
+++ b/cpp/src/lance/io/exec/project.h
@@ -28,6 +28,10 @@ namespace lance::io {
 class FileReader;
 }
 
+namespace lance::arrow {
+class LanceFragment;
+}
+
 namespace lance::io::exec {
 
 /// \brief Projection over dataset.
@@ -47,6 +51,11 @@ class Project : ExecNode {
       std::shared_ptr<FileReader> reader,
       std::shared_ptr<::arrow::dataset::ScanOptions> scan_options);
 
+  static ::arrow::Result<std::unique_ptr<Project>> Make(
+      const lance::arrow::LanceFragment& fragment,
+      std::shared_ptr<::arrow::dataset::ScanOptions> scan_options);
+
+  /// Read the next batch. Returns nullptr if EOF.
   ::arrow::Result<ScanBatch> Next() override;
 
   constexpr Type type() const override { return kProject; }

--- a/cpp/src/lance/io/exec/project.h
+++ b/cpp/src/lance/io/exec/project.h
@@ -62,6 +62,8 @@ class Project : ExecNode {
 
   std::string ToString() const override;
 
+  const std::shared_ptr<lance::format::Schema>& schema() const { return projected_schema_; }
+
  private:
   Project(std::unique_ptr<ExecNode> child, std::shared_ptr<lance::format::Schema> projected_schema);
 

--- a/cpp/src/lance/io/exec/project.h
+++ b/cpp/src/lance/io/exec/project.h
@@ -51,6 +51,11 @@ class Project : ExecNode {
       std::shared_ptr<FileReader> reader,
       std::shared_ptr<::arrow::dataset::ScanOptions> scan_options);
 
+  /// Make a Project from the fragment and scan options.
+  ///
+  /// \param fragment Lance fragment
+  /// \param scan_options Arrow scan options.
+  /// \return Project if success. Returns the error status otherwise.
   static ::arrow::Result<std::unique_ptr<Project>> Make(
       const lance::arrow::LanceFragment& fragment,
       std::shared_ptr<::arrow::dataset::ScanOptions> scan_options);
@@ -58,17 +63,19 @@ class Project : ExecNode {
   /// Read the next batch. Returns nullptr if EOF.
   ::arrow::Result<ScanBatch> Next() override;
 
+  /// ExecNode type.
   constexpr Type type() const override { return kProject; }
 
+  /// Debug String.
   std::string ToString() const override;
 
+  /// Returns the projected schema.
   const std::shared_ptr<lance::format::Schema>& schema() const { return projected_schema_; }
 
  private:
   Project(std::unique_ptr<ExecNode> child, std::shared_ptr<lance::format::Schema> projected_schema);
 
   std::unique_ptr<ExecNode> child_;
-
   std::shared_ptr<lance::format::Schema> projected_schema_;
 };
 

--- a/cpp/src/lance/io/exec/project.h
+++ b/cpp/src/lance/io/exec/project.h
@@ -40,17 +40,6 @@ class Project : ExecNode {
  public:
   Project() = delete;
 
-  /// Make a Project from the full dataset schema and scan options.
-  ///
-  /// \param reader file reader.
-  /// \param schema dataset schema.
-  /// \param scan_options Arrow scan options.
-  /// \return Project if success. Returns the error status otherwise.
-  ///
-  static ::arrow::Result<std::unique_ptr<Project>> Make(
-      std::shared_ptr<FileReader> reader,
-      std::shared_ptr<::arrow::dataset::ScanOptions> scan_options);
-
   /// Make a Project from the fragment and scan options.
   ///
   /// \param fragment Lance fragment

--- a/cpp/src/lance/io/exec/scan.cc
+++ b/cpp/src/lance/io/exec/scan.cc
@@ -24,8 +24,9 @@ namespace lance::io::exec {
 
 constexpr int kMinimalIOThreads = 4;
 
-::arrow::Result<std::unique_ptr<Scan>> Scan::Make(const std::vector<FileReaderWithSchema>& readers,
-                                                  int64_t batch_size) {
+::arrow::Result<std::unique_ptr<Scan>> Scan::Make(
+    const std::vector<lance::arrow::LanceFragment::FileReaderWithSchema>& readers,
+    int64_t batch_size) {
   if (readers.empty()) {
     return ::arrow::Status::Invalid("Scan::Make: can not accept zero readers");
   }
@@ -35,7 +36,8 @@ constexpr int kMinimalIOThreads = 4;
   return std::unique_ptr<Scan>(new Scan(readers, batch_size));
 }
 
-Scan::Scan(const std::vector<FileReaderWithSchema>& readers, int64_t batch_size)
+Scan::Scan(const std::vector<lance::arrow::LanceFragment::FileReaderWithSchema>& readers,
+           int64_t batch_size)
     : readers_(std::begin(readers), std::end(readers)),
       batch_size_(batch_size),
       current_batch_page_length_(std::get<0>(readers_[0])->metadata().GetBatchLength(0)) {}

--- a/cpp/src/lance/io/exec/scan.cc
+++ b/cpp/src/lance/io/exec/scan.cc
@@ -26,20 +26,23 @@ constexpr int kMinimalIOThreads = 4;
 
 ::arrow::Result<std::unique_ptr<Scan>> Scan::Make(
     const std::vector<lance::arrow::LanceFragment::FileReaderWithSchema>& readers,
-    int64_t batch_size) {
+    int64_t batch_size,
+    ::arrow::internal::Executor* executor) {
   if (readers.empty()) {
     return ::arrow::Status::Invalid("Scan::Make: can not accept zero readers");
   }
   if (std::get<0>(readers[0])->metadata().num_batches() == 0) {
     return ::arrow::Status::IOError("Can not open Scan on empty file");
   }
-  return std::unique_ptr<Scan>(new Scan(readers, batch_size));
+  return std::unique_ptr<Scan>(new Scan(readers, batch_size, executor));
 }
 
 Scan::Scan(const std::vector<lance::arrow::LanceFragment::FileReaderWithSchema>& readers,
-           int64_t batch_size)
+           int64_t batch_size,
+           ::arrow::internal::Executor* executor)
     : readers_(std::begin(readers), std::end(readers)),
       batch_size_(batch_size),
+      executor_(executor),
       current_batch_page_length_(std::get<0>(readers_[0])->metadata().GetBatchLength(0)) {}
 
 ::arrow::Result<ScanBatch> Scan::Next() {
@@ -74,12 +77,11 @@ Scan::Scan(const std::vector<lance::arrow::LanceFragment::FileReaderWithSchema>&
     // i.e., Github Action runners.
     ARROW_RETURN_NOT_OK(::arrow::SetCpuThreadPoolCapacity(kMinimalIOThreads));
   }
-  auto executor = ::arrow::internal::GetCpuThreadPool();
   std::vector<::arrow::Future<std::shared_ptr<::arrow::RecordBatch>>> futs;
   for (auto [reader, schema] : readers_) {
     ARROW_ASSIGN_OR_RAISE(
         auto fut,
-        executor->Submit(
+        executor_->Submit(
             [batch_id, offset](
                 std::shared_ptr<lance::io::FileReader> r,
                 std::shared_ptr<lance::format::Schema> s,
@@ -109,11 +111,10 @@ Scan::Scan(const std::vector<lance::arrow::LanceFragment::FileReaderWithSchema>&
 
 ::arrow::Result<std::shared_ptr<::arrow::RecordBatch>> Scan::Take(
     int32_t batch_id, const std::shared_ptr<::arrow::Int32Array>& indices) {
-  auto executor = ::arrow::internal::GetCpuThreadPool();
   std::vector<::arrow::Future<std::shared_ptr<::arrow::RecordBatch>>> futs;
   for (auto [reader, schema] : readers_) {
     ARROW_ASSIGN_OR_RAISE(auto fut,
-                          executor->Submit(
+                          executor_->Submit(
                               [batch_id, &indices](std::shared_ptr<lance::io::FileReader> r,
                                                    std::shared_ptr<lance::format::Schema> s)
                                   -> ::arrow::Result<std::shared_ptr<::arrow::RecordBatch>> {

--- a/cpp/src/lance/io/exec/scan.h
+++ b/cpp/src/lance/io/exec/scan.h
@@ -23,6 +23,7 @@
 #include <tuple>
 #include <vector>
 
+#include "lance/arrow/fragment.h"
 #include "lance/io/exec/base.h"
 
 namespace lance::format {
@@ -38,9 +39,6 @@ namespace lance::io::exec {
 /// Leaf scan node.
 class Scan : public ExecNode {
  public:
-  using FileReaderWithSchema =
-      std::tuple<std::shared_ptr<FileReader>, std::shared_ptr<lance::format::Schema>>;
-
   /// Factory method.
   ///
   /// \param readers a vector of the tuples of `[reader, schema]`, including opened file reader
@@ -48,7 +46,8 @@ class Scan : public ExecNode {
   /// \param batch_size batch size.
   /// \return a Scan node if succeed.
   static ::arrow::Result<std::unique_ptr<Scan>> Make(
-      const std::vector<FileReaderWithSchema>& readers, int64_t batch_size);
+      const std::vector<lance::arrow::LanceFragment::FileReaderWithSchema>& readers,
+      int64_t batch_size);
 
   Scan() = delete;
 
@@ -74,10 +73,10 @@ class Scan : public ExecNode {
   ///
   /// \param readers A vector of opened readers with the projected schema.
   /// \param batch_size scan batch size.
-  Scan(const std::vector<FileReaderWithSchema>& readers,
+  Scan(const std::vector<lance::arrow::LanceFragment::FileReaderWithSchema>& readers,
        int64_t batch_size);
 
-  std::vector<FileReaderWithSchema> readers_;
+  std::vector<lance::arrow::LanceFragment::FileReaderWithSchema> readers_;
   const int64_t batch_size_;
 
   /// Keep track of the progress.

--- a/cpp/src/lance/io/exec/scan.h
+++ b/cpp/src/lance/io/exec/scan.h
@@ -44,10 +44,12 @@ class Scan : public ExecNode {
   /// \param readers a vector of the tuples of `[reader, schema]`, including opened file reader
   ///                and projection schema.
   /// \param batch_size batch size.
+  /// \param executor executor to run parallel jobs.
   /// \return a Scan node if succeed.
   static ::arrow::Result<std::unique_ptr<Scan>> Make(
       const std::vector<lance::arrow::LanceFragment::FileReaderWithSchema>& readers,
-      int64_t batch_size);
+      int64_t batch_size,
+      ::arrow::internal::Executor* executor = ::arrow::internal::GetCpuThreadPool());
 
   Scan() = delete;
 
@@ -76,11 +78,14 @@ class Scan : public ExecNode {
   ///
   /// \param readers A vector of opened readers with the projected schema.
   /// \param batch_size scan batch size.
+  /// \param executor executor to run parallel jobs.
   Scan(const std::vector<lance::arrow::LanceFragment::FileReaderWithSchema>& readers,
-       int64_t batch_size);
+       int64_t batch_size,
+       ::arrow::internal::Executor* executor);
 
   std::vector<lance::arrow::LanceFragment::FileReaderWithSchema> readers_;
   const int64_t batch_size_;
+  ::arrow::internal::Executor* executor_;
 
   /// Keep track of the progress.
   std::mutex lock_;

--- a/cpp/src/lance/io/exec/scan.h
+++ b/cpp/src/lance/io/exec/scan.h
@@ -58,6 +58,9 @@ class Scan : public ExecNode {
   /// Returns the next available batch in the file. Or returns nullptr if EOF.
   ::arrow::Result<ScanBatch> Next() override;
 
+  ::arrow::Result<std::shared_ptr<::arrow::RecordBatch>> Take(
+      int32_t batch_id, const std::shared_ptr<::arrow::Int32Array>& indices);
+
   /// Debug String
   std::string ToString() const override;
 

--- a/cpp/src/lance/io/exec/take.cc
+++ b/cpp/src/lance/io/exec/take.cc
@@ -18,6 +18,7 @@
 
 #include <memory>
 
+#include "lance/arrow/type.h"
 #include "lance/arrow/utils.h"
 #include "lance/io/exec/scan.h"
 

--- a/cpp/src/lance/io/exec/take.cc
+++ b/cpp/src/lance/io/exec/take.cc
@@ -19,23 +19,13 @@
 #include <memory>
 
 #include "lance/arrow/utils.h"
+#include "lance/io/exec/scan.h"
 
 namespace lance::io::exec {
 
-Take::Take(std::shared_ptr<FileReader> reader,
-           std::shared_ptr<lance::format::Schema> schema,
-           std::unique_ptr<ExecNode> child)
-    : reader_(std::move(reader)), schema_(std::move(schema)), child_(std::move(child)) {
+Take::Take(std::unique_ptr<ExecNode> child, std::unique_ptr<Scan> scan)
+    : child_(std::move(child)), scan_(std::move(scan)) {
   assert(child_);
-}
-
-::arrow::Result<std::unique_ptr<Take>> Take::Make(std::shared_ptr<FileReader> reader,
-                                                  std::shared_ptr<lance::format::Schema> schema,
-                                                  std::unique_ptr<ExecNode> child) {
-  if (!child) {
-    return ::arrow::Status::Invalid("Take::Make: child can not be null");
-  }
-  return std::unique_ptr<Take>(new Take(reader, schema, std::move(child)));
 }
 
 ::arrow::Result<ScanBatch> Take::Next() {
@@ -46,21 +36,20 @@ Take::Take(std::shared_ptr<FileReader> reader,
   assert(filtered.indices);
   const auto batch_id = filtered.batch_id;
   auto offset = filtered.offset;
-  if (!schema_ || schema_->fields().empty()) {
+  if (!scan_) {
     return ScanBatch(filtered.batch, batch_id, offset);
-  } else {
-    auto offset_datum = ::arrow::Datum(offset);
-    ARROW_ASSIGN_OR_RAISE(auto adjusted_offsets,
-                          ::arrow::compute::Add(filtered.indices, offset_datum));
-    auto adjusted_offsets_arr =
-        std::dynamic_pointer_cast<::arrow::Int32Array>(adjusted_offsets.make_array());
-    ARROW_ASSIGN_OR_RAISE(auto rest_columns,
-                          reader_->ReadBatch(*schema_, batch_id, adjusted_offsets_arr));
-    assert(filtered.batch->num_rows() == rest_columns->num_rows());
-    ARROW_ASSIGN_OR_RAISE(auto merged_batch,
-                          lance::arrow::MergeRecordBatches(filtered.batch, rest_columns));
-    return ScanBatch(merged_batch, filtered.batch_id, offset);
   }
+
+  auto offset_datum = ::arrow::Datum(offset);
+  ARROW_ASSIGN_OR_RAISE(auto adjusted_offsets,
+                        ::arrow::compute::Add(filtered.indices, offset_datum));
+  auto adjusted_offsets_arr =
+      std::dynamic_pointer_cast<::arrow::Int32Array>(adjusted_offsets.make_array());
+  ARROW_ASSIGN_OR_RAISE(auto rest_columns, scan_->Take(batch_id, adjusted_offsets_arr));
+  assert(filtered.batch->num_rows() == rest_columns->num_rows());
+  ARROW_ASSIGN_OR_RAISE(auto merged_batch,
+                        lance::arrow::MergeRecordBatches(filtered.batch, rest_columns));
+  return ScanBatch(merged_batch, filtered.batch_id, offset);
 }
 
 std::string Take::ToString() const { return "Take"; }

--- a/cpp/src/lance/io/exec/take.h
+++ b/cpp/src/lance/io/exec/take.h
@@ -25,6 +25,8 @@
 
 namespace lance::io::exec {
 
+class Scan;
+
 /// \brief Take Node
 ///
 /// Take node takes the filtered results from child node, and uses the indices to
@@ -39,15 +41,12 @@ namespace lance::io::exec {
 ///  Take.child -> Limit.child -> Filter.child -> Scan
 class Take : public ExecNode {
  public:
-  /// Factory method.
+  /// Constructor.
   ///
-  /// \param reader An opened lance file reader.
-  /// \param schema Schema for the takers.
   /// \param child the child filter node.
-  /// \return a take node if success.
-  static ::arrow::Result<std::unique_ptr<Take>> Make(std::shared_ptr<FileReader> reader,
-                                                     std::shared_ptr<lance::format::Schema> schema,
-                                                     std::unique_ptr<ExecNode> child);
+  /// \param scan the scan node to execute point query. If scan is nullptr, Take node can read all
+  ///             columns from child already.
+  Take(std::unique_ptr<ExecNode> child, std::unique_ptr<Scan> scan);
 
   /// Returns the next batch.
   ///
@@ -60,21 +59,12 @@ class Take : public ExecNode {
 
   constexpr Type type() const override { return kTake; }
 
+  /// Debug string
   std::string ToString() const override;
 
  private:
-  /// Constructor.
-  ///
-  /// \param reader An opened lance file reader.
-  /// \param schema Schema for the takers.
-  /// \param child the child filter node.
-  Take(std::shared_ptr<FileReader> reader,
-       std::shared_ptr<lance::format::Schema> schema,
-       std::unique_ptr<ExecNode> child);
-
-  std::shared_ptr<FileReader> reader_;
-  std::shared_ptr<lance::format::Schema> schema_;
   std::unique_ptr<ExecNode> child_;
+  std::unique_ptr<Scan> scan_;
 };
 
 }  // namespace lance::io::exec

--- a/cpp/src/lance/io/reader_test.cc
+++ b/cpp/src/lance/io/reader_test.cc
@@ -123,6 +123,8 @@ TEST_CASE("Filter over dictionary base") {
                                              ::arrow::compute::literal("bike")))
             .ok());
   auto scanner = scan_builder->Finish().ValueOrDie();
-  auto actual = scanner->ToTable().ValueOrDie();
+  auto result = scanner->ToTable();
+
+  auto actual = result.ValueOrDie();
   CHECK(actual->num_rows() == 0);
 }

--- a/cpp/src/lance/io/reader_test.cc
+++ b/cpp/src/lance/io/reader_test.cc
@@ -123,8 +123,6 @@ TEST_CASE("Filter over dictionary base") {
                                              ::arrow::compute::literal("bike")))
             .ok());
   auto scanner = scan_builder->Finish().ValueOrDie();
-  auto result = scanner->ToTable();
-
-  auto actual = result.ValueOrDie();
+  auto actual = scanner->ToTable().ValueOrDie();
   CHECK(actual->num_rows() == 0);
 }

--- a/cpp/src/lance/io/record_batch_reader.cc
+++ b/cpp/src/lance/io/record_batch_reader.cc
@@ -74,13 +74,10 @@ std::shared_ptr<::arrow::Schema> RecordBatchReader::schema() const {
 }
 
 ::arrow::Future<std::shared_ptr<::arrow::RecordBatch>> RecordBatchReader::operator()() {
-  auto result = executor_->Submit([&]() {
+  ARROW_ASSIGN_OR_RAISE(auto fut, executor_->Submit([&]() {
     return ::arrow::Future<std::shared_ptr<::arrow::RecordBatch>>::MakeFinished(this->ReadBatch());
-  });
-  if (!result.ok()) {
-    return result.status();
-  }
-  return ::arrow::Future<std::shared_ptr<::arrow::RecordBatch>>(result.ValueOrDie());
+  }));
+  return fut;
 }
 
 }  // namespace lance::io

--- a/cpp/src/lance/io/record_batch_reader.cc
+++ b/cpp/src/lance/io/record_batch_reader.cc
@@ -40,14 +40,6 @@ namespace lance::io {
   return RecordBatchReader(std::move(project), executor);
 };
 
-::arrow::Result<RecordBatchReader> RecordBatchReader::Make(
-    std::shared_ptr<FileReader> reader,
-    std::shared_ptr<::arrow::dataset::ScanOptions> options,
-    ::arrow::internal::Executor* executor) noexcept {
-  ARROW_ASSIGN_OR_RAISE(auto project, exec::Project::Make(std::move(reader), std::move(options)));
-  return RecordBatchReader(std::move(project), executor);
-}
-
 RecordBatchReader::RecordBatchReader(std::shared_ptr<exec::Project> project,
                                      ::arrow::internal::Executor* executor)
     : project_(std::move(project)), executor_(executor) {}

--- a/cpp/src/lance/io/record_batch_reader.cc
+++ b/cpp/src/lance/io/record_batch_reader.cc
@@ -32,32 +32,34 @@
 
 namespace lance::io {
 
-RecordBatchReader::RecordBatchReader(std::shared_ptr<FileReader> reader,
-                                     std::shared_ptr<::arrow::dataset::ScanOptions> options,
-                                     ::arrow::internal::ThreadPool* thread_pool) noexcept
-    : reader_(reader), options_(options), thread_pool_(thread_pool) {
-  assert(thread_pool_);
+::arrow::Result<RecordBatchReader> RecordBatchReader::Make(
+    const lance::arrow::LanceFragment& fragment,
+    std::shared_ptr<::arrow::dataset::ScanOptions> options,
+    ::arrow::internal::Executor* executor) noexcept {
+  ARROW_ASSIGN_OR_RAISE(auto project, exec::Project::Make(fragment, std::move(options)));
+  return RecordBatchReader(std::move(project), executor);
+};
+
+::arrow::Result<RecordBatchReader> RecordBatchReader::Make(
+    std::shared_ptr<FileReader> reader,
+    std::shared_ptr<::arrow::dataset::ScanOptions> options,
+    ::arrow::internal::Executor* executor) noexcept {
+  ARROW_ASSIGN_OR_RAISE(auto project, exec::Project::Make(std::move(reader), std::move(options)));
+  return RecordBatchReader(std::move(project), executor);
 }
+
+RecordBatchReader::RecordBatchReader(std::shared_ptr<exec::Project> project,
+                                     ::arrow::internal::Executor* executor)
+    : project_(std::move(project)), executor_(executor) {}
 
 RecordBatchReader::RecordBatchReader(const RecordBatchReader& other) noexcept
-    : reader_(other.reader_),
-      options_(other.options_),
-      project_(other.project_),
-      thread_pool_(other.thread_pool_) {}
+    : project_(other.project_), executor_(other.executor_) {}
 
 RecordBatchReader::RecordBatchReader(RecordBatchReader&& other) noexcept
-    : reader_(std::move(other.reader_)),
-      options_(std::move(other.options_)),
-      project_(std::move(other.project_)),
-      thread_pool_(std::move(other.thread_pool_)) {}
-
-::arrow::Status RecordBatchReader::Open() {
-  ARROW_ASSIGN_OR_RAISE(project_, exec::Project::Make(reader_, options_));
-  return ::arrow::Status::OK();
-}
+    : project_(std::move(other.project_)), executor_(std::move(other.executor_)) {}
 
 std::shared_ptr<::arrow::Schema> RecordBatchReader::schema() const {
-  return options_->projected_schema;
+  return project_->schema()->ToArrow();
 }
 
 ::arrow::Status RecordBatchReader::ReadNext(std::shared_ptr<::arrow::RecordBatch>* batch) {
@@ -72,7 +74,7 @@ std::shared_ptr<::arrow::Schema> RecordBatchReader::schema() const {
 }
 
 ::arrow::Future<std::shared_ptr<::arrow::RecordBatch>> RecordBatchReader::operator()() {
-  auto result = thread_pool_->Submit([&]() {
+  auto result = executor_->Submit([&]() {
     return ::arrow::Future<std::shared_ptr<::arrow::RecordBatch>>::MakeFinished(this->ReadBatch());
   });
   if (!result.ok()) {

--- a/cpp/src/lance/io/record_batch_reader.h
+++ b/cpp/src/lance/io/record_batch_reader.h
@@ -28,6 +28,11 @@
 namespace arrow::dataset {
 class ScanOptions;
 }
+
+namespace lance::arrow {
+class LanceFragment;
+}
+
 namespace lance::format {
 class Schema;
 }
@@ -43,10 +48,18 @@ class Project;
 /// Lance RecordBatchReader
 class RecordBatchReader : ::arrow::RecordBatchReader {
  public:
-  /// Constructor.
-  RecordBatchReader(std::shared_ptr<FileReader> reader,
-                    std::shared_ptr<::arrow::dataset::ScanOptions> options,
-                    ::arrow::internal::ThreadPool* thread_pool_) noexcept;
+  /// Factory method.
+  static ::arrow::Result<RecordBatchReader> Make(
+      const lance::arrow::LanceFragment& fragment,
+      std::shared_ptr<::arrow::dataset::ScanOptions> options,
+      ::arrow::internal::Executor* executor = ::arrow::internal::GetCpuThreadPool()) noexcept;
+
+  static ::arrow::Result<RecordBatchReader> Make(
+      std::shared_ptr<FileReader> reader,
+      std::shared_ptr<::arrow::dataset::ScanOptions> options,
+      ::arrow::internal::Executor* executor = ::arrow::internal::GetCpuThreadPool()) noexcept;
+
+  RecordBatchReader() = delete;
 
   /// Copy constructor.
   RecordBatchReader(const RecordBatchReader& other) noexcept;
@@ -56,9 +69,6 @@ class RecordBatchReader : ::arrow::RecordBatchReader {
 
   ~RecordBatchReader() = default;
 
-  /// Open the RecordBatchReader. Must call it before start iterating.
-  ::arrow::Status Open();
-
   std::shared_ptr<::arrow::Schema> schema() const override;
 
   ::arrow::Status ReadNext(std::shared_ptr<::arrow::RecordBatch>* batch) override;
@@ -67,15 +77,13 @@ class RecordBatchReader : ::arrow::RecordBatchReader {
   ::arrow::Future<std::shared_ptr<::arrow::RecordBatch>> operator()();
 
  private:
-  RecordBatchReader() = delete;
+  RecordBatchReader(std::shared_ptr<exec::Project> project, ::arrow::internal::Executor* executor);
 
   ::arrow::Result<std::shared_ptr<::arrow::RecordBatch>> ReadBatch() const;
 
-  std::shared_ptr<FileReader> reader_;
-  std::shared_ptr<::arrow::dataset::ScanOptions> options_;
   /// Projection over the dataset.
   std::shared_ptr<exec::Project> project_;
-  ::arrow::internal::ThreadPool* thread_pool_;
+  ::arrow::internal::Executor* executor_;
 };
 
 }  // namespace lance::io

--- a/cpp/src/lance/io/record_batch_reader.h
+++ b/cpp/src/lance/io/record_batch_reader.h
@@ -67,7 +67,7 @@ class RecordBatchReader : ::arrow::RecordBatchReader {
   /// Move constructor.
   RecordBatchReader(RecordBatchReader&& other) noexcept;
 
-  ~RecordBatchReader() = default;
+  ~RecordBatchReader() override = default;
 
   std::shared_ptr<::arrow::Schema> schema() const override;
 

--- a/cpp/src/lance/io/record_batch_reader.h
+++ b/cpp/src/lance/io/record_batch_reader.h
@@ -54,11 +54,6 @@ class RecordBatchReader : ::arrow::RecordBatchReader {
       std::shared_ptr<::arrow::dataset::ScanOptions> options,
       ::arrow::internal::Executor* executor = ::arrow::internal::GetCpuThreadPool()) noexcept;
 
-  static ::arrow::Result<RecordBatchReader> Make(
-      std::shared_ptr<FileReader> reader,
-      std::shared_ptr<::arrow::dataset::ScanOptions> options,
-      ::arrow::internal::Executor* executor = ::arrow::internal::GetCpuThreadPool()) noexcept;
-
   RecordBatchReader() = delete;
 
   /// Copy constructor.

--- a/cpp/src/lance/io/writer.h
+++ b/cpp/src/lance/io/writer.h
@@ -39,7 +39,7 @@ class FileWriter final : public ::arrow::dataset::FileWriter {
   FileWriter(std::shared_ptr<::arrow::Schema> schema,
              std::shared_ptr<::arrow::dataset::FileWriteOptions> options,
              std::shared_ptr<::arrow::io::OutputStream> destination,
-             ::arrow::fs::FileLocator destination_locator);
+             ::arrow::fs::FileLocator destination_locator = {});
 
   ~FileWriter();
 

--- a/cpp/src/lance/testing/io.cc
+++ b/cpp/src/lance/testing/io.cc
@@ -121,7 +121,7 @@ std::unique_ptr<io::exec::ExecNode> TableScan::MakeEmpty() {
   };
 }
 
-/// Make one lance format from the table.
+/// Make one lance fragment from the table.
 ::arrow::Result<std::shared_ptr<lance::arrow::LanceFragment>> MakeFragment(
     const std::shared_ptr<::arrow::Table>& table) {
   auto data_dir = lance::testing::MakeTemporaryDir().ValueOrDie();

--- a/cpp/src/lance/testing/io.cc
+++ b/cpp/src/lance/testing/io.cc
@@ -28,9 +28,13 @@
 #include <string>
 
 #include "lance/arrow/file_lance.h"
+#include "lance/arrow/fragment.h"
 #include "lance/arrow/utils.h"
 #include "lance/arrow/writer.h"
 #include "lance/io/reader.h"
+#include "lance/io/writer.h"
+
+namespace fs = std::filesystem;
 
 namespace lance::testing {
 
@@ -116,5 +120,35 @@ std::unique_ptr<io::exec::ExecNode> TableScan::MakeEmpty() {
       0,
   };
 }
+
+/// Make one lance format from the table.
+::arrow::Result<std::shared_ptr<lance::arrow::LanceFragment>> MakeFragment(
+    const std::shared_ptr<::arrow::Table>& table) {
+  auto data_dir = lance::testing::MakeTemporaryDir().ValueOrDie();
+  auto local_fs = std::make_shared<::arrow::fs::LocalFileSystem>();
+  std::string filename(fs::path(data_dir) / "12345-67890.lance");
+  auto output = local_fs->OpenOutputStream(filename).ValueOrDie();
+
+  {
+    auto write_options = lance::arrow::LanceFileFormat().DefaultWriteOptions();
+    auto writer = lance::io::FileWriter(table->schema(), write_options, output);
+    auto batch_reader = ::arrow::TableBatchReader(table);
+    std::shared_ptr<::arrow::RecordBatch> batch;
+    while (true) {
+      ARROW_RETURN_NOT_OK(batch_reader.ReadNext(&batch));
+      if (batch == nullptr) {
+        break;
+      }
+      ARROW_RETURN_NOT_OK(writer.Write(batch));
+    }
+    writer.Finish().Wait();
+  }
+
+  auto schema = std::make_shared<lance::format::Schema>(table->schema());
+  auto data_file = lance::format::DataFile(filename, schema->GetFieldIds());
+  auto fragment = std::make_shared<lance::format::DataFragment>(data_file);
+  return std::make_shared<lance::arrow::LanceFragment>(
+      local_fs, data_dir, std::move(fragment), std::move(schema));
+};
 
 }  // namespace lance::testing

--- a/cpp/src/lance/testing/io.h
+++ b/cpp/src/lance/testing/io.h
@@ -21,6 +21,7 @@
 #include <memory>
 #include <string>
 
+#include "lance/arrow/fragment.h"
 #include "lance/io/exec/base.h"
 #include "lance/io/reader.h"
 
@@ -45,6 +46,9 @@ namespace lance::testing {
     const std::vector<std::string>& partitions = {},
     uint64_t max_rows_per_group = 0,
     uint64_t max_rows_per_file = 0);
+
+::arrow::Result<std::shared_ptr<lance::arrow::LanceFragment>> MakeFragment(
+    const std::shared_ptr<::arrow::Table>& table);
 
 /// A ExecNode that scans a Table in memory.
 ///


### PR DESCRIPTION
Use `LanceFragment` to build I/O exec plan, so that I/O exec plan can take multiple data files in the same Fragment into account.