### PR TITLE
[BUG] Fix reading version aux data reading and writing

### DIFF
--- a/cpp/src/lance/format/manifest.cc
+++ b/cpp/src/lance/format/manifest.cc
@@ -43,7 +43,9 @@ Manifest::Manifest(const Manifest& other) noexcept
     : schema_(other.schema_), version_(other.version_), fragments_(other.fragments()) {}
 
 Manifest::Manifest(const lance::format::pb::Manifest& pb)
-    : schema_(std::make_unique<Schema>(pb.fields(), pb.metadata())), version_(pb.version()) {
+    : schema_(std::make_unique<Schema>(pb.fields(), pb.metadata())),
+      version_(pb.version()),
+      version_aux_data_position_(pb.version_aux_data()) {
   for (auto& pb_fragment : pb.fragments()) {
     fragments_.emplace_back(std::make_shared<DataFragment>(pb_fragment));
   }
@@ -69,6 +71,7 @@ pb::Manifest Manifest::ToProto() const {
   }
   pb.mutable_metadata()->insert(schema_->metadata().begin(), schema_->metadata().end());
   pb.set_version(version_);
+  pb.set_version_aux_data(version_aux_data_position());
 
   for (const auto& fragment : fragments_) {
     auto pb_fragment = pb.add_fragments();
@@ -85,9 +88,7 @@ uint64_t Manifest::version_aux_data_position() const {
   return version_aux_data_position_.value_or(0);
 }
 
-void Manifest::SetVersionAuxDataPosition(uint64_t pos) {
-  version_aux_data_position_ = pos;
-}
+void Manifest::SetVersionAuxDataPosition(uint64_t pos) { version_aux_data_position_ = pos; }
 
 const std::vector<std::shared_ptr<DataFragment>>& Manifest::fragments() const { return fragments_; }
 

--- a/cpp/src/lance/io/pb.h
+++ b/cpp/src/lance/io/pb.h
@@ -4,6 +4,7 @@
 
 #include <arrow/buffer.h>
 #include <arrow/result.h>
+#include <fmt/format.h>
 #include <google/protobuf/message_lite.h>
 #include <google/protobuf/util/time_util.h>
 
@@ -35,8 +36,12 @@ template <ProtoMessage P>
   P proto;
   ARROW_ASSIGN_OR_RAISE(auto buf, source->ReadAt(offset + sizeof(pb_size), pb_size));
   if (!proto.ParseFromArray(buf->data(), buf->size())) {
-    return ::arrow::Status::Invalid("Failed to parse protobuf");
-  };
+    return ::arrow::Status::Invalid(fmt::format(
+        "Failed to parse protobuf at offset {}: expected protobuf size={} buffer size={}",
+        offset,
+        pb_size,
+        buf->size()));
+  }
   return proto;
 }
 


### PR DESCRIPTION
When dictionary array involved, the version aux data offset is usually not zero, because we will write dictionary value array first in the manifest file. The bug was due to the aux data position are not serialized correctly in the code path. 