### PR TITLE
Temporarily pin duckdb to 0.5.1

### DIFF
--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -4,7 +4,7 @@ breathe
 cython
 pandas
 piccolo-theme
-duckdb
+duckdb>=0.5.1,<0.6
 jupyterlab
 fastai
 --extra-index-url https://download.pytorch.org/whl/cpu

--- a/python/notebooks/03_exploratory_data_analysis.ipynb
+++ b/python/notebooks/03_exploratory_data_analysis.ipynb
@@ -20,7 +20,7 @@
     "```sh\n",
     "python -m venv ~/.venv/lance\n",
     "source ~/.venv/lance/bin/activate\n",
-    "pip install pylance duckdb matplotlib\n",
+    "pip install pylance duckdb==0.5.1 matplotlib\n",
     "```\n",
     "\n",
     "You'll also need AWS credentials configured for data access.\n",

--- a/python/notebooks/quickstart.ipynb
+++ b/python/notebooks/quickstart.ipynb
@@ -46,7 +46,7 @@
     "```bash\n",
     "python -m venv ~/.venv/lance\n",
     "source ~/.venv/lance/bin/activate\n",
-    "pip install pylance duckdb pandas pillow matplotlib\n",
+    "pip install pylance duckdb==0.5.1 pandas pillow matplotlib\n",
     "```"
    ]
   },

--- a/python/setup.py
+++ b/python/setup.py
@@ -71,7 +71,7 @@ setup(
     ext_modules=cythonize(extensions, language_level="3"),
     zip_safe=False,
     install_requires=["numpy", "pillow", "pyarrow>=10,<11", "requests", "pandas"],
-    extras_require={"test": ["pytest>=6.0", "duckdb", "click", "requests_mock", "hypothesis"]},
+    extras_require={"test": ["pytest>=6.0", "duckdb>=0.5.1,<0.6", "click", "requests_mock", "hypothesis"]},
     python_requires=">=3.8",
     packages=find_packages(),
     classifiers=[


### PR DESCRIPTION
Requirements to get 0.6 working:
- #312 linux build works fine (had to explicitly add cmath.h)
- #312 osx build still fails: cmake errors complain about not being able to find malloc (which has been deprecated on osx).
- Update the artifacts on s3 (upload.sh)
- Update latest pointer to 0.2
