### PR TITLE
Refactor dataset diff and compute metric

### DIFF
--- a/cpp/include/lance/arrow/dataset.h
+++ b/cpp/include/lance/arrow/dataset.h
@@ -131,6 +131,10 @@ class LanceDataset : public ::arrow::dataset::Dataset {
   static ::arrow::Result<std::shared_ptr<LanceDataset>> Make(
       const std::string& uri, std::optional<uint64_t> version = std::nullopt);
 
+  /// Create a new LanceDataset at a given version
+  ::arrow::Result<std::shared_ptr<LanceDataset>> Checkout(
+      std::optional<uint64_t> version = std::nullopt) const;
+
   /// Get all the dataset versions.
   ::arrow::Result<std::vector<DatasetVersion>> versions() const;
 

--- a/cpp/src/lance/arrow/dataset.cc
+++ b/cpp/src/lance/arrow/dataset.cc
@@ -327,6 +327,10 @@ LanceDataset::~LanceDataset() {}
   return std::shared_ptr<LanceDataset>(new LanceDataset(std::move(impl)));
 }
 
+::arrow::Result<std::shared_ptr<LanceDataset>> LanceDataset::Checkout(std::optional<uint64_t> version) const {
+  return LanceDataset::Make(impl_->fs, impl_->base_uri, version);
+}
+
 ::arrow::Result<std::vector<DatasetVersion>> LanceDataset::versions() const {
   std::vector<DatasetVersion> versions;
   ::arrow::fs::FileSelector selector;

--- a/python/lance/_lib.pyx
+++ b/python/lance/_lib.pyx
@@ -4,9 +4,11 @@ from datetime import datetime, timezone
 from pathlib import Path
 from typing import Callable, Dict, List, Optional, Union
 
+import pandas as pd
 import pyarrow
 
 from cython.operator cimport dereference as deref
+from lance.util.versioning import LanceDiff, compute_metric
 from libc.stdint cimport int64_t, uint64_t
 from libc.time cimport time_t
 from libcpp cimport bool
@@ -227,6 +229,8 @@ cdef extern from "lance/arrow/dataset.h" namespace "lance::arrow" nogil:
                 optional[uint64_t] version,
         )
 
+        CResult[shared_ptr[CLanceDataset]] Checkout(optional[uint64_t] version)
+
         CDatasetVersion version() const;
 
         CResult[CDatasetVersion] latest_version() const;
@@ -262,6 +266,23 @@ cdef class FileSystemDataset(Dataset):
     cdef void init(self, const shared_ptr[CDataset]& sp):
         Dataset.init(self, sp)
         self.lance_dataset = <CLanceDataset *> sp.get()
+
+    def checkout(self, version: Optional[int]) -> FileSystemDataset:
+        if version is None:
+            version = 0
+        return self._checkout(version)
+
+    def _checkout(self, uint64_t version) -> FileSystemDataset:
+        cdef:
+            shared_ptr[CLanceDataset] c_dataset
+            shared_ptr[CDataset] c_base_dataset
+            optional[uint64_t] c_version
+
+        c_version = optional[uint64_t](version)
+
+        c_dataset = GetResultValue(self.lance_dataset.Checkout(c_version))
+        c_base_dataset = static_pointer_cast[CDataset, CLanceDataset](c_dataset)
+        return FileSystemDataset.wrap(move(c_base_dataset))
 
     @property
     def uri(self) -> str:
@@ -363,6 +384,34 @@ cdef class FileSystemDataset(Dataset):
         )
         return FileSystemDataset.wrap(static_pointer_cast[CDataset, CLanceDataset](dataset))
 
+    def diff(self, v1: int, v2: int) -> LanceDiff:
+        """
+        Get the difference from v1 to v2 of this dataset
+
+        Parameters
+        ----------
+        v1: int
+            Start version
+        v2: int
+            End version
+        """
+        return LanceDiff(self.checkout(v1), self.checkout(v2))
+
+    def compute_metric(self, metric_func: Callable[[Dataset], pd.DataFrame],
+                       versions: list[int] = None) -> pd.DataFrame:
+        """
+        Compute a metric across versions for this dataset
+
+        Parameters
+        ----------
+        metric_func: FileSystemDataset -> pd.DataFrame
+            Function to compute some arbitrary metric for a given version
+        versions: list of int, default None
+            Compute for specified versions. Compute for all versions if None.
+        """
+        return compute_metric(self, metric_func, versions=versions)
+
+
 def _lance_dataset_write(
     Dataset data,
     object base_dir not None,
@@ -441,3 +490,4 @@ def _lance_dataset_make(
     c_dataset = GetResultValue(CLanceDataset.Make(c_filesystem, base_dir, c_version))
     c_base_dataset = static_pointer_cast[CDataset, CLanceDataset](c_dataset)
     return FileSystemDataset.wrap(move(c_base_dataset))
+

--- a/python/lance/_lib.pyx
+++ b/python/lance/_lib.pyx
@@ -384,33 +384,6 @@ cdef class FileSystemDataset(Dataset):
         )
         return FileSystemDataset.wrap(static_pointer_cast[CDataset, CLanceDataset](dataset))
 
-    def diff(self, v1: int, v2: int) -> LanceDiff:
-        """
-        Get the difference from v1 to v2 of this dataset
-
-        Parameters
-        ----------
-        v1: int
-            Start version
-        v2: int
-            End version
-        """
-        return LanceDiff(self.checkout(v1), self.checkout(v2))
-
-    def compute_metric(self, metric_func: Callable[[Dataset], pd.DataFrame],
-                       versions: list[int] = None) -> pd.DataFrame:
-        """
-        Compute a metric across versions for this dataset
-
-        Parameters
-        ----------
-        metric_func: FileSystemDataset -> pd.DataFrame
-            Function to compute some arbitrary metric for a given version
-        versions: list of int, default None
-            Compute for specified versions. Compute for all versions if None.
-        """
-        return compute_metric(self, metric_func, versions=versions)
-
 
 def _lance_dataset_write(
     Dataset data,

--- a/python/lance/tests/util/test_versioning.py
+++ b/python/lance/tests/util/test_versioning.py
@@ -23,7 +23,6 @@ from lance.util.versioning import (
     LanceDiff,
     RowDiff,
     compute_metric,
-    diff,
     get_version_asof,
 )
 
@@ -65,12 +64,12 @@ def _get_test_timestamps(naive):
 
 def test_compute_metric(tmp_path):
     base_dir = tmp_path / "test"
-    _create_dataset(base_dir)
+    ds = _create_dataset(base_dir)
 
     def func(dataset):
         return dataset.to_table().to_pandas().max().to_frame().T
 
-    metrics = compute_metric(base_dir, func)
+    metrics = ds.compute_metric(func)
     assert "version" in metrics
 
 
@@ -80,14 +79,14 @@ def _create_dataset(base_dir):
     table2 = pa.Table.from_pylist([{"a": 100, "b": 200}])
     lance.write_dataset(table2, base_dir, mode="append")
     table3 = pa.Table.from_pylist([{"a": 100, "c": 100, "d": 200}])
-    lance.dataset(base_dir).merge(table3, left_on="a", right_on="a")
+    return lance.dataset(base_dir).merge(table3, left_on="a", right_on="a")
 
 
 def test_diff(tmp_path):
     base_dir = tmp_path / "test"
-    _create_dataset(base_dir)
+    ds = _create_dataset(base_dir)
 
-    d = diff(base_dir, 1, 2)
+    d = ds.diff(1, 2)
     assert isinstance(d, LanceDiff)
 
     rows = d.rows_added(key="a")

--- a/python/lance/tests/util/test_versioning.py
+++ b/python/lance/tests/util/test_versioning.py
@@ -22,7 +22,6 @@ from lance.util.versioning import (
     ColumnDiff,
     LanceDiff,
     RowDiff,
-    compute_metric,
     get_version_asof,
 )
 
@@ -69,7 +68,7 @@ def test_compute_metric(tmp_path):
     def func(dataset):
         return dataset.to_table().to_pandas().max().to_frame().T
 
-    metrics = ds.compute_metric(func)
+    metrics = lance.compute_metric(ds, func)
     assert "version" in metrics
 
 
@@ -86,7 +85,7 @@ def test_diff(tmp_path):
     base_dir = tmp_path / "test"
     ds = _create_dataset(base_dir)
 
-    d = ds.diff(1, 2)
+    d = lance.diff(ds, 1, 2)
     assert isinstance(d, LanceDiff)
 
     rows = d.rows_added(key="a")
@@ -96,7 +95,7 @@ def test_diff(tmp_path):
     assert isinstance(tbl, pa.Table)
     assert len(tbl) == 1
 
-    cols = ds.diff(2, 3).columns_added()
+    cols = lance.diff(ds, 2, 3).columns_added()
     assert isinstance(cols, ColumnDiff)
     assert len(cols.schema) == 2
     tbl = cols.head()

--- a/python/lance/tests/util/test_versioning.py
+++ b/python/lance/tests/util/test_versioning.py
@@ -96,7 +96,7 @@ def test_diff(tmp_path):
     assert isinstance(tbl, pa.Table)
     assert len(tbl) == 1
 
-    cols = d.columns_added()
+    cols = ds.diff(2, 3).columns_added()
     assert isinstance(cols, ColumnDiff)
     assert len(cols.schema) == 2
     tbl = cols.head()

--- a/python/lance/util/versioning.py
+++ b/python/lance/util/versioning.py
@@ -128,7 +128,7 @@ class LanceDiff:
         """
         v2_fields = _flat_schema(self.v2.schema)
         v1_fields = set([f.name for f in _flat_schema(self.v1.schema)])
-        new_fields = [f for f in v2_fields if f not in v1_fields]
+        new_fields = [f for f in v2_fields if f.name not in v1_fields]
         return ColumnDiff(self.v2, new_fields)
 
 

--- a/python/lance/util/versioning.py
+++ b/python/lance/util/versioning.py
@@ -77,6 +77,18 @@ def compute_metric(
 ) -> pd.DataFrame:
     """
     Compare metrics across versions of a dataset
+
+    Parameters
+    ----------
+    ds: FileSystemDataset
+        The base dataset we want to compute metrics across versions for.
+    metric_func: Callable[[FileSystemDataset], pd.DataFrame]
+        Function to compute metrics DataFrame from a given dataset version.
+    versions: list, default None
+        All versions if not specified.
+    with_version: bool or str, default True
+        If bool then controls whether to add the version as auxiliary output.
+        If str then assumed to be the name of the auxiliary output column.
     """
     if versions is None:
         versions = ds.versions()


### PR DESCRIPTION
1. Minor bug fixes
2. Add `ds.compute_metric(func)` and `ds.diff(v1, v2)` to dataset interface