### PR TITLE
[C++] Add RAII util (defer) to auto cleanup / close resources after exiting the scope

### DIFF
--- a/cpp/CMakeLists.txt
+++ b/cpp/CMakeLists.txt
@@ -150,6 +150,7 @@ set(lance_objects
         $<TARGET_OBJECTS:format>
         $<TARGET_OBJECTS:io>
         $<TARGET_OBJECTS:lance_io_exec>
+        $<TARGET_OBJECTS:lance_util>
         )
 
 add_subdirectory(src)

--- a/cpp/src/lance/CMakeLists.txt
+++ b/cpp/src/lance/CMakeLists.txt
@@ -16,6 +16,7 @@ add_subdirectory(arrow)
 add_subdirectory(encodings)
 add_subdirectory(format)
 add_subdirectory(io)
+add_subdirectory(util)
 
 if (CMAKE_BUILD_TYPE STREQUAL Debug)
     add_subdirectory(testing)

--- a/cpp/src/lance/util/CMakeLists.txt
+++ b/cpp/src/lance/util/CMakeLists.txt
@@ -1,0 +1,17 @@
+# Copyright 2022 Lance Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may not
+# use this file except in compliance with the License. You may obtain a copy of
+# the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations under
+# the License.
+
+add_library(lance_util OBJECT defer.h defer.cc)
+
+add_lance_test(defer_test)

--- a/cpp/src/lance/util/defer.cc
+++ b/cpp/src/lance/util/defer.cc
@@ -20,9 +20,10 @@ namespace lance::util {
 
 Defer::Defer(std::function<void()>&& cb) : callback_(std::move(cb)) {}
 
-Defer::Defer(Defer&& other)
-    : callback_(std::move(other.callback_)){
+Defer::Defer(Defer&& other) : callback_(std::move(other.callback_)){};
 
-      };
+Defer::~Defer() {
+  callback_();
+}
 
 }  // namespace lance::util

--- a/cpp/src/lance/util/defer.cc
+++ b/cpp/src/lance/util/defer.cc
@@ -1,0 +1,28 @@
+//  Copyright 2022 Lance Authors
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+
+#include "lance/util/defer.h"
+
+#include <utility>
+
+namespace lance::util {
+
+Defer::Defer(std::function<void()>&& cb) : callback_(std::move(cb)) {}
+
+Defer::Defer(Defer&& other)
+    : callback_(std::move(other.callback_)){
+
+      };
+
+}  // namespace lance::util

--- a/cpp/src/lance/util/defer.h
+++ b/cpp/src/lance/util/defer.h
@@ -21,6 +21,18 @@ namespace lance::util {
 /// Defer the execution of a lambda function until out of scope.
 ///
 /// It offers RAII to general function calls. It is modeled after Golang's Defer statement.
+///
+/// \example
+///
+/// void WriteData(const std::string& path) {
+///   auto fd = fopen(path.c_str());
+///   Defer closer([&file]() { fclose(fd); }
+///   for (int i = 0; i < 10; i++) {
+///       fprint(fd, "line: %d\n", i);
+///   }
+///   // fd is closed when out of scope.
+/// }
+///
 class Defer {
  public:
   Defer() = delete;

--- a/cpp/src/lance/util/defer.h
+++ b/cpp/src/lance/util/defer.h
@@ -18,13 +18,19 @@
 
 namespace lance::util {
 
+/// Defer the execution of a lambda function until out of scope.
+///
+/// It offers RAII to general function calls. It is modeled after Golang's Defer statement.
 class Defer {
  public:
   Defer() = delete;
 
-  explicit Defer(std::function<void()>&& cb);
+  explicit Defer(std::function<void(void)>&& cb);
 
+  /// Move constructor.
   Defer(Defer&& other);
+
+  ~Defer();
 
  private:
   std::function<void()> callback_;

--- a/cpp/src/lance/util/defer.h
+++ b/cpp/src/lance/util/defer.h
@@ -26,7 +26,7 @@ namespace lance::util {
 ///
 /// void WriteData(const std::string& path) {
 ///   auto fd = fopen(path.c_str());
-///   Defer closer([&file]() { fclose(fd); }
+///   Defer auto_closer([&]() { fclose(fd); }
 ///   for (int i = 0; i < 10; i++) {
 ///       fprint(fd, "line: %d\n", i);
 ///   }

--- a/cpp/src/lance/util/defer.h
+++ b/cpp/src/lance/util/defer.h
@@ -1,0 +1,33 @@
+//  Copyright 2022 Lance Authors
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+
+#pragma once
+
+#include <functional>
+
+namespace lance::util {
+
+class Defer {
+ public:
+  Defer() = delete;
+
+  explicit Defer(std::function<void()>&& cb);
+
+  Defer(Defer&& other);
+
+ private:
+  std::function<void()> callback_;
+};
+
+}  // namespace lance::util

--- a/cpp/src/lance/util/defer_test.cc
+++ b/cpp/src/lance/util/defer_test.cc
@@ -20,7 +20,7 @@ TEST_CASE("Test Call Defer") {
   int i = 100;
 
   {
-    lance::util::Defer incr = [&]() { i += 200; };
+    lance::util::Defer incr([&i]() { i += 200; });
 
     CHECK(i == 100);
     i += 20;

--- a/cpp/src/lance/util/defer_test.cc
+++ b/cpp/src/lance/util/defer_test.cc
@@ -1,0 +1,30 @@
+//  Copyright 2022 Lance Authors
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+
+#include "lance/util/defer.h"
+
+#include <catch2/catch_test_macros.hpp>
+
+TEST_CASE("Test Call Defer") {
+  int i = 100;
+
+  {
+    lance::util::Defer incr = [&]() { i += 200; };
+
+    CHECK(i == 100);
+    i += 20;
+  }
+
+  CHECK(i == 320);
+}


### PR DESCRIPTION
Modeled after Golang's [`defer`](https://gobyexample.com/defer) and Google's [`abseil::Cleanup`](https://github.com/abseil/abseil-cpp/blob/master/absl/cleanup/cleanup.h).