### PR TITLE
[Python] Fix lance.dataset open local related path

### DIFF
--- a/python/lance/__init__.py
+++ b/python/lance/__init__.py
@@ -67,7 +67,8 @@ def dataset(
 
     """
     if not filesystem:
-        filesystem, uri = pa.fs.FileSystem.from_uri(uri)
+        from pyarrow.fs import _resolve_filesystem_and_path
+        filesystem, uri = _resolve_filesystem_and_path(uri, filesystem)
 
     if version is None:
         if (

--- a/python/lance/tests/test_api.py
+++ b/python/lance/tests/test_api.py
@@ -138,3 +138,6 @@ def test_open_local_path(tmp_path: Path):
     with cd(tmp_path):
         ds = lance.dataset("./local_path")
         assert ds.to_table() == table
+
+    ds = lance.dataset(base_dir.absolute())
+    assert ds.to_table() == table

--- a/python/lance/tests/test_api.py
+++ b/python/lance/tests/test_api.py
@@ -16,12 +16,12 @@
 from pathlib import Path
 
 import pandas as pd
-
-import lance
 import pyarrow as pa
 import pyarrow.dataset as ds
 
+import lance
 from lance import LanceFileFormat, dataset
+from lance.util import cd
 
 
 def test_simple_round_trips(tmp_path: Path):
@@ -128,3 +128,13 @@ def test_write_versioned_dataset(tmp_path: Path):
     assert dataset.version["version"] == 3
     assert dataset.latest_version()["version"] == 3
     assert len(dataset.versions()) == 3
+
+
+def test_open_local_path(tmp_path: Path):
+    table = pa.Table.from_pylist([{"a": 1, "b": 2}])
+    base_dir = tmp_path / "local_path"
+    lance.write_dataset(table, base_dir)
+
+    with cd(tmp_path):
+        ds = lance.dataset("./local_path")
+        assert ds.to_table() == table

--- a/python/lance/tests/test_api.py
+++ b/python/lance/tests/test_api.py
@@ -139,5 +139,9 @@ def test_open_local_path(tmp_path: Path):
         ds = lance.dataset("./local_path")
         assert ds.to_table() == table
 
+    with cd(tmp_path):
+        ds = lance.dataset("local_path")
+        assert ds.to_table() == table
+
     ds = lance.dataset(base_dir.absolute())
     assert ds.to_table() == table

--- a/python/lance/util/__init__.py
+++ b/python/lance/util/__init__.py
@@ -1,0 +1,29 @@
+# Copyright 2022 Lance Developers
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import os
+from contextlib import contextmanager
+from pathlib import Path
+from typing import Union
+
+
+@contextmanager
+def cd(new_dir: Union[str, Path]):
+    """Change the directory in a context."""
+    cur_dir = os.getcwd()
+    os.chdir(os.path.expanduser(new_dir))
+    try:
+        yield
+    finally:
+        os.chdir(cur_dir)


### PR DESCRIPTION
Fix `lance.dataset()` to load local dataset without explicit `file://` scheme