### PR TITLE
[Rust] Read batch with rowid as a meta column.

### DIFF
--- a/rust/src/dataset/scanner.rs
+++ b/rust/src/dataset/scanner.rs
@@ -52,6 +52,9 @@ pub struct Scanner<'a> {
     offset: Option<i64>,
 
     fragments: Vec<Fragment>,
+
+    /// Scan the dataset with a meta column: "_rowid"
+    with_row_id: bool,
 }
 
 impl<'a> Scanner<'a> {
@@ -62,6 +65,7 @@ impl<'a> Scanner<'a> {
             limit: None,
             offset: None,
             fragments: dataset.fragments().to_vec(),
+            with_row_id: false,
         }
     }
 
@@ -77,6 +81,12 @@ impl<'a> Scanner<'a> {
     pub fn limit(&mut self, limit: i64, offset: Option<i64>) -> &mut Self {
         self.limit = Some(limit);
         self.offset = offset;
+        self
+    }
+
+    /// Instruct the scanner to return the `_rowid` meta column from the dataset.
+    pub fn with_row_id(&mut self) -> &mut Self {
+        self.with_row_id = true;
         self
     }
 
@@ -103,6 +113,7 @@ impl<'a> Scanner<'a> {
             manifest,
             PREFECTH_SIZE,
             &self.projections,
+            self.with_row_id,
         )
     }
 }
@@ -119,6 +130,7 @@ impl ScannerStream {
         manifest: Arc<Manifest>,
         prefetch_size: usize,
         schema: &Schema,
+        with_row_id: bool,
     ) -> Self {
         let (tx, rx) = mpsc::channel(prefetch_size);
 
@@ -127,17 +139,24 @@ impl ScannerStream {
             for frag in &fragments {
                 let data_file = &frag.files[0];
                 let path = data_dir.child(data_file.path.clone());
-                let reader =
-                    match FileReader::new(&object_store, &path, Some(manifest.as_ref())).await {
-                        Ok(mut r) => {
-                            r.set_projection(schema.clone());
-                            r
-                        }
-                        Err(e) => {
-                            tx.send(Err(e)).await.unwrap();
-                            continue;
-                        }
-                    };
+                let reader = match FileReader::try_new_with_fragment(
+                    &object_store,
+                    &path,
+                    frag.id,
+                    Some(manifest.as_ref()),
+                )
+                .await
+                {
+                    Ok(mut r) => {
+                        r.set_projection(schema.clone());
+                        r.with_row_id(with_row_id);
+                        r
+                    }
+                    Err(e) => {
+                        tx.send(Err(e)).await.unwrap();
+                        continue;
+                    }
+                };
                 for batch_id in 0..reader.num_batches() {
                     tx.send(reader.read_batch(batch_id as i32).await)
                         .await

--- a/rust/src/dataset/scanner.rs
+++ b/rust/src/dataset/scanner.rs
@@ -179,10 +179,3 @@ impl Stream for ScannerStream {
         std::pin::Pin::into_inner(self).rx.poll_recv(cx)
     }
 }
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-
-    use futures::stream::StreamExt;
-}

--- a/rust/src/format/metadata.rs
+++ b/rust/src/format/metadata.rs
@@ -78,9 +78,9 @@ impl Metadata {
             .push(batch_len + self.batch_offsets.last().unwrap())
     }
 
-    /// Get the logical length of a batch.
-    pub fn get_batch_length(&self, batch_id: usize) -> Option<i32> {
-        self.batch_offsets.get(batch_id).copied()
+    /// Get the starting offset of the batch.
+    pub fn get_offset(&self, batch_id: i32) -> Option<i32> {
+        self.batch_offsets.get(batch_id as usize).copied()
     }
 }
 

--- a/rust/src/io/writer.rs
+++ b/rust/src/io/writer.rs
@@ -405,7 +405,7 @@ mod tests {
         file_writer.write(&batch).await.unwrap();
         file_writer.finish().await.unwrap();
 
-        let reader = FileReader::new(&store, &path, None).await.unwrap();
+        let reader = FileReader::try_new(&store, &path).await.unwrap();
         let actual = reader.read_batch(0).await.unwrap();
         assert_eq!(actual, batch);
     }


### PR DESCRIPTION
Similar to the `rowid/object id` in Postgres, `_rowid` can be used to refer to a row reliably.  Reliability here means that appending and adding/removing columns (schema evolution) does not change the row id. It will only be changed when background compaction happens, or deleting rows. 

We can use this ID in the index for fast row look up across the Dataset. But it could need future work to keep index updated with the dataset changes.
