### PR TITLE
L2 distance

### DIFF
--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -35,7 +35,7 @@ async-recursion = "1.0"
 async-trait = "0.1.60"
 byteorder = "1.4.3"
 chrono = "0.4.23"
-clap = { version = "4.0.32", features = ["derive"], optional = true }
+clap = { version = "4.1.1", features = ["derive"], optional = true }
 object_store = { version = "0.5", features = ["aws"] }
 pin-project = "1.0"
 prost = "0.11"
@@ -48,9 +48,18 @@ futures = "0.3"
 [build-dependencies]
 prost-build = "0.11"
 
+[dev-dependencies]
+criterion = { version="0.4", features = ["async", "async_tokio"]}
+pprof = { version = "0.11", features = ["flamegraph", "criterion"] }
+clap = { version = "4.1.1", features = ["derive"] }
+
 [features]
 cli = ["clap"]
 
 [[bin]]
 name = "lq"
 required-features = ["cli"]
+
+[[bench]]
+name = "distance"
+harness = false

--- a/rust/benches/distance.rs
+++ b/rust/benches/distance.rs
@@ -1,0 +1,47 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+use criterion::{criterion_group, criterion_main, Criterion};
+
+use arrow_array::FixedSizeListArray;
+
+use lance::utils::distance::{l2_distance, l2_distance_arrow};
+use lance::{arrow::FixedSizeListArrayExt, utils::testing::generate_random_array};
+
+fn bench_distance(c: &mut Criterion) {
+    const DIMENSION: i32 = 1024;
+
+    let key = generate_random_array(DIMENSION as usize);
+    // 1M of 1024 D vectors. 4GB in memory.
+    let values = generate_random_array(1024 * 1024 * DIMENSION as usize);
+    let target = FixedSizeListArray::try_new(values, DIMENSION).unwrap();
+
+    c.bench_function("L2 distance", |b| {
+        b.iter(|| {
+            l2_distance(&key, &target).unwrap();
+        })
+    });
+
+    c.bench_function("L2_distance_arrow", |b| {
+        b.iter(|| {
+            l2_distance(&key, &target).unwrap();
+        })
+    });
+}
+
+criterion_group!(benches, bench_distance);
+criterion_main!(benches);

--- a/rust/src/utils.rs
+++ b/rust/src/utils.rs
@@ -15,4 +15,7 @@
 // specific language governing permissions and limitations
 // under the License.
 
+//! Various utilities
+
 pub mod distance;
+pub mod testing;

--- a/rust/src/utils.rs
+++ b/rust/src/utils.rs
@@ -15,19 +15,4 @@
 // specific language governing permissions and limitations
 // under the License.
 
-//! Lance Columnar Data Format
-//!
-//! Lance columnar data format is an alternative to Parquet. It provides 100x faster for random access,
-//! automatic versioning, optimized for computer vision, bioinformatics, spatial and ML data.
-//! [Apache Arrow](https://arrow.apache.org/) and DuckDB compatible.
-
-pub mod arrow;
-pub mod dataset;
-pub mod datatypes;
-pub mod encodings;
-pub mod error;
-pub mod format;
-pub mod io;
-pub mod utils;
-
-pub use error::{Error, Result};
+pub mod distance;

--- a/rust/src/utils/distance.rs
+++ b/rust/src/utils/distance.rs
@@ -77,12 +77,12 @@ fn l2_distance_x86_64(from: &Float32Array, to: &FixedSizeListArray) -> Result<Ar
         Float32Array::from_trusted_len_iter(
             (0..to.len())
                 .map(|idx| {
-                    return euclidean_distance_fma(
+                    euclidean_distance_fma(
                         from_vector,
-                        &buffer[idx * dimension as usize..(idx + 1) * dimension as usize],
-                    );
+                        &buffer[idx * dimension..(idx + 1) * dimension],
+                    )
                 })
-                .map(|d| Some(d)),
+                .map(Some),
         )
     };
     Ok(Arc::new(scores))
@@ -108,7 +108,7 @@ pub fn l2_distance(from: &Float32Array, to: &FixedSizeListArray) -> Result<Arc<F
                     let arr = left.as_any().downcast_ref::<Float32Array>().unwrap();
                     l2_distance_arrow(from, arr)
                 })
-                .map(|d| Some(d)),
+                .map(Some),
         )
     };
     Ok(Arc::new(scores))

--- a/rust/src/utils/distance.rs
+++ b/rust/src/utils/distance.rs
@@ -91,7 +91,7 @@ fn l2_distance_x86_64(from: &Float32Array, to: &FixedSizeListArray) -> Result<Ar
 /// Euclidean Distance (L2) from one vector to a list of vectors.
 pub fn l2_distance(from: &Float32Array, to: &FixedSizeListArray) -> Result<Arc<Float32Array>> {
     assert_eq!(from.len(), to.value_length() as usize);
-    debug_assert_eq!(to.value_type(), DataType::Float32);
+    assert_eq!(to.value_type(), DataType::Float32);
 
     #[cfg(any(target_arch = "x86_64"))]
     {

--- a/rust/src/utils/distance.rs
+++ b/rust/src/utils/distance.rs
@@ -1,0 +1,134 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+//! Compute distance
+//!
+
+use std::sync::Arc;
+
+use arrow_arith::{aggregate::sum, arity::binary};
+use arrow_array::{
+    cast::as_primitive_array, types::Float32Type, Array, FixedSizeListArray, Float32Array,
+};
+use arrow_schema::DataType;
+
+use crate::Result;
+
+// TODO: wait [std::simd] to be stable to replace manually written AVX/FMA code.
+//
+// `from` and `to` must have the same length.
+#[cfg(any(target_arch = "x86_64"))]
+#[target_feature(enable = "fma")]
+unsafe fn euclidean_distance_fma(from: &[f32], to: &[f32]) -> f32 {
+    use std::arch::x86_64::*;
+    debug_assert_eq!(from.len(), to.len());
+
+    let len = from.len();
+    let mut sums = _mm256_setzero_ps();
+    for i in (0..len).step_by(8) {
+        // Cache line-aligned
+        let left = _mm256_load_ps(from.as_ptr().add(i));
+        let right = _mm256_load_ps(to.as_ptr().add(i));
+        let sub = _mm256_sub_ps(left, right);
+        // sum = sub * sub + sum
+        sums = _mm256_fmadd_ps(sub, sub, sums);
+    }
+    // Shift and add vector, until only 1 value left.
+    for _ in 0..3 {
+        let shifted = _mm256_permute2f128_ps(sums, sums, 81);
+        sums = _mm256_add_ps(sums, shifted);
+    }
+    let mut results: [f32; 8] = [0f32; 8];
+    _mm256_storeu_ps(results.as_mut_ptr(), sums);
+    results[7]
+}
+
+// Calculate L2 distance directly using Arrow compute kernels.
+//
+#[inline]
+pub(crate) fn l2_distance_arrow(from: &Float32Array, to: &Float32Array) -> f32 {
+    let mul: Float32Array = binary(from, to, |a, b| (a - b).powf(2.0)).unwrap();
+    sum(&mul).unwrap()
+}
+
+/// Euclidean Distance (L2) from a point to a list of points.
+pub fn l2_distance(from: &Float32Array, to: &FixedSizeListArray) -> Result<Arc<Float32Array>> {
+    assert_eq!(from.len(), to.value_length() as usize);
+    assert_eq!(to.value_type(), DataType::Float32);
+    assert_eq!(
+        to.value_length() % 8,
+        0,
+        "Vector dimension must be a mulitply of 8"
+    );
+
+    #[cfg(any(target_arch = "x86_64"))]
+    {
+        let inner_array = to.values();
+        let buffer = as_primitive_array::<Float32Type>(&inner_array).values();
+        let dimension = from.len();
+    };
+    let scores: Float32Array = unsafe {
+        Float32Array::from_trusted_len_iter(
+            (0..to.len())
+                .map(|idx| {
+                    #[cfg(any(target_arch = "x86_64"))]
+                    {
+                        if is_x86_feature_detected!("fma") {
+                            return euclidean_distance_fma(
+                                from.values(),
+                                &buffer[idx * dimension as usize..(idx + 1) * dimension as usize],
+                            );
+                        }
+                    }
+                    // Fallback
+                    let left = to.value(idx);
+                    let arr = left.as_any().downcast_ref::<Float32Array>().unwrap();
+                    l2_distance_arrow(from, arr)
+                })
+                .map(|d| Some(d)),
+        )
+    };
+    Ok(Arc::new(scores))
+}
+
+#[cfg(test)]
+mod tests {
+
+    use super::*;
+
+    use arrow_array::types::Float32Type;
+
+    #[test]
+    fn test_euclidean_distance() {
+        let mat = FixedSizeListArray::from_iter_primitive::<Float32Type, _, _>(
+            vec![
+                Some((0..8).map(|v| Some(v as f32)).collect::<Vec<_>>()),
+                Some((1..9).map(|v| Some(v as f32)).collect::<Vec<_>>()),
+                Some((2..10).map(|v| Some(v as f32)).collect::<Vec<_>>()),
+                Some((3..11).map(|v| Some(v as f32)).collect::<Vec<_>>()),
+            ],
+            8,
+        );
+        let point = Float32Array::from((2..10).map(|v| Some(v as f32)).collect::<Vec<_>>());
+        let scores = l2_distance(&point, &mat).unwrap();
+
+        assert_eq!(
+            scores.as_ref(),
+            &Float32Array::from(vec![32.0, 8.0, 0.0, 8.0])
+        );
+    }
+}

--- a/rust/src/utils/distance.rs
+++ b/rust/src/utils/distance.rs
@@ -21,9 +21,7 @@
 use std::sync::Arc;
 
 use arrow_arith::{aggregate::sum, arity::binary};
-use arrow_array::{
-    cast::as_primitive_array, types::Float32Type, Array, FixedSizeListArray, Float32Array,
-};
+use arrow_array::{Array, FixedSizeListArray, Float32Array};
 use arrow_schema::DataType;
 
 use crate::Result;
@@ -67,6 +65,8 @@ pub fn l2_distance_arrow(from: &Float32Array, to: &Float32Array) -> f32 {
 
 #[cfg(any(target_arch = "x86_64"))]
 fn l2_distance_x86_64(from: &Float32Array, to: &FixedSizeListArray) -> Result<Arc<Float32Array>> {
+    use arrow::{cast::as_primitive_array, types::Float32Type};
+
     let inner_array = to.values();
     let buffer = as_primitive_array::<Float32Type>(&inner_array).values();
     let dimension = from.len();

--- a/rust/src/utils/distance.rs
+++ b/rust/src/utils/distance.rs
@@ -60,7 +60,7 @@ unsafe fn euclidean_distance_fma(from: &[f32], to: &[f32]) -> f32 {
 // Calculate L2 distance directly using Arrow compute kernels.
 //
 #[inline]
-pub(crate) fn l2_distance_arrow(from: &Float32Array, to: &Float32Array) -> f32 {
+pub fn l2_distance_arrow(from: &Float32Array, to: &Float32Array) -> f32 {
     let mul: Float32Array = binary(from, to, |a, b| (a - b).powf(2.0)).unwrap();
     sum(&mul).unwrap()
 }
@@ -75,12 +75,10 @@ pub fn l2_distance(from: &Float32Array, to: &FixedSizeListArray) -> Result<Arc<F
         "Vector dimension must be a mulitply of 8"
     );
 
-    #[cfg(any(target_arch = "x86_64"))]
-    {
-        let inner_array = to.values();
-        let buffer = as_primitive_array::<Float32Type>(&inner_array).values();
-        let dimension = from.len();
-    };
+    let inner_array = to.values();
+    let buffer = as_primitive_array::<Float32Type>(&inner_array).values();
+    let dimension = from.len();
+
     let scores: Float32Array = unsafe {
         Float32Array::from_trusted_len_iter(
             (0..to.len())

--- a/rust/src/utils/distance.rs
+++ b/rust/src/utils/distance.rs
@@ -144,17 +144,12 @@ mod tests {
     #[test]
     fn test_odd_length_vector() {
         let mat = FixedSizeListArray::from_iter_primitive::<Float32Type, _, _>(
-            vec![
-                Some((0..5).map(|v| Some(v as f32)).collect::<Vec<_>>()),
-            ],
+            vec![Some((0..5).map(|v| Some(v as f32)).collect::<Vec<_>>())],
             5,
         );
         let point = Float32Array::from((2..7).map(|v| Some(v as f32)).collect::<Vec<_>>());
         let scores = l2_distance(&point, &mat).unwrap();
 
-        assert_eq!(
-            scores.as_ref(),
-            &Float32Array::from(vec![20.0])
-        );
+        assert_eq!(scores.as_ref(), &Float32Array::from(vec![20.0]));
     }
 }

--- a/rust/src/utils/distance.rs
+++ b/rust/src/utils/distance.rs
@@ -91,7 +91,7 @@ fn l2_distance_x86_64(from: &Float32Array, to: &FixedSizeListArray) -> Result<Ar
 /// Euclidean Distance (L2) from one vector to a list of vectors.
 pub fn l2_distance(from: &Float32Array, to: &FixedSizeListArray) -> Result<Arc<Float32Array>> {
     assert_eq!(from.len(), to.value_length() as usize);
-    assert_eq!(to.value_type(), DataType::Float32);
+    debug_assert_eq!(to.value_type(), DataType::Float32);
 
     #[cfg(any(target_arch = "x86_64"))]
     {

--- a/rust/src/utils/distance.rs
+++ b/rust/src/utils/distance.rs
@@ -65,7 +65,7 @@ pub fn l2_distance_arrow(from: &Float32Array, to: &Float32Array) -> f32 {
 
 #[cfg(any(target_arch = "x86_64"))]
 fn l2_distance_x86_64(from: &Float32Array, to: &FixedSizeListArray) -> Result<Arc<Float32Array>> {
-    use arrow::{cast::as_primitive_array, types::Float32Type};
+    use arrow_array::{cast::as_primitive_array, types::Float32Type};
 
     let inner_array = to.values();
     let buffer = as_primitive_array::<Float32Type>(&inner_array).values();

--- a/rust/src/utils/testing.rs
+++ b/rust/src/utils/testing.rs
@@ -1,0 +1,33 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+//! Testing utilities
+
+use rand::Rng;
+use std::iter::repeat_with;
+
+use arrow_array::Float32Array;
+
+/// Create a random float32 array.
+pub fn generate_random_array(n: usize) -> Float32Array {
+    let mut rng = rand::thread_rng();
+    Float32Array::from(
+        repeat_with(|| rng.gen::<f32>())
+            .take(n)
+            .collect::<Vec<f32>>(),
+    )
+}


### PR DESCRIPTION
Use `std::arch` provided by the stable Rust. We could use `std::simd` when it is ready for stable rust. 

```
# On X86_64
RUSTFLAGS="-C target-feature=+avx2,+fma" cargo bench --bench distance
# On M1
cargo bench --bench distance
```

| CPU  |  Default | Fallback | Naive Arrow Impl (+AVX2) |
|-----|--------|---------|--------------------------|
| AMD 5900X (X86_64) | 204ms | 1070ms | 1457ms |
| Apple M1 |  1267ms (same as fallback) | 1272 ms | 1551ms |

Note that, I did not hand write simd for M1 / Aarch64 yet, `std::arch::aarch64` seems not stable at the moment. Also, no BLAS-based performance is tested so that there is no extra dependency for Lance. 
