### PR TITLE
Make Scan an ExecNode

### DIFF
--- a/rust/src/dataset.rs
+++ b/rust/src/dataset.rs
@@ -134,14 +134,14 @@ impl Dataset {
             ));
         }
 
-        let mut manifest = Manifest::new(&schema);
         let mut fragment_id = 0;
+        let mut fragments: Vec<Fragment> = vec![];
 
         macro_rules! new_writer {
             () => {{
                 let file_path = format!("{}.lance", Uuid::new_v4());
                 let fragment = Fragment::with_file(fragment_id, &file_path, &schema);
-                manifest.fragments.push(fragment);
+                fragments.push(fragment);
                 fragment_id += 1;
                 Some(new_file_writer(&object_store, &file_path, &schema).await?)
             }};
@@ -178,6 +178,7 @@ impl Dataset {
         };
         drop(writer);
 
+        let mut manifest = Manifest::new(&schema, Arc::new(fragments));
         let manifest_file_path = object_store
             .base_path()
             .child(VERSIONS_DIR)
@@ -247,7 +248,7 @@ impl Dataset {
         &self.manifest.schema
     }
 
-    pub fn fragments(&self) -> &[Fragment] {
+    pub fn fragments(&self) -> &Arc<Vec<Fragment>> {
         &self.manifest.fragments
     }
 }

--- a/rust/src/dataset/scanner.rs
+++ b/rust/src/dataset/scanner.rs
@@ -144,7 +144,7 @@ impl<'a> Scanner<'a> {
 #[pin_project::pin_project]
 pub struct ScannerStream {
     #[pin]
-    exec_node: Box<dyn ExecNode + Unpin>,
+    exec_node: Box<dyn ExecNode + Unpin + Send>,
 }
 
 impl ScannerStream {

--- a/rust/src/format/manifest.rs
+++ b/rust/src/format/manifest.rs
@@ -15,6 +15,8 @@
 // specific language governing permissions and limitations
 // under the License.
 
+use std::sync::Arc;
+
 use super::Fragment;
 use crate::datatypes::Schema;
 use crate::format::{pb, ProtoStruct};
@@ -34,15 +36,15 @@ pub struct Manifest {
     pub version: u64,
 
     /// Fragments, the pieces to build the dataset.
-    pub fragments: Vec<Fragment>,
+    pub fragments: Arc<Vec<Fragment>>,
 }
 
 impl Manifest {
-    pub fn new(schema: &Schema) -> Self {
+    pub fn new(schema: &Schema, fragments: Arc<Vec<Fragment>>) -> Self {
         Self {
             schema: schema.clone(),
             version: 1,
-            fragments: vec![],
+            fragments,
         }
     }
 }
@@ -56,7 +58,7 @@ impl From<pb::Manifest> for Manifest {
         Self {
             schema: Schema::from(&p.fields),
             version: p.version,
-            fragments: p.fragments.iter().map(Fragment::from).collect(),
+            fragments: Arc::new(p.fragments.iter().map(Fragment::from).collect()),
         }
     }
 }

--- a/rust/src/io.rs
+++ b/rust/src/io.rs
@@ -25,6 +25,7 @@ use prost::bytes::Bytes;
 use prost::Message;
 use tokio::io::{AsyncWrite, AsyncWriteExt};
 
+pub(crate) mod exec;
 pub mod object_reader;
 pub mod object_store;
 pub mod object_writer;

--- a/rust/src/io/exec.rs
+++ b/rust/src/io/exec.rs
@@ -1,0 +1,35 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+use arrow_array::RecordBatch;
+use futures::stream::Stream;
+
+mod scan;
+
+use crate::Result;
+pub(crate) use scan::Scan;
+
+#[derive(Debug)]
+pub enum NodeType {
+    /// Dataset Scan
+    SCAN = 1,
+}
+
+/// I/O Exec Node
+pub(crate) trait ExecNode: Stream<Item = Result<RecordBatch>> {
+    fn node_type(&self) -> NodeType;
+}

--- a/rust/src/io/exec/scan.rs
+++ b/rust/src/io/exec/scan.rs
@@ -1,0 +1,113 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+use std::pin::Pin;
+use std::sync::Arc;
+use std::task::{Context, Poll};
+
+use arrow_array::RecordBatch;
+use futures::stream::Stream;
+use object_store::path::Path;
+use tokio::sync::mpsc::{self, Receiver};
+
+use super::{ExecNode, NodeType};
+use crate::format::Manifest;
+use crate::io::{FileReader, ObjectStore};
+use crate::{datatypes::Schema, format::Fragment};
+use crate::{Error, Result};
+
+/// Dataset Scan Node.
+pub(crate) struct Scan {
+    rx: Receiver<Result<RecordBatch>>,
+}
+
+impl Scan {
+    /// Create a new scan node.
+    pub fn new(
+        object_store: &'static ObjectStore,
+        data_dir: Path,
+        fragments: &'static [Fragment],
+        projection: &Schema,
+        manifest: Arc<Manifest>,
+        prefetch_size: usize,
+        with_row_id: bool,
+    ) -> Self {
+        let (tx, rx) = mpsc::channel(8);
+
+        let projection = projection.clone();
+        tokio::spawn(async move {
+            for frag in fragments {
+                if tx.is_closed() {
+                    return;
+                }
+                let data_file = &frag.files[0];
+                let path = data_dir.child(data_file.path.clone());
+                let reader = match FileReader::try_new_with_fragment(
+                    &object_store,
+                    &path,
+                    frag.id,
+                    Some(manifest.as_ref()),
+                )
+                .await
+                {
+                    Ok(mut r) => {
+                        r.set_projection(projection.clone());
+                        r.with_row_id(with_row_id);
+                        r
+                    }
+                    Err(e) => {
+                        tx.send(Err(Error::IO(format!(
+                            "Failed to open file: {}: {}",
+                            path.to_string(),
+                            e.to_string()
+                        ))))
+                        .await
+                        .expect("Scanner sending error message");
+                        // Stop reading.
+                        break;
+                    }
+                };
+                for batch_id in 0..reader.num_batches() {
+                    let batch = reader.read_batch(batch_id as i32).await;
+                    if tx.is_closed() {
+                        return;
+                    }
+                    tx.send(batch)
+                        .await
+                        .expect("Scanner: failed to send record batch");
+                }
+            }
+            drop(tx)
+        });
+
+        Self { rx }
+    }
+}
+
+impl ExecNode for Scan {
+    fn node_type(&self) -> NodeType {
+        NodeType::SCAN
+    }
+}
+
+impl Stream for Scan {
+    type Item = Result<RecordBatch>;
+
+    fn poll_next(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Option<Self::Item>> {
+        Pin::into_inner(self).rx.poll_recv(cx)
+    }
+}

--- a/rust/src/io/exec/scan.rs
+++ b/rust/src/io/exec/scan.rs
@@ -100,7 +100,7 @@ impl Scan {
 
         Self {
             rx,
-            _io_thread: io_thread,  // Drop the background I/O thread with the stream.
+            _io_thread: io_thread, // Drop the background I/O thread with the stream.
         }
     }
 }

--- a/rust/src/io/writer.rs
+++ b/rust/src/io/writer.rs
@@ -287,7 +287,7 @@ impl<'a> FileWriter<'a> {
             field.set_dictionary_values(value_arrs);
         }
         // Write dictionary values to disk.
-        let mut manifest = Manifest::new(&schema);
+        let mut manifest = Manifest::new(&schema, Arc::new(vec![]));
         let pos = write_manifest(&mut self.object_writer, &mut manifest).await?;
 
         // Step 3. Write metadata.


### PR DESCRIPTION
This PR refactors the scanner code out to a `Scan : ExecNode` struct. This is the first step to build the i/o execution path similar to C++.