### PR TITLE
Cli to operate on dataset indices

### DIFF
--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -47,6 +47,7 @@ rand = "0.8.3"
 futures = "0.3"
 uuid = { version = "1.2", features = ["v4"] }
 faiss = {version = "0.11.0", features=["gpu"], optional = true }
+path-absolutize = "3.0.14"
 
 [build-dependencies]
 prost-build = "0.11"

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -46,6 +46,7 @@ url = "2.3"
 rand = "0.8.3"
 futures = "0.3"
 uuid = { version = "1.2", features = ["v4"] }
+faiss = {version = "0.11.0", features=["gpu"], optional = true }
 
 [build-dependencies]
 prost-build = "0.11"
@@ -58,6 +59,7 @@ tempfile = "3.3.0"
 
 [features]
 cli = ["clap"]
+# faiss = ["faiss"]
 
 [[bin]]
 name = "lq"

--- a/rust/src/bin/lq.rs
+++ b/rust/src/bin/lq.rs
@@ -26,6 +26,7 @@ use futures::TryStreamExt;
 use lance::dataset::Dataset;
 use lance::datatypes::Schema;
 use lance::index::vector::ivf::IvfPqIndexBuilder;
+use lance::index::IndexBuilder;
 use lance::{Error, Result};
 
 #[derive(Parser)]
@@ -188,9 +189,8 @@ async fn create_index(
     match index_type {
         IndexType::IvfPQ => {
             let builder =
-                IvfPqIndexBuilder::try_new(dataset, column, num_partitions, num_sub_vectors)?;
-
-            Ok(())
+                IvfPqIndexBuilder::try_new(dataset, name, column, num_partitions, num_sub_vectors)?;
+            builder.build()
         }
     }
 }

--- a/rust/src/bin/lq.rs
+++ b/rust/src/bin/lq.rs
@@ -56,18 +56,34 @@ enum Commands {
         #[arg(value_enum)]
         action: IndexAction,
 
-        // Dataset URI.
+        /// Dataset URI.
         uri: String,
 
         /// The column to build index on.
-        #[arg(short, long)]
+        #[arg(short, long, value_name = "NAME")]
         column: Option<String>,
+
+        /// Set index type
+        #[arg(short = 't', long = "type", value_enum, value_name = "TYPE")]
+        index_type: IndexType,
+
+        /// Nunber of IVF partitions. Only useful when the index type is 'ivf-pq'.
+        #[arg(short = 'p', long, default_value_t = 64, value_name = "NUM")]
+        num_partitions: u32,
+
+        #[arg(short = 's', long, default_value_t = 8, value_name = "NUM")]
+        num_sub_vectors: u32,
     },
 }
 
 #[derive(Copy, Clone, PartialEq, Eq, PartialOrd, Ord, ValueEnum)]
 enum IndexAction {
     Create,
+}
+
+#[derive(Copy, Clone, PartialEq, Eq, PartialOrd, Ord, ValueEnum)]
+enum IndexType {
+    IvfPQ,
 }
 
 #[tokio::main]
@@ -97,6 +113,9 @@ async fn main() {
             action,
             uri,
             column,
+            index_type,
+            num_partitions,
+            num_sub_vectors,
         } => {}
     }
 }

--- a/rust/src/bin/lq.rs
+++ b/rust/src/bin/lq.rs
@@ -25,6 +25,7 @@ use futures::TryStreamExt;
 
 use lance::dataset::Dataset;
 use lance::datatypes::Schema;
+use lance::index::vector::ivf::IvfPqIndexBuilder;
 use lance::{Error, Result};
 
 #[derive(Parser)]
@@ -180,5 +181,16 @@ async fn create_index(
             )))
         }
     }
-    todo!()
+
+    let index_type =
+        index_type.ok_or_else(|| Err(Error::IO("Must specify index type".to_string())))?;
+
+    match index_type {
+        IndexType::IvfPQ => {
+            let builder =
+                IvfPqIndexBuilder::try_new(dataset, column, num_partitions, num_sub_vectors)?;
+
+            Ok(())
+        }
+    }
 }

--- a/rust/src/bin/lq.rs
+++ b/rust/src/bin/lq.rs
@@ -165,9 +165,11 @@ async fn create_index(
         .field(col)
         .ok_or_else(|| Error::IO(format!("Column {} does not exist in dataset", col)))?;
     if matches!(field.data_type(), DataType::FixedSizeList(elem_type, _)) {
-
     } else {
-        return Err(Error::IO(format!("Column '{}' is not a vector column: {}", col, field)));
+        return Err(Error::IO(format!(
+            "Column '{}' is not a vector column: {}",
+            col, field
+        )));
     }
     todo!()
 }

--- a/rust/src/bin/lq.rs
+++ b/rust/src/bin/lq.rs
@@ -164,12 +164,21 @@ async fn create_index(
     let field = schema
         .field(col)
         .ok_or_else(|| Error::IO(format!("Column {} does not exist in dataset", col)))?;
-    if matches!(field.data_type(), DataType::FixedSizeList(elem_type, _)) {
-    } else {
-        return Err(Error::IO(format!(
-            "Column '{}' is not a vector column: {}",
-            col, field
-        )));
+    match field.data_type() {
+        DataType::FixedSizeList(elem_type, _) => {
+            if !matches!(elem_type.as_ref(), &DataType::Float32) {
+                return Err(Error::IO(format!(
+                    "Only support to create vector index on f32 vector, but got {}",
+                    elem_type.as_ref()
+                )));
+            }
+        }
+        _ => {
+            return Err(Error::IO(format!(
+                "Column '{}' is not a vector column: {}",
+                col, field
+            )))
+        }
     }
     todo!()
 }

--- a/rust/src/bin/lq.rs
+++ b/rust/src/bin/lq.rs
@@ -116,6 +116,8 @@ async fn main() {
             index_type,
             num_partitions,
             num_sub_vectors,
-        } => {}
+        } => {
+            let dataset = Dataset::open(uri).await.unwrap();
+        }
     }
 }

--- a/rust/src/bin/lq.rs
+++ b/rust/src/bin/lq.rs
@@ -166,7 +166,7 @@ async fn create_index(
         .ok_or_else(|| Error::IO(format!("Column {} does not exist in dataset", col)))?;
     match field.data_type() {
         DataType::FixedSizeList(elem_type, _) => {
-            if !matches!(elem_type.as_ref(), &DataType::Float32) {
+            if !matches!(elem_type.as_ref().data_type(), &DataType::Float32) {
                 return Err(Error::IO(format!(
                     "Only support to create vector index on f32 vector, but got {}",
                     elem_type.as_ref()

--- a/rust/src/bin/lq.rs
+++ b/rust/src/bin/lq.rs
@@ -15,16 +15,13 @@
 // specific language governing permissions and limitations
 // under the License.
 
-use std::num;
-
 use arrow_array::RecordBatch;
 use arrow_schema::DataType;
 use clap::{Parser, Subcommand, ValueEnum};
-use futures::stream::{Stream, StreamExt};
+use futures::stream::StreamExt;
 use futures::TryStreamExt;
 
 use lance::dataset::Dataset;
-use lance::datatypes::Schema;
 use lance::index::vector::ivf::IvfPqIndexBuilder;
 use lance::index::IndexBuilder;
 use lance::{Error, Result};
@@ -183,14 +180,18 @@ async fn create_index(
         }
     }
 
-    let index_type =
-        index_type.ok_or_else(|| Err(Error::IO("Must specify index type".to_string())))?;
+    let index_type = index_type.ok_or_else(|| Error::IO("Must specify index type".to_string()))?;
 
     match index_type {
         IndexType::IvfPQ => {
-            let builder =
-                IvfPqIndexBuilder::try_new(dataset, name, column, num_partitions, num_sub_vectors)?;
-            builder.build()
+            let builder = IvfPqIndexBuilder::try_new(
+                dataset,
+                name.as_ref().unwrap(),
+                column.as_ref().unwrap(),
+                *num_partitions,
+                *num_sub_vectors,
+            )?;
+            builder.build().await
         }
     }
 }

--- a/rust/src/dataset.rs
+++ b/rust/src/dataset.rs
@@ -23,8 +23,8 @@ use crate::format::{Fragment, Manifest};
 use crate::io::{read_manifest, write_manifest, FileReader, FileWriter};
 use crate::io::{read_metadata_offset, ObjectStore};
 use crate::{Error, Result};
-pub use write::*;
 pub use scanner::ROW_ID;
+pub use write::*;
 
 const LATEST_MANIFEST_NAME: &str = "_latest.manifest";
 const VERSIONS_DIR: &str = "_versions";

--- a/rust/src/dataset.rs
+++ b/rust/src/dataset.rs
@@ -123,8 +123,6 @@ impl Dataset {
             Err(object_store::Error::NotFound { path: _, source: _ }) => { /* we are good */ }
             Err(e) => return Err(Error::from(e)),
         }
-        println!("After check manifest path exist");
-
         let params = params.unwrap_or_default();
 
         let mut peekable = batches.peekable();

--- a/rust/src/dataset.rs
+++ b/rust/src/dataset.rs
@@ -116,12 +116,14 @@ impl Dataset {
         // 1. check the directory does not exist.
         let object_store = Arc::new(ObjectStore::new(uri)?);
 
+        println!("After creating object store");
         let latest_manifest_path = latest_manifest_path(object_store.base_path());
         match object_store.inner.head(&latest_manifest_path).await {
             Ok(_) => return Err(Error::IO(format!("Dataset already exists: {}", uri))),
             Err(object_store::Error::NotFound { path: _, source: _ }) => { /* we are good */ }
             Err(e) => return Err(Error::from(e)),
         }
+        println!("After check manifest path exist");
 
         let params = params.unwrap_or_default();
 
@@ -148,6 +150,7 @@ impl Dataset {
                 let fragment = Fragment::with_file(fragment_id, &file_path, &schema);
                 fragments.push(fragment);
                 fragment_id += 1;
+                println!("Try to open file: {}\n", file_path);
                 Some(new_file_writer(&object_store, &file_path, &schema).await?)
             }};
         }

--- a/rust/src/dataset.rs
+++ b/rust/src/dataset.rs
@@ -24,6 +24,7 @@ use crate::io::{read_manifest, write_manifest, FileReader, FileWriter};
 use crate::io::{read_metadata_offset, ObjectStore};
 use crate::{Error, Result};
 pub use write::*;
+pub use scanner::ROW_ID;
 
 const LATEST_MANIFEST_NAME: &str = "_latest.manifest";
 const VERSIONS_DIR: &str = "_versions";

--- a/rust/src/dataset/scanner.rs
+++ b/rust/src/dataset/scanner.rs
@@ -31,6 +31,9 @@ use crate::index::vector::Query;
 use crate::io::exec::{ExecNodeBox, KNNFlat, Limit, Scan, Take};
 use crate::Result;
 
+/// Column name for the meta row ID.
+pub const ROW_ID: &str = "_rowid";
+
 /// Dataset Scanner
 ///
 /// ```rust,ignore

--- a/rust/src/datatypes.rs
+++ b/rust/src/datatypes.rs
@@ -546,7 +546,7 @@ impl Schema {
         Ok(Self::from(&filtered_protos))
     }
 
-    fn field(&self, name: &str) -> Option<&Field> {
+    pub fn field(&self, name: &str) -> Option<&Field> {
         self.fields.iter().find(|f| f.name == name)
     }
 

--- a/rust/src/error.rs
+++ b/rust/src/error.rs
@@ -73,4 +73,10 @@ impl From<tokio::task::JoinError> for Error {
     }
 }
 
+impl From<object_store::path::Error> for Error {
+    fn from(e: object_store::path::Error) -> Self {
+        Self::IO(e.to_string())
+    }
+}
+
 impl std::error::Error for Error {}

--- a/rust/src/index.rs
+++ b/rust/src/index.rs
@@ -18,6 +18,8 @@
 //! Secondary Index
 //!
 
+use async_trait::async_trait;
+
 /// Protobuf definitions for the index on-disk format.
 #[allow(clippy::all)]
 pub mod pb {
@@ -25,3 +27,22 @@ pub mod pb {
 }
 
 pub mod vector;
+
+use crate::Result;
+
+/// Index Type
+pub enum IndexType {
+    // Preserve 0-100 for simple indices.
+
+    // 100+ and up for vector index.
+    /// Flat vector index.
+    Vector = 100,
+}
+
+/// Builds index.
+#[async_trait]
+pub trait IndexBuilder {
+    fn index_type() -> IndexType;
+
+    async fn build(&self) -> Result<()>;
+}

--- a/rust/src/index/vector.rs
+++ b/rust/src/index/vector.rs
@@ -25,6 +25,7 @@ use async_trait::async_trait;
 
 pub mod flat;
 pub mod ivf;
+mod kmeans;
 mod pq;
 
 use crate::Result;

--- a/rust/src/index/vector/ivf.rs
+++ b/rust/src/index/vector/ivf.rs
@@ -549,7 +549,8 @@ impl IndexBuilder for IvfPqIndexBuilder<'_> {
         let path = self
             .dataset
             .indices_dir()
-            .child(format!("{}.idx", self.column));
+            .child(self.name.as_str())
+            .child(INDEX_FILE_NAME);
         let mut writer = object_store.create(&path).await?;
 
         // First, scan the dataset to train IVF models.

--- a/rust/src/index/vector/ivf.rs
+++ b/rust/src/index/vector/ivf.rs
@@ -533,6 +533,11 @@ impl IndexBuilder for IvfPqIndexBuilder<'_> {
 
     /// Build the IVF_PQ index
     async fn build(&self) -> Result<()> {
+        println!(
+            "Building vector index: IVF{},PQ{}",
+            self.num_partitions, self.num_sub_vectors
+        );
+
         // Step 1. Sanity check
         let schema = self.dataset.schema().field(&self.column);
         if schema.is_none() {

--- a/rust/src/index/vector/ivf.rs
+++ b/rust/src/index/vector/ivf.rs
@@ -595,7 +595,7 @@ impl IndexBuilder for IvfPqIndexBuilder<'_> {
                 .await?;
         }
 
-        let metadata = IvfPQIndexMetadata{
+        let metadata = IvfPQIndexMetadata {
             name: self.name.clone(),
             column: self.column.clone(),
             dimension: self.dimension as u32,

--- a/rust/src/index/vector/ivf.rs
+++ b/rust/src/index/vector/ivf.rs
@@ -552,6 +552,7 @@ impl IndexBuilder for IvfPqIndexBuilder<'_> {
             .child(format!("{}.idx", self.column));
         let mut writer = object_store.create(&path).await?;
 
+        // First, scan the dataset to train IVF models.
         let mut scanner = self.dataset.scan();
         scanner.project(&[&self.column])?;
 
@@ -565,6 +566,7 @@ impl IndexBuilder for IvfPqIndexBuilder<'_> {
             .await?,
         );
 
+        // A new scanner, with row id to build inverted index.
         scanner = self.dataset.scan();
         scanner.project(&[&self.column])?;
         scanner.with_row_id();

--- a/rust/src/index/vector/kmeans.rs
+++ b/rust/src/index/vector/kmeans.rs
@@ -1,0 +1,16 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.

--- a/rust/src/index/vector/kmeans.rs
+++ b/rust/src/index/vector/kmeans.rs
@@ -14,3 +14,34 @@
 // KIND, either express or implied.  See the License for the
 // specific language governing permissions and limitations
 // under the License.
+
+use arrow_array::Float32Array;
+
+use crate::Result;
+
+#[cfg(feature = "faiss")]
+fn train_kmeans_faiss(
+    array: &Float32Array,
+    dimension: usize,
+    num_clusters: u32,
+    max_iters: u32,
+) -> Result<Vec<f32>> {
+    use faiss::cluster::kmeans_clustering;
+
+    let model = kmeans_clustering(dimension as u32, num_clusters, array.values()).unwrap();
+    Ok(model.centroids)
+}
+
+/// Train kmean models and returns the centroids.
+pub fn train_kmeans(
+    array: &Float32Array,
+    dimension: usize,
+    num_clusters: u32,
+    max_iterations: u32,
+) -> Result<Vec<f32>> {
+    #[cfg(feature = "faiss")]
+    return train_kmeans(array, dimension, num_clusters, max_iterations);
+
+    #[cfg(not(feature = "faiss"))]
+    Ok(vec![])
+}

--- a/rust/src/index/vector/kmeans.rs
+++ b/rust/src/index/vector/kmeans.rs
@@ -29,7 +29,7 @@ fn train_kmeans_faiss(
     use faiss::cluster::kmeans_clustering;
 
     let model = kmeans_clustering(dimension as u32, num_clusters, array.values()).unwrap();
-    Ok(model.centroids)
+    Ok(model.centroids.into())
 }
 
 /// Fallback implementation of KMeans.

--- a/rust/src/index/vector/kmeans.rs
+++ b/rust/src/index/vector/kmeans.rs
@@ -25,13 +25,14 @@ fn train_kmeans_faiss(
     dimension: usize,
     num_clusters: u32,
     max_iters: u32,
-) -> Result<Vec<f32>> {
+) -> Result<Float32Array> {
     use faiss::cluster::kmeans_clustering;
 
     let model = kmeans_clustering(dimension as u32, num_clusters, array.values()).unwrap();
     Ok(model.centroids)
 }
 
+/// Fallback implementation of KMeans.
 fn train_kmeans_fallback() -> Result<Float32Array> {
     todo!()
 }

--- a/rust/src/index/vector/kmeans.rs
+++ b/rust/src/index/vector/kmeans.rs
@@ -32,16 +32,20 @@ fn train_kmeans_faiss(
     Ok(model.centroids)
 }
 
-/// Train kmean models and returns the centroids.
+fn train_kmeans_fallback() -> Result<Float32Array> {
+    todo!()
+}
+
+/// Train kmean model and returns the centroids of each cluster.
 pub fn train_kmeans(
     array: &Float32Array,
     dimension: usize,
     num_clusters: u32,
     max_iterations: u32,
-) -> Result<Vec<f32>> {
+) -> Result<Float32Array> {
     #[cfg(feature = "faiss")]
     return train_kmeans(array, dimension, num_clusters, max_iterations);
 
     #[cfg(not(feature = "faiss"))]
-    Ok(vec![])
+    train_kmeans_fallback()
 }

--- a/rust/src/index/vector/kmeans.rs
+++ b/rust/src/index/vector/kmeans.rs
@@ -45,7 +45,7 @@ pub fn train_kmeans(
     max_iterations: u32,
 ) -> Result<Float32Array> {
     #[cfg(feature = "faiss")]
-    return train_kmeans(array, dimension, num_clusters, max_iterations);
+    return train_kmeans_faiss(array, dimension, num_clusters, max_iterations);
 
     #[cfg(not(feature = "faiss"))]
     train_kmeans_fallback()

--- a/rust/src/index/vector/pq.rs
+++ b/rust/src/index/vector/pq.rs
@@ -234,8 +234,8 @@ impl ProductQuantizer {
             .unwrap()
     }
 
-     /// Transform the vector array to PQ code array.
-     fn transform(&self, sub_vectors: &[FixedSizeListArray]) -> FixedSizeListArray {
+    /// Transform the vector array to PQ code array.
+    fn transform(&self, sub_vectors: &[FixedSizeListArray]) -> FixedSizeListArray {
         assert_eq!(sub_vectors.len(), self.num_sub_vectors as usize);
 
         let capacity = sub_vectors.len() * sub_vectors[0].len();
@@ -246,8 +246,7 @@ impl ProductQuantizer {
             for i in 0..vec.len() {
                 let value = vec.value(i);
                 let vector: &Float32Array = as_primitive_array(value.as_ref());
-                let id =
-                    argmin(l2_distance(vector, &centroids).unwrap().as_ref()).unwrap() as u8;
+                let id = argmin(l2_distance(vector, &centroids).unwrap().as_ref()).unwrap() as u8;
                 pg_codebook_builder[i * self.num_sub_vectors as usize + idx] = id;
             }
         }
@@ -272,8 +271,7 @@ impl ProductQuantizer {
             // Centroids for one sub vector.
             let values = sub_vec.values();
             let flatten_array: &Float32Array = as_primitive_array(&values);
-            let centroids =
-                train_kmeans(flatten_array, dimension, num_centorids, 100)?;
+            let centroids = train_kmeans(flatten_array, dimension, num_centorids, 100)?;
             // TODO: COPIED COPIED COPIED
             unsafe {
                 codebook_builder.append_trusted_len_iter(centroids.values().iter().copied());

--- a/rust/src/index/vector/pq.rs
+++ b/rust/src/index/vector/pq.rs
@@ -26,6 +26,7 @@ use arrow_ord::sort::sort_to_indices;
 use arrow_schema::{DataType, Field as ArrowField, Schema as ArrowSchema};
 use arrow_select::take::take;
 
+use crate::index::vector::kmeans::train_kmeans;
 use crate::io::object_reader::ObjectReader;
 use crate::Result;
 use crate::{arrow::*, utils::distance::l2_distance};
@@ -232,6 +233,56 @@ impl ProductQuantizer {
         FixedSizeListArray::try_new(f32_arr, self.dimension as i32 / self.num_sub_vectors as i32)
             .unwrap()
     }
+
+     /// Transform the vector array to PQ code array.
+     fn transform(&self, sub_vectors: &[FixedSizeListArray]) -> FixedSizeListArray {
+        assert_eq!(sub_vectors.len(), self.num_sub_vectors as usize);
+
+        let capacity = sub_vectors.len() * sub_vectors[0].len();
+        let mut pg_codebook_builder: Vec<u8> = vec![0; capacity];
+        for (idx, vec) in sub_vectors.iter().enumerate() {
+            // Centroids for sub-vector.
+            let centroids = self.centroids(idx);
+            for i in 0..vec.len() {
+                let value = vec.value(i);
+                let vector: &Float32Array = as_primitive_array(value.as_ref());
+                let id =
+                    argmin(l2_distance(vector, &centroids).unwrap().as_ref()).unwrap() as u8;
+                pg_codebook_builder[i * self.num_sub_vectors as usize + idx] = id;
+            }
+        }
+        let values = UInt8Array::from_iter(pg_codebook_builder);
+        FixedSizeListArray::try_new(values, self.num_sub_vectors as i32).unwrap()
+    }
+
+    /// Train a [ProductQuantizer] using an array of vectors.
+    pub fn fit_transform(&mut self, data: &FixedSizeListArray) -> Result<FixedSizeListArray> {
+        assert!(data.value_length() % self.num_sub_vectors as i32 == 0);
+        assert_eq!(data.value_type(), DataType::Float32);
+        assert_eq!(data.null_count(), 0);
+
+        let sub_vectors = divide_to_subvectors(data, self.num_sub_vectors as i32);
+        let num_centorids = 2_u32.pow(self.nbits);
+        let dimension = data.value_length() as usize / self.num_sub_vectors;
+
+        let mut codebook_builder =
+            Float32Builder::with_capacity(num_centorids as usize * data.value_length() as usize);
+        // TODO: parallel training.
+        for sub_vec in &sub_vectors {
+            // Centroids for one sub vector.
+            let values = sub_vec.values();
+            let flatten_array: &Float32Array = as_primitive_array(&values);
+            let centroids =
+                train_kmeans(flatten_array, dimension, num_centorids, 100)?;
+            // TODO: COPIED COPIED COPIED
+            unsafe {
+                codebook_builder.append_trusted_len_iter(centroids.values().iter().copied());
+            }
+        }
+        let pd_centroids = codebook_builder.finish();
+        self.codebook = Some(Arc::new(pd_centroids));
+        Ok(self.transform(&sub_vectors))
+    }
 }
 
 /// Divide a 2D vector in [`FixedSizeListArray`] to `m` sub-vectors.
@@ -263,4 +314,38 @@ fn divide_to_subvectors(array: &FixedSizeListArray, m: i32) -> Vec<FixedSizeList
         subarrays.push(sub_array);
     }
     subarrays
+}
+
+#[cfg(test)]
+mod tests {
+
+    use super::*;
+    use arrow_array::types::Float32Type;
+
+    #[test]
+    fn test_divide_to_subvectors() {
+        let values = Float32Array::from_iter((0..320).map(|v| v as f32));
+        // A [10, 32] array.
+        let mat = FixedSizeListArray::try_new(values, 32).unwrap();
+        let sub_vectors = divide_to_subvectors(&mat, 4);
+        assert_eq!(sub_vectors.len(), 4);
+        assert_eq!(sub_vectors[0].len(), 10);
+        assert_eq!(sub_vectors[0].value_length(), 8);
+
+        assert_eq!(
+            sub_vectors[0],
+            FixedSizeListArray::from_iter_primitive::<Float32Type, _, _>(
+                (0..10)
+                    .map(|i| {
+                        Some(
+                            (i * 32..i * 32 + 8)
+                                .map(|v| Some(v as f32))
+                                .collect::<Vec<_>>(),
+                        )
+                    })
+                    .collect::<Vec<_>>(),
+                8
+            )
+        );
+    }
 }

--- a/rust/src/io/object_store.rs
+++ b/rust/src/io/object_store.rs
@@ -17,6 +17,7 @@
 
 //! Wraps [ObjectStore](object_store::ObjectStore)
 
+use std::fs;
 use std::sync::Arc;
 
 use ::object_store::{
@@ -55,10 +56,11 @@ impl ObjectStore {
         let parsed = match Url::parse(uri) {
             Ok(u) => u,
             Err(ParseError::RelativeUrlWithoutBase) => {
+                let absolute_path = fs::canonicalize(uri)?;
                 return Ok(Self {
                     inner: Arc::new(LocalFileSystem::new()),
                     scheme: String::from("file"),
-                    base_path: Path::from(uri),
+                    base_path: Path::from_absolute_path(absolute_path)?,
                     prefetch_size: 4 * 1024,
                 });
             }

--- a/rust/src/io/object_store.rs
+++ b/rust/src/io/object_store.rs
@@ -24,8 +24,8 @@ use ::object_store::{
     aws::AmazonS3Builder, memory::InMemory, path::Path, ObjectStore as OSObjectStore,
 };
 use object_store::local::LocalFileSystem;
-use url::{ParseError, Url};
 use path_absolutize::*;
+use url::{ParseError, Url};
 
 use crate::error::{Error, Result};
 use crate::io::object_reader::ObjectReader;

--- a/rust/src/io/object_store.rs
+++ b/rust/src/io/object_store.rs
@@ -17,7 +17,6 @@
 
 //! Wraps [ObjectStore](object_store::ObjectStore)
 
-use std::fs;
 use std::sync::Arc;
 
 use ::object_store::{

--- a/rust/src/io/object_writer.rs
+++ b/rust/src/io/object_writer.rs
@@ -18,11 +18,13 @@
 use std::pin::Pin;
 use std::task::{Context, Poll};
 
+use arrow_array::Array;
 use object_store::{path::Path, MultipartId};
 use pin_project::pin_project;
 use prost::Message;
 use tokio::io::{AsyncWrite, AsyncWriteExt};
 
+use crate::encodings::plain::PlainEncoder;
 use crate::format::{ProtoStruct, MAGIC, MAJOR_VERSION, MINOR_VERSION};
 use crate::io::ObjectStore;
 use crate::Result;
@@ -75,6 +77,12 @@ impl ObjectWriter {
     ) -> Result<usize> {
         let msg: M = M::from(obj);
         self.write_protobuf(&msg).await
+    }
+
+    /// Write array using plain encoding.
+    pub async fn write_plain_encoded_array(&mut self, array: &dyn Array) -> Result<usize> {
+        let mut encoder = PlainEncoder::new(self, array.data_type());
+        encoder.encode(array).await
     }
 
     /// Write magics to the tail of a file before closing the file.

--- a/rust/src/io/object_writer.rs
+++ b/rust/src/io/object_writer.rs
@@ -79,7 +79,9 @@ impl ObjectWriter {
         self.write_protobuf(&msg).await
     }
 
-    /// Write array using plain encoding.
+    /// Write an array using plain encoding.
+    ///
+    /// Returns the file position if success.
     pub async fn write_plain_encoded_array(&mut self, array: &dyn Array) -> Result<usize> {
         let mut encoder = PlainEncoder::new(self, array.data_type());
         encoder.encode(array).await


### PR DESCRIPTION
```
Usage: lq index [OPTIONS] <ACTION> <URI>

Arguments:
  <ACTION>  Actions on index [possible values: create]
  <URI>     Dataset URI

Options:
  -c, --column <NAME>          The column to build index on
  -n, --name <NAME>            Index name
  -t, --type <TYPE>            Set index type [possible values: ivf-pq]
  -p, --num-partitions <NUM>   Nunber of IVF partitions. Only useful when the index type is 'ivf-pq' [default: 64]
  -s, --num-sub-vectors <NUM>  Number of sub-vectors in Product Quantizer [default: 8]
  -h, --help                   Print help

```