### PR TITLE
[Rust] Read/Write Protobuf-backed struct directly from file or buffers.

### DIFF
--- a/rust/src/dataset.rs
+++ b/rust/src/dataset.rs
@@ -9,7 +9,7 @@ use object_store::path::Path;
 use self::scanner::Scanner;
 use crate::datatypes::Schema;
 use crate::error::Result;
-use crate::format::{pb, Fragment, Manifest};
+use crate::format::{Fragment, Manifest};
 use crate::io::reader::read_manifest;
 use crate::io::{read_metadata_offset, ObjectStore};
 
@@ -69,10 +69,7 @@ impl Dataset {
             .bytes()
             .await?;
         let offset = read_metadata_offset(&bytes)?;
-        let manifest_pb = object_reader
-            .read_message::<pb::Manifest>(offset as usize)
-            .await?;
-        let mut manifest: Manifest = (&manifest_pb).into();
+        let mut manifest: Manifest = object_reader.read_struct(offset).await?;
         manifest.schema.load_dictionary(&object_reader).await?;
         Ok(Self {
             object_store,

--- a/rust/src/error.rs
+++ b/rust/src/error.rs
@@ -39,31 +39,31 @@ impl std::fmt::Display for Error {
 
 impl From<ArrowError> for Error {
     fn from(e: ArrowError) -> Self {
-        Error::Arrow(e.to_string())
+        Self::Arrow(e.to_string())
     }
 }
 
 impl From<std::io::Error> for Error {
     fn from(e: std::io::Error) -> Self {
-        Error::IO(e.to_string())
+        Self::IO(e.to_string())
     }
 }
 
 impl From<object_store::Error> for Error {
     fn from(e: object_store::Error) -> Self {
-        Error::IO(e.to_string())
+        Self::IO(e.to_string())
     }
 }
 
 impl From<prost::DecodeError> for Error {
     fn from(e: prost::DecodeError) -> Self {
-        Error::IO(e.to_string())
+        Self::IO(e.to_string())
     }
 }
 
 impl From<tokio::task::JoinError> for Error {
     fn from(e: tokio::task::JoinError) -> Self {
-        Error::IO(e.to_string())
+        Self::IO(e.to_string())
     }
 }
 

--- a/rust/src/format.rs
+++ b/rust/src/format.rs
@@ -7,8 +7,15 @@ pub use manifest::Manifest;
 pub use metadata::Metadata;
 pub use page_table::{PageInfo, PageTable};
 
+use prost::Message;
+
 /// Protobuf definitions
 #[allow(clippy::all)]
 pub mod pb {
     include!(concat!(env!("OUT_DIR"), "/lance.format.pb.rs"));
+}
+
+/// Annotation on a struct that can be converted a Protobuf message.
+pub trait ProtoStruct {
+    type Proto: Message;
 }

--- a/rust/src/format/fragment.rs
+++ b/rust/src/format/fragment.rs
@@ -17,7 +17,7 @@
 
 use std::collections::BTreeSet;
 
-use crate::format::{pb, ProtoStruct};
+use crate::format::pb;
 
 /// Lance Data File
 ///
@@ -30,24 +30,11 @@ pub struct DataFile {
     fields: Vec<i32>,
 }
 
-impl ProtoStruct for DataFile {
-    type Proto = pb::DataFile;
-}
-
 impl From<&DataFile> for pb::DataFile {
     fn from(df: &DataFile) -> Self {
         Self {
             path: df.path.clone(),
             fields: df.fields.clone(),
-        }
-    }
-}
-
-impl From<pb::DataFile> for DataFile {
-    fn from(proto: pb::DataFile) -> Self {
-        Self {
-            path: proto.path.clone(),
-            fields: proto.fields.clone(),
         }
     }
 }
@@ -82,10 +69,6 @@ impl Fragment {
             .into_iter()
             .collect()
     }
-}
-
-impl ProtoStruct for Fragment {
-    type Proto = pb::DataFragment;
 }
 
 impl From<&pb::DataFragment> for Fragment {

--- a/rust/src/format/fragment.rs
+++ b/rust/src/format/fragment.rs
@@ -17,8 +17,7 @@
 
 use std::collections::BTreeSet;
 
-use crate::format::pb;
-use crate::format::pb::DataFragment;
+use crate::format::{pb, ProtoStruct};
 
 /// Lance Data File
 ///
@@ -31,11 +30,24 @@ pub struct DataFile {
     fields: Vec<i32>,
 }
 
+impl ProtoStruct for DataFile {
+    type Proto = pb::DataFile;
+}
+
 impl From<&DataFile> for pb::DataFile {
     fn from(df: &DataFile) -> Self {
         Self {
             path: df.path.clone(),
             fields: df.fields.clone(),
+        }
+    }
+}
+
+impl From<pb::DataFile> for DataFile {
+    fn from(proto: pb::DataFile) -> Self {
+        Self {
+            path: proto.path.clone(),
+            fields: proto.fields.clone(),
         }
     }
 }
@@ -72,8 +84,12 @@ impl Fragment {
     }
 }
 
+impl ProtoStruct for Fragment {
+    type Proto = pb::DataFragment;
+}
+
 impl From<&pb::DataFragment> for Fragment {
-    fn from(p: &DataFragment) -> Self {
+    fn from(p: &pb::DataFragment) -> Self {
         Self {
             id: p.id,
             files: p.files.iter().map(DataFile::from).collect(),

--- a/rust/src/format/manifest.rs
+++ b/rust/src/format/manifest.rs
@@ -17,7 +17,7 @@
 
 use super::Fragment;
 use crate::datatypes::Schema;
-use crate::format::pb;
+use crate::format::{pb, ProtoStruct};
 
 /// Manifest of a dataset
 ///
@@ -36,8 +36,12 @@ pub struct Manifest {
     pub fragments: Vec<Fragment>,
 }
 
-impl From<&pb::Manifest> for Manifest {
-    fn from(p: &pb::Manifest) -> Self {
+impl ProtoStruct for Manifest {
+    type Proto = pb::Manifest;
+}
+
+impl From<pb::Manifest> for Manifest {
+    fn from(p: pb::Manifest) -> Self {
         Self {
             schema: Schema::from(&p.fields),
             version: p.version,

--- a/rust/src/format/metadata.rs
+++ b/rust/src/format/metadata.rs
@@ -15,10 +15,10 @@
 // specific language governing permissions and limitations
 // under the License.
 
-use crate::format::pb;
+use crate::format::{pb, ProtoStruct};
 
 /// Data File Metadata
-#[derive(Debug, Default)]
+#[derive(Debug, Default, PartialEq)]
 pub struct Metadata {
     /// Offset of each record batch.
     pub batch_offsets: Vec<i32>,
@@ -28,6 +28,10 @@ pub struct Metadata {
 
     /// The file position of the manifest block in the file.
     pub manifest_position: Option<usize>,
+}
+
+impl ProtoStruct for Metadata {
+    type Proto = pb::Metadata;
 }
 
 impl From<&Metadata> for pb::Metadata {
@@ -40,8 +44,8 @@ impl From<&Metadata> for pb::Metadata {
     }
 }
 
-impl From<&pb::Metadata> for Metadata {
-    fn from(m: &pb::Metadata) -> Self {
+impl From<pb::Metadata> for Metadata {
+    fn from(m: pb::Metadata) -> Self {
         Self {
             batch_offsets: m.batch_offsets.clone(),
             page_table_position: m.page_table_position as usize,

--- a/rust/src/io.rs
+++ b/rust/src/io.rs
@@ -30,6 +30,8 @@ pub mod object_store;
 pub mod object_writer;
 pub mod reader;
 
+use crate::format::ProtoStruct;
+
 pub use self::object_store::ObjectStore;
 
 const MAGIC: &[u8; 4] = b"LANC";
@@ -62,7 +64,16 @@ pub fn read_metadata_offset(bytes: &Bytes) -> Result<usize> {
     Ok(LittleEndian::read_u64(offset_bytes.as_ref()) as usize)
 }
 
+/// Read protobuf from a buffer.
 pub fn read_message<M: Message + Default>(buf: &Bytes) -> Result<M> {
     let msg_len = LittleEndian::read_u32(&buf) as usize;
     Ok(M::decode(&buf[4..4 + msg_len])?)
+}
+
+/// Read a Protobuf-backed struct from a buffer.
+pub fn read_struct<M: Message + Default, T: ProtoStruct<Proto = M> + From<M>>(
+    buf: &Bytes,
+) -> Result<T> {
+    let msg: M = read_message(buf)?;
+    Ok(T::from(msg))
 }

--- a/rust/src/io.rs
+++ b/rust/src/io.rs
@@ -66,7 +66,7 @@ pub fn read_metadata_offset(bytes: &Bytes) -> Result<usize> {
 
 /// Read protobuf from a buffer.
 pub fn read_message<M: Message + Default>(buf: &Bytes) -> Result<M> {
-    let msg_len = LittleEndian::read_u32(&buf) as usize;
+    let msg_len = LittleEndian::read_u32(buf) as usize;
     Ok(M::decode(&buf[4..4 + msg_len])?)
 }
 

--- a/rust/src/io/object_reader.rs
+++ b/rust/src/io/object_reader.rs
@@ -32,6 +32,7 @@ use prost::Message;
 
 use crate::encodings::{binary::BinaryDecoder, plain::PlainDecoder, Decoder};
 use crate::error::{Error, Result};
+use crate::format::ProtoStruct;
 use crate::io::ObjectStore;
 
 /// Object Reader
@@ -65,6 +66,20 @@ impl<'a> ObjectReader<'a> {
             self.cached_metadata = Some(self.object_store.inner.head(&self.path).await?);
         };
         Ok(self.cached_metadata.as_ref().map_or(0, |m| m.size))
+    }
+
+    /// Read a Protobuf-backed struct at file position: `pos`.
+    pub async fn read_struct<
+        'm,
+        M: Message + Default + 'static,
+        T: ProtoStruct<Proto = M> + From<M>,
+    >(
+        &mut self,
+        pos: usize,
+    ) -> Result<T> {
+        let msg = self.read_message::<M>(pos).await?;
+        let obj = T::from(msg);
+        Ok(obj)
     }
 
     /// Read a protobuf message at position `pos`.

--- a/rust/src/io/object_reader.rs
+++ b/rust/src/io/object_reader.rs
@@ -129,11 +129,11 @@ impl<'a> ObjectReader<'a> {
     ) -> Result<ArrayRef> {
         use arrow_schema::DataType::*;
         let decoder: Box<dyn Decoder + Send> = match data_type {
-            Utf8 => Box::new(BinaryDecoder::<Utf8Type>::new(&self, position, length)),
-            Binary => Box::new(BinaryDecoder::<BinaryType>::new(&self, position, length)),
-            LargeUtf8 => Box::new(BinaryDecoder::<LargeUtf8Type>::new(&self, position, length)),
+            Utf8 => Box::new(BinaryDecoder::<Utf8Type>::new(self, position, length)),
+            Binary => Box::new(BinaryDecoder::<BinaryType>::new(self, position, length)),
+            LargeUtf8 => Box::new(BinaryDecoder::<LargeUtf8Type>::new(self, position, length)),
             LargeBinary => Box::new(BinaryDecoder::<LargeBinaryType>::new(
-                &self, position, length,
+                self, position, length,
             )),
             _ => {
                 return Err(Error::IO(

--- a/rust/src/io/object_store.rs
+++ b/rust/src/io/object_store.rs
@@ -76,7 +76,7 @@ impl ObjectStore {
             "s3" => {
                 scheme = "s3".to_string();
                 match AmazonS3Builder::from_env()
-                    .with_bucket_name(bucket_name.clone())
+                    .with_bucket_name(bucket_name)
                     .build()
                 {
                     Ok(s3) => Arc::new(s3),
@@ -113,7 +113,7 @@ impl ObjectStore {
     pub async fn open(&self, path: &Path) -> Result<ObjectReader> {
         match ObjectReader::new(self, path.clone(), self.prefetch_size) {
             Ok(r) => Ok(r),
-            Err(e) => Err(e.into()),
+            Err(e) => Err(e),
         }
     }
 }

--- a/rust/src/io/reader.rs
+++ b/rust/src/io/reader.rs
@@ -38,7 +38,7 @@ use crate::error::{Error, Result};
 use crate::format::Manifest;
 use crate::format::{pb, Metadata, PageTable};
 use crate::io::object_reader::ObjectReader;
-use crate::io::{read_message, read_metadata_offset};
+use crate::io::{read_metadata_offset, read_struct};
 use crate::{
     datatypes::{Field, Schema},
     format::PageInfo,
@@ -108,8 +108,7 @@ impl<'a> FileReader<'a> {
             object_reader.read_struct(metadata_pos).await?
         } else {
             let offset = tail_bytes.len() - (file_size - metadata_pos);
-            let proto = read_message::<pb::Metadata>(&tail_bytes.slice(offset..))?;
-            Metadata::from(proto)
+            read_struct(&tail_bytes.slice(offset..))?
         };
 
         let (projection, num_columns) = if let Some(m) = manifest {

--- a/rust/src/io/reader.rs
+++ b/rust/src/io/reader.rs
@@ -69,7 +69,7 @@ pub async fn read_manifest(object_store: &ObjectStore, path: &Path) -> Result<Ma
     assert!(file_size - manifest_pos < buf.len());
     let proto =
         pb::Manifest::decode(&buf[buf.len() - (file_size - manifest_pos) + 4..buf.len() - 16])?;
-    Ok(Manifest::from(&proto))
+    Ok(Manifest::from(proto))
 }
 
 /// Lance File Reader.
@@ -102,24 +102,22 @@ impl<'a> FileReader<'a> {
             )
             .await?;
         let metadata_pos = read_metadata_offset(&tail_bytes)?;
-        let metadata_pb = if metadata_pos < file_size - tail_bytes.len() {
+
+        let metadata: Metadata = if metadata_pos < file_size - tail_bytes.len() {
             // We have not read the metadata bytes yet.
-            object_reader
-                .read_message::<pb::Metadata>(metadata_pos)
-                .await?
+            object_reader.read_struct(metadata_pos).await?
         } else {
             let offset = tail_bytes.len() - (file_size - metadata_pos);
-            read_message::<pb::Metadata>(&tail_bytes.slice(offset..))?
+            let proto = read_message::<pb::Metadata>(&tail_bytes.slice(offset..))?;
+            Metadata::from(proto)
         };
-        let metadata = Metadata::from(&metadata_pb);
 
         let (projection, num_columns) = if let Some(m) = manifest {
             (m.schema.clone(), m.schema.max_field_id().unwrap())
         } else {
-            let manifest_pb = object_reader
-                .read_message::<pb::Manifest>(metadata.manifest_position.unwrap())
+            let m: Manifest = object_reader
+                .read_struct(metadata.manifest_position.unwrap())
                 .await?;
-            let m = Manifest::from(&manifest_pb);
             (m.schema.clone(), m.schema.max_field_id().unwrap())
         };
         let page_table = PageTable::new(


### PR DESCRIPTION
Provide `read_struct<T: ProtoStruct>(pos)` and `write_struct<T: ProtoStruct>(pos)` .