### PR TITLE
[C++] add Dataset::Make(string) API

### DIFF
--- a/cpp/CMakeLists.txt
+++ b/cpp/CMakeLists.txt
@@ -160,7 +160,7 @@ endif ()
 add_library(lance SHARED ${lance_objects})
 target_link_libraries(lance PUBLIC
         ${Protobuf_LIBRARIES}
-        ${ARROW_SHARED_LIB}
-        ${ARROW_DATASET_SHARED_LIB}
+        Arrow::arrow_shared
+        ArrowDataset::arrow_dataset_shared
         fmt::fmt
         )

--- a/cpp/include/lance/arrow/dataset.h
+++ b/cpp/include/lance/arrow/dataset.h
@@ -123,6 +123,14 @@ class LanceDataset : public ::arrow::dataset::Dataset {
       const std::string& base_uri,
       std::optional<uint64_t> version = std::nullopt);
 
+  /// Load dataset from URI, with a optional version.
+  ///
+  /// \param uri a fully qualified dataset URI
+  /// \param version optional version to load.
+  /// \return See `Make(fs, base_uri, version)`.
+  static ::arrow::Result<std::shared_ptr<LanceDataset>> Make(
+      const std::string& uri, std::optional<uint64_t> version = std::nullopt);
+
   /// Get all the dataset versions.
   ::arrow::Result<std::vector<DatasetVersion>> versions() const;
 

--- a/cpp/src/lance/arrow/dataset.cc
+++ b/cpp/src/lance/arrow/dataset.cc
@@ -293,6 +293,13 @@ LanceDataset::~LanceDataset() {}
   return WriteManifest(fs, base_dir, manifest);
 }
 
+::arrow::Result<std::shared_ptr<LanceDataset>> LanceDataset::Make(const std::string& uri,
+                                                                  std::optional<uint64_t> version) {
+  std::string path;
+  ARROW_ASSIGN_OR_RAISE(auto fs, ::arrow::fs::FileSystemFromUriOrPath(uri, &path));
+  return Make(fs, path, version);
+}
+
 ::arrow::Result<std::shared_ptr<LanceDataset>> LanceDataset::Make(
     const std::shared_ptr<::arrow::fs::FileSystem>& fs,
     const std::string& base_uri,

--- a/cpp/src/lance/format/CMakeLists.txt
+++ b/cpp/src/lance/format/CMakeLists.txt
@@ -16,7 +16,7 @@
 protobuf_generate_cpp(
         PROTO_SRCS
         PROTO_HDRS
-        ${CMAKE_SOURCE_DIR}/../protos/format.proto
+        ${PROJECT_SOURCE_DIR}/../protos/format.proto
 )
 
 add_library(


### PR DESCRIPTION
* Allow creating `LanceDataset` directly from a qualified URI to simplify the caller code.
* Correctly set protobuf generation code to the relative path of cpp source code, making the core cpp project available as cmake subproject to be built. 