### PR TITLE
Replace ObjectReader as a pub trait. 

### DIFF
--- a/rust/src/dataset.rs
+++ b/rust/src/dataset.rs
@@ -20,8 +20,8 @@ use self::scanner::Scanner;
 use crate::arrow::*;
 use crate::datatypes::Schema;
 use crate::format::{Fragment, Manifest};
+use crate::io::{object_reader::read_struct, read_metadata_offset, ObjectStore};
 use crate::io::{read_manifest, write_manifest, FileReader, FileWriter};
-use crate::io::{read_metadata_offset, ObjectStore};
 use crate::{Error, Result};
 pub use scanner::ROW_ID;
 pub use write::*;
@@ -87,7 +87,7 @@ impl Dataset {
         let base_path = object_store.base_path().clone();
         let latest_manifest_path = latest_manifest_path(&base_path);
 
-        let mut object_reader = object_store.open(&latest_manifest_path).await?;
+        let object_reader = object_store.open(&latest_manifest_path).await?;
         let bytes = object_store
             .inner
             .get(&latest_manifest_path)
@@ -95,7 +95,7 @@ impl Dataset {
             .bytes()
             .await?;
         let offset = read_metadata_offset(&bytes)?;
-        let mut manifest: Manifest = object_reader.read_struct(offset).await?;
+        let mut manifest: Manifest = read_struct(&object_reader, offset).await?;
         manifest.schema.load_dictionary(&object_reader).await?;
         Ok(Self {
             object_store,

--- a/rust/src/dataset.rs
+++ b/rust/src/dataset.rs
@@ -95,8 +95,8 @@ impl Dataset {
             .bytes()
             .await?;
         let offset = read_metadata_offset(&bytes)?;
-        let mut manifest: Manifest = read_struct(&object_reader, offset).await?;
-        manifest.schema.load_dictionary(&object_reader).await?;
+        let mut manifest: Manifest = read_struct(object_reader.as_ref(), offset).await?;
+        manifest.schema.load_dictionary(object_reader.as_ref()).await?;
         Ok(Self {
             object_store,
             base: base_path,

--- a/rust/src/dataset.rs
+++ b/rust/src/dataset.rs
@@ -96,7 +96,10 @@ impl Dataset {
             .await?;
         let offset = read_metadata_offset(&bytes)?;
         let mut manifest: Manifest = read_struct(object_reader.as_ref(), offset).await?;
-        manifest.schema.load_dictionary(object_reader.as_ref()).await?;
+        manifest
+            .schema
+            .load_dictionary(object_reader.as_ref())
+            .await?;
         Ok(Self {
             object_store,
             base: base_path,

--- a/rust/src/datatypes.rs
+++ b/rust/src/datatypes.rs
@@ -15,7 +15,7 @@ use async_recursion::async_recursion;
 use crate::arrow::DataTypeExt;
 use crate::encodings::Encoding;
 use crate::format::pb;
-use crate::io::object_reader::{read_fixed_stride_array, ObjectReader, read_binary_array};
+use crate::io::object_reader::{read_binary_array, read_fixed_stride_array, ObjectReader};
 use crate::{Error, Result};
 
 /// LogicalType is a string presentation of arrow type.

--- a/rust/src/datatypes.rs
+++ b/rust/src/datatypes.rs
@@ -15,7 +15,7 @@ use async_recursion::async_recursion;
 use crate::arrow::DataTypeExt;
 use crate::encodings::Encoding;
 use crate::format::pb;
-use crate::io::object_reader::CloudObjectReader;
+use crate::io::object_reader::{read_fixed_stride_array, ObjectReader, read_binary_array};
 use crate::{Error, Result};
 
 /// LogicalType is a string presentation of arrow type.
@@ -386,7 +386,7 @@ impl Field {
     }
 
     #[async_recursion]
-    async fn load_dictionary<'a>(&mut self, reader: &'a CloudObjectReader<'_>) -> Result<()> {
+    async fn load_dictionary<'a>(&mut self, reader: &dyn ObjectReader) -> Result<()> {
         if let DataType::Dictionary(_, value_type) = self.data_type() {
             assert!(self.dictionary.is_some());
             if let Some(dict_info) = self.dictionary.as_mut() {
@@ -394,26 +394,26 @@ impl Field {
                 match value_type.as_ref() {
                     Utf8 | Binary => {
                         dict_info.values = Some(
-                            reader
-                                .read_binary_array(
-                                    value_type.as_ref(),
-                                    dict_info.offset,
-                                    dict_info.length,
-                                    ..,
-                                )
-                                .await?,
+                            read_binary_array(
+                                reader,
+                                value_type.as_ref(),
+                                dict_info.offset,
+                                dict_info.length,
+                                ..,
+                            )
+                            .await?,
                         );
                     }
                     Int8 | Int16 | Int32 | Int64 | UInt8 | UInt16 | UInt32 | UInt64 => {
                         dict_info.values = Some(
-                            reader
-                                .read_fixed_stride_array(
-                                    value_type.as_ref(),
-                                    dict_info.offset,
-                                    dict_info.length,
-                                    ..,
-                                )
-                                .await?,
+                            read_fixed_stride_array(
+                                reader,
+                                value_type.as_ref(),
+                                dict_info.offset,
+                                dict_info.length,
+                                ..,
+                            )
+                            .await?,
                         );
                     }
                     _ => {
@@ -616,7 +616,7 @@ impl Schema {
     }
 
     /// Load dictionary value array from manifest files.
-    pub(crate) async fn load_dictionary<'a>(&mut self, reader: &'a CloudObjectReader<'_>) -> Result<()> {
+    pub(crate) async fn load_dictionary<'a>(&mut self, reader: &dyn ObjectReader) -> Result<()> {
         for field in self.fields.as_mut_slice() {
             field.load_dictionary(reader).await?;
         }

--- a/rust/src/datatypes.rs
+++ b/rust/src/datatypes.rs
@@ -15,7 +15,7 @@ use async_recursion::async_recursion;
 use crate::arrow::DataTypeExt;
 use crate::encodings::Encoding;
 use crate::format::pb;
-use crate::io::object_reader::ObjectReader;
+use crate::io::object_reader::CloudObjectReader;
 use crate::{Error, Result};
 
 /// LogicalType is a string presentation of arrow type.
@@ -386,7 +386,7 @@ impl Field {
     }
 
     #[async_recursion]
-    async fn load_dictionary<'a>(&mut self, reader: &'a ObjectReader<'_>) -> Result<()> {
+    async fn load_dictionary<'a>(&mut self, reader: &'a CloudObjectReader<'_>) -> Result<()> {
         if let DataType::Dictionary(_, value_type) = self.data_type() {
             assert!(self.dictionary.is_some());
             if let Some(dict_info) = self.dictionary.as_mut() {
@@ -616,7 +616,7 @@ impl Schema {
     }
 
     /// Load dictionary value array from manifest files.
-    pub(crate) async fn load_dictionary<'a>(&mut self, reader: &'a ObjectReader<'_>) -> Result<()> {
+    pub(crate) async fn load_dictionary<'a>(&mut self, reader: &'a CloudObjectReader<'_>) -> Result<()> {
         for field in self.fields.as_mut_slice() {
             field.load_dictionary(reader).await?;
         }

--- a/rust/src/encodings/binary.rs
+++ b/rust/src/encodings/binary.rs
@@ -114,7 +114,7 @@ impl<'a, T: ByteArrayType> BinaryDecoder<'a, T> {
     ///     let object_store = ObjectStore::new(":memory:").unwrap();
     ///     let path = Path::from("/data.lance");
     ///     let reader = object_store.open(&path).await.unwrap();
-    ///     let string_decoder = BinaryDecoder::<Utf8Type>::new(&reader, 100, 1024);
+    ///     let string_decoder = BinaryDecoder::<Utf8Type>::new(reader.as_ref(), 100, 1024);
     /// };
     /// ```
     pub fn new(reader: &'a dyn ObjectReader, position: usize, length: usize) -> Self {
@@ -288,8 +288,8 @@ mod tests {
         let store = ObjectStore::memory();
         let path = Path::from("/foo");
         let pos = write_test_data(&store, &path, arr).await.unwrap();
-        let mut reader = store.open(&path).await.unwrap();
-        let decoder = BinaryDecoder::<GenericStringType<O>>::new(&mut reader, pos, arr.len());
+        let reader = store.open(&path).await.unwrap();
+        let decoder = BinaryDecoder::<GenericStringType<O>>::new(reader.as_ref(), pos, arr.len());
         let actual_arr = decoder.decode().await.unwrap();
         assert_eq!(
             actual_arr
@@ -328,8 +328,8 @@ mod tests {
         let pos = encoder.encode(&data).await.unwrap();
         object_writer.shutdown().await.unwrap();
 
-        let mut reader = store.open(&path).await.unwrap();
-        let decoder = BinaryDecoder::<Utf8Type>::new(&mut reader, pos, data.len());
+        let reader = store.open(&path).await.unwrap();
+        let decoder = BinaryDecoder::<Utf8Type>::new(reader.as_ref(), pos, data.len());
         assert_eq!(
             decoder.decode().await.unwrap().as_ref(),
             &StringArray::from_iter_values(["a", "b", "c", "d", "e", "f", "g"])
@@ -369,8 +369,8 @@ mod tests {
         let path = Path::from("/foo");
         let pos = write_test_data(&store, &path, &data).await.unwrap();
 
-        let mut reader = store.open(&path).await.unwrap();
-        let decoder = BinaryDecoder::<Utf8Type>::new(&mut reader, pos, data.len());
+        let reader = store.open(&path).await.unwrap();
+        let decoder = BinaryDecoder::<Utf8Type>::new(reader.as_ref(), pos, data.len());
 
         let actual = decoder
             .take(&UInt32Array::from_iter_values([1, 2, 5]))

--- a/rust/src/encodings/binary.rs
+++ b/rust/src/encodings/binary.rs
@@ -25,7 +25,7 @@ use super::Encoder;
 use super::{plain::PlainDecoder, AsyncIndex};
 use crate::encodings::Decoder;
 use crate::error::Result;
-use crate::io::object_reader::CloudObjectReader;
+use crate::io::object_reader::ObjectReader;
 use crate::io::object_writer::ObjectWriter;
 use crate::io::ReadBatchParams;
 
@@ -85,7 +85,7 @@ impl<'a> Encoder for BinaryEncoder<'a> {
 
 /// Var-binary encoding decoder.
 pub struct BinaryDecoder<'a, T: ByteArrayType> {
-    reader: &'a CloudObjectReader<'a>,
+    reader: &'a dyn ObjectReader,
 
     position: usize,
 
@@ -117,7 +117,7 @@ impl<'a, T: ByteArrayType> BinaryDecoder<'a, T> {
     ///     let string_decoder = BinaryDecoder::<Utf8Type>::new(&reader, 100, 1024);
     /// };
     /// ```
-    pub fn new(reader: &'a CloudObjectReader, position: usize, length: usize) -> Self {
+    pub fn new(reader: &'a dyn ObjectReader, position: usize, length: usize) -> Self {
         Self {
             reader,
             position,

--- a/rust/src/encodings/binary.rs
+++ b/rust/src/encodings/binary.rs
@@ -25,7 +25,7 @@ use super::Encoder;
 use super::{plain::PlainDecoder, AsyncIndex};
 use crate::encodings::Decoder;
 use crate::error::Result;
-use crate::io::object_reader::ObjectReader;
+use crate::io::object_reader::CloudObjectReader;
 use crate::io::object_writer::ObjectWriter;
 use crate::io::ReadBatchParams;
 
@@ -85,7 +85,7 @@ impl<'a> Encoder for BinaryEncoder<'a> {
 
 /// Var-binary encoding decoder.
 pub struct BinaryDecoder<'a, T: ByteArrayType> {
-    reader: &'a ObjectReader<'a>,
+    reader: &'a CloudObjectReader<'a>,
 
     position: usize,
 
@@ -117,7 +117,7 @@ impl<'a, T: ByteArrayType> BinaryDecoder<'a, T> {
     ///     let string_decoder = BinaryDecoder::<Utf8Type>::new(&reader, 100, 1024);
     /// };
     /// ```
-    pub fn new(reader: &'a ObjectReader, position: usize, length: usize) -> Self {
+    pub fn new(reader: &'a CloudObjectReader, position: usize, length: usize) -> Self {
         Self {
             reader,
             position,

--- a/rust/src/encodings/dictionary.rs
+++ b/rust/src/encodings/dictionary.rs
@@ -222,7 +222,7 @@ mod tests {
 
         let reader = store.open(&path).await.unwrap();
         let decoder = DictionaryDecoder::new(
-            &reader,
+            reader.as_ref(),
             pos,
             arr.len(),
             arr.data_type(),

--- a/rust/src/encodings/dictionary.rs
+++ b/rust/src/encodings/dictionary.rs
@@ -15,9 +15,10 @@
 // specific language governing permissions and limitations
 // under the License.
 
-//! Dictinary encoding.
+//! Dictionary encoding.
 //!
 
+use std::fmt;
 use std::sync::Arc;
 
 use arrow_array::cast::{as_dictionary_array, as_primitive_array};
@@ -34,7 +35,7 @@ use super::AsyncIndex;
 use crate::encodings::plain::PlainDecoder;
 use crate::encodings::{Decoder, Encoder};
 use crate::error::Result;
-use crate::io::{object_reader::CloudObjectReader, object_writer::ObjectWriter, ReadBatchParams};
+use crate::io::{object_reader::ObjectReader, object_writer::ObjectWriter, ReadBatchParams};
 use crate::Error;
 
 /// Encoder for Dictionary encoding.
@@ -84,9 +85,8 @@ impl<'a> Encoder for DictionaryEncoder<'a> {
 }
 
 /// Decoder for Dictionary encoding.
-#[derive(Debug)]
 pub struct DictionaryDecoder<'a> {
-    reader: &'a CloudObjectReader<'a>,
+    reader: &'a dyn ObjectReader,
     /// The start position of the key array in the file.
     position: usize,
     /// Number of the rows in this batch.
@@ -97,9 +97,20 @@ pub struct DictionaryDecoder<'a> {
     value_arr: ArrayRef,
 }
 
+impl fmt::Debug for DictionaryDecoder<'_> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("DictionaryDecoder")
+            .field("position", &self.position)
+            .field("length", &self.length)
+            .field("data_type", &self.data_type)
+            .field("value_arr", &self.value_arr)
+            .finish()
+    }
+}
+
 impl<'a> DictionaryDecoder<'a> {
     pub fn new(
-        reader: &'a CloudObjectReader<'a>,
+        reader: &'a dyn ObjectReader,
         position: usize,
         length: usize,
         data_type: &'a DataType,

--- a/rust/src/encodings/dictionary.rs
+++ b/rust/src/encodings/dictionary.rs
@@ -34,7 +34,7 @@ use super::AsyncIndex;
 use crate::encodings::plain::PlainDecoder;
 use crate::encodings::{Decoder, Encoder};
 use crate::error::Result;
-use crate::io::{object_reader::ObjectReader, object_writer::ObjectWriter, ReadBatchParams};
+use crate::io::{object_reader::CloudObjectReader, object_writer::ObjectWriter, ReadBatchParams};
 use crate::Error;
 
 /// Encoder for Dictionary encoding.
@@ -86,7 +86,7 @@ impl<'a> Encoder for DictionaryEncoder<'a> {
 /// Decoder for Dictionary encoding.
 #[derive(Debug)]
 pub struct DictionaryDecoder<'a> {
-    reader: &'a ObjectReader<'a>,
+    reader: &'a CloudObjectReader<'a>,
     /// The start position of the key array in the file.
     position: usize,
     /// Number of the rows in this batch.
@@ -99,7 +99,7 @@ pub struct DictionaryDecoder<'a> {
 
 impl<'a> DictionaryDecoder<'a> {
     pub fn new(
-        reader: &'a ObjectReader<'a>,
+        reader: &'a CloudObjectReader<'a>,
         position: usize,
         length: usize,
         data_type: &'a DataType,

--- a/rust/src/encodings/plain.rs
+++ b/rust/src/encodings/plain.rs
@@ -476,7 +476,7 @@ mod tests {
         assert_eq!(encoder.encode(&array).await.unwrap(), 0);
         writer.shutdown().await.unwrap();
 
-        let mut reader = store.open(&path).await.unwrap();
+        let reader = store.open(&path).await.unwrap();
         assert!(reader.size().await.unwrap() > 0);
         let decoder = PlainDecoder::new(&reader, array.data_type(), 0, array.len()).unwrap();
         assert_eq!(
@@ -518,7 +518,7 @@ mod tests {
         assert_eq!(encoder.encode(&array).await.unwrap(), 0);
         writer.shutdown().await.unwrap();
 
-        let mut reader = store.open(&path).await.unwrap();
+        let reader = store.open(&path).await.unwrap();
         assert!(reader.size().await.unwrap() > 0);
         let decoder = PlainDecoder::new(&reader, array.data_type(), 0, array.len()).unwrap();
 

--- a/rust/src/encodings/plain.rs
+++ b/rust/src/encodings/plain.rs
@@ -45,7 +45,7 @@ use crate::Error;
 use super::Decoder;
 use crate::encodings::AsyncIndex;
 use crate::error::Result;
-use crate::io::object_reader::CloudObjectReader;
+use crate::io::object_reader::ObjectReader;
 use crate::io::object_writer::ObjectWriter;
 use crate::io::ReadBatchParams;
 
@@ -100,7 +100,7 @@ impl<'a> PlainEncoder<'a> {
 
 /// Decoder for plain encoding.
 pub struct PlainDecoder<'a> {
-    reader: &'a CloudObjectReader<'a>,
+    reader: &'a dyn ObjectReader,
     data_type: &'a DataType,
     /// The start position of the batch in the file.
     position: usize,
@@ -119,7 +119,7 @@ fn make_byte_offset(data_type: &DataType, row_offset: usize) -> Result<usize> {
 
 impl<'a> PlainDecoder<'a> {
     pub fn new(
-        reader: &'a CloudObjectReader,
+        reader: &'a dyn ObjectReader,
         data_type: &'a DataType,
         position: usize,
         length: usize,

--- a/rust/src/encodings/plain.rs
+++ b/rust/src/encodings/plain.rs
@@ -478,7 +478,8 @@ mod tests {
 
         let reader = store.open(&path).await.unwrap();
         assert!(reader.size().await.unwrap() > 0);
-        let decoder = PlainDecoder::new(reader.as_ref(), array.data_type(), 0, array.len()).unwrap();
+        let decoder =
+            PlainDecoder::new(reader.as_ref(), array.data_type(), 0, array.len()).unwrap();
         assert_eq!(
             decoder.get(2..4).await.unwrap().as_ref(),
             &Int32Array::from_iter_values([2, 3])
@@ -520,7 +521,8 @@ mod tests {
 
         let reader = store.open(&path).await.unwrap();
         assert!(reader.size().await.unwrap() > 0);
-        let decoder = PlainDecoder::new(reader.as_ref(), array.data_type(), 0, array.len()).unwrap();
+        let decoder =
+            PlainDecoder::new(reader.as_ref(), array.data_type(), 0, array.len()).unwrap();
 
         let results = decoder
             .take(&UInt32Array::from_iter(

--- a/rust/src/encodings/plain.rs
+++ b/rust/src/encodings/plain.rs
@@ -373,9 +373,9 @@ mod tests {
         assert_eq!(encoder.encode(expected.as_ref()).await.unwrap(), 0);
         object_writer.shutdown().await.unwrap();
 
-        let mut reader = store.open(&path).await.unwrap();
+        let reader = store.open(&path).await.unwrap();
         assert!(reader.size().await.unwrap() > 0);
-        let decoder = PlainDecoder::new(&reader, &data_type, 0, expected.len()).unwrap();
+        let decoder = PlainDecoder::new(reader.as_ref(), &data_type, 0, expected.len()).unwrap();
         let arr = decoder.decode().await.unwrap();
         let actual = arr.as_ref();
         assert_eq!(expected.as_ref(), actual);
@@ -478,7 +478,7 @@ mod tests {
 
         let reader = store.open(&path).await.unwrap();
         assert!(reader.size().await.unwrap() > 0);
-        let decoder = PlainDecoder::new(&reader, array.data_type(), 0, array.len()).unwrap();
+        let decoder = PlainDecoder::new(reader.as_ref(), array.data_type(), 0, array.len()).unwrap();
         assert_eq!(
             decoder.get(2..4).await.unwrap().as_ref(),
             &Int32Array::from_iter_values([2, 3])
@@ -520,7 +520,7 @@ mod tests {
 
         let reader = store.open(&path).await.unwrap();
         assert!(reader.size().await.unwrap() > 0);
-        let decoder = PlainDecoder::new(&reader, array.data_type(), 0, array.len()).unwrap();
+        let decoder = PlainDecoder::new(reader.as_ref(), array.data_type(), 0, array.len()).unwrap();
 
         let results = decoder
             .take(&UInt32Array::from_iter(

--- a/rust/src/encodings/plain.rs
+++ b/rust/src/encodings/plain.rs
@@ -45,7 +45,7 @@ use crate::Error;
 use super::Decoder;
 use crate::encodings::AsyncIndex;
 use crate::error::Result;
-use crate::io::object_reader::ObjectReader;
+use crate::io::object_reader::CloudObjectReader;
 use crate::io::object_writer::ObjectWriter;
 use crate::io::ReadBatchParams;
 
@@ -100,7 +100,7 @@ impl<'a> PlainEncoder<'a> {
 
 /// Decoder for plain encoding.
 pub struct PlainDecoder<'a> {
-    reader: &'a ObjectReader<'a>,
+    reader: &'a CloudObjectReader<'a>,
     data_type: &'a DataType,
     /// The start position of the batch in the file.
     position: usize,
@@ -119,7 +119,7 @@ fn make_byte_offset(data_type: &DataType, row_offset: usize) -> Result<usize> {
 
 impl<'a> PlainDecoder<'a> {
     pub fn new(
-        reader: &'a ObjectReader,
+        reader: &'a CloudObjectReader,
         data_type: &'a DataType,
         position: usize,
         length: usize,

--- a/rust/src/format/page_table.rs
+++ b/rust/src/format/page_table.rs
@@ -24,7 +24,7 @@ use tokio::io::AsyncWriteExt;
 use crate::encodings::plain::PlainDecoder;
 use crate::encodings::Decoder;
 use crate::error::Result;
-use crate::io::object_reader::CloudObjectReader;
+use crate::io::object_reader::ObjectReader;
 use crate::io::object_writer::ObjectWriter;
 
 #[derive(Clone, Debug, PartialEq)]
@@ -50,7 +50,7 @@ pub struct PageTable {
 impl PageTable {
     /// Load [PageTable] from disk.
     pub async fn load<'a>(
-        reader: &'a CloudObjectReader<'_>,
+        reader: &dyn ObjectReader,
         position: usize,
         num_columns: i32,
         num_batches: i32,

--- a/rust/src/format/page_table.rs
+++ b/rust/src/format/page_table.rs
@@ -24,7 +24,7 @@ use tokio::io::AsyncWriteExt;
 use crate::encodings::plain::PlainDecoder;
 use crate::encodings::Decoder;
 use crate::error::Result;
-use crate::io::object_reader::ObjectReader;
+use crate::io::object_reader::CloudObjectReader;
 use crate::io::object_writer::ObjectWriter;
 
 #[derive(Clone, Debug, PartialEq)]
@@ -50,7 +50,7 @@ pub struct PageTable {
 impl PageTable {
     /// Load [PageTable] from disk.
     pub async fn load<'a>(
-        reader: &'a ObjectReader<'_>,
+        reader: &'a CloudObjectReader<'_>,
         position: usize,
         num_columns: i32,
         num_batches: i32,

--- a/rust/src/index/vector/ivf.rs
+++ b/rust/src/index/vector/ivf.rs
@@ -44,7 +44,7 @@ use super::{
     pq::{PQIndex, ProductQuantizer},
     Query, VectorIndex,
 };
-use crate::io::{object_reader::ObjectReader, read_message, read_metadata_offset};
+use crate::io::{object_reader::CloudObjectReader, read_message, read_metadata_offset};
 use crate::utils::distance::l2_distance;
 use crate::{arrow::*, index::pb::vector_index_stage::Stage};
 use crate::{dataset::scanner::Scanner, index::pb};
@@ -59,7 +59,7 @@ const INDEX_FILE_NAME: &str = "index.idx";
 /// IVF PQ Index.
 #[derive(Debug)]
 pub struct IvfPQIndex<'a> {
-    reader: ObjectReader<'a>,
+    reader: CloudObjectReader<'a>,
 
     /// Index name.
     name: String,

--- a/rust/src/index/vector/ivf.rs
+++ b/rust/src/index/vector/ivf.rs
@@ -44,7 +44,7 @@ use super::{
     pq::{PQIndex, ProductQuantizer},
     Query, VectorIndex,
 };
-use crate::io::{object_reader::CloudObjectReader, read_message, read_metadata_offset};
+use crate::io::{object_reader::{ObjectReader, CloudObjectReader}, read_message, read_metadata_offset};
 use crate::utils::distance::l2_distance;
 use crate::{arrow::*, index::pb::vector_index_stage::Stage};
 use crate::{dataset::scanner::Scanner, index::pb};

--- a/rust/src/index/vector/ivf.rs
+++ b/rust/src/index/vector/ivf.rs
@@ -46,7 +46,7 @@ use super::{
 };
 use crate::io::{
     object_reader::{read_message, CloudObjectReader, ObjectReader},
-    read_message as read_message_from_buf, read_metadata_offset,
+    read_message_from_buf, read_metadata_offset,
 };
 use crate::utils::distance::l2_distance;
 use crate::{arrow::*, index::pb::vector_index_stage::Stage};

--- a/rust/src/index/vector/ivf.rs
+++ b/rust/src/index/vector/ivf.rs
@@ -99,7 +99,7 @@ impl<'a> IvfPQIndex<'a> {
         let metadata_pos = read_metadata_offset(&tail_bytes)?;
         let proto: pb::Index = if metadata_pos < file_size - tail_bytes.len() {
             // We have not read the metadata bytes yet.
-            read_message(&reader, metadata_pos).await?
+            read_message(reader.as_ref(), metadata_pos).await?
         } else {
             let offset = tail_bytes.len() - (file_size - metadata_pos);
             read_message_from_buf(&tail_bytes.slice(offset..))?
@@ -107,7 +107,7 @@ impl<'a> IvfPQIndex<'a> {
         let index_metadata = IvfPQIndexMetadata::try_from(&proto)?;
 
         Ok(Self {
-            reader: Box::new(reader),
+            reader: reader,
             name: name.to_string(),
             column: index_metadata.column.clone(),
             dimension: index_metadata.dimension as usize,

--- a/rust/src/index/vector/pq.rs
+++ b/rust/src/index/vector/pq.rs
@@ -27,7 +27,7 @@ use arrow_schema::{DataType, Field as ArrowField, Schema as ArrowSchema};
 use arrow_select::take::take;
 
 use crate::index::vector::kmeans::train_kmeans;
-use crate::io::object_reader::CloudObjectReader;
+use crate::io::object_reader::{read_fixed_stride_array, ObjectReader};
 use crate::Result;
 use crate::{arrow::*, utils::distance::l2_distance};
 
@@ -74,27 +74,31 @@ pub struct PQIndex {
 impl PQIndex {
     /// Load a PQ index (page) from the disk.
     pub async fn load(
-        reader: &CloudObjectReader<'_>,
+        reader: &dyn ObjectReader,
         pq: &ProductQuantizer,
         offset: usize,
         length: usize,
     ) -> Result<PQIndex> {
         // TODO: read code book, PQ code and row_ids in parallel.
         let code_book_length = ProductQuantizer::codebook_length(pq.nbits, pq.dimension);
-        let codebook = reader
-            .read_fixed_stride_array(&DataType::Float32, offset, code_book_length as usize, ..)
-            .await?;
+        let codebook = read_fixed_stride_array(
+            reader,
+            &DataType::Float32,
+            offset,
+            code_book_length as usize,
+            ..,
+        )
+        .await?;
 
         let pq_code_offset = offset + code_book_length as usize * 4;
         let pq_code_length = pq.num_sub_vectors as usize * length;
-        let pq_code = reader
-            .read_fixed_stride_array(&DataType::UInt8, pq_code_offset, pq_code_length, ..)
-            .await?;
+        let pq_code =
+            read_fixed_stride_array(reader, &DataType::UInt8, pq_code_offset, pq_code_length, ..)
+                .await?;
 
         let row_id_offset = pq_code_offset + pq_code_length /* *1 */;
-        let row_ids = reader
-            .read_fixed_stride_array(&DataType::UInt64, row_id_offset, length, ..)
-            .await?;
+        let row_ids =
+            read_fixed_stride_array(reader, &DataType::UInt64, row_id_offset, length, ..).await?;
 
         Ok(Self {
             nbits: pq.nbits,

--- a/rust/src/index/vector/pq.rs
+++ b/rust/src/index/vector/pq.rs
@@ -27,7 +27,7 @@ use arrow_schema::{DataType, Field as ArrowField, Schema as ArrowSchema};
 use arrow_select::take::take;
 
 use crate::index::vector::kmeans::train_kmeans;
-use crate::io::object_reader::ObjectReader;
+use crate::io::object_reader::CloudObjectReader;
 use crate::Result;
 use crate::{arrow::*, utils::distance::l2_distance};
 
@@ -74,7 +74,7 @@ pub struct PQIndex {
 impl PQIndex {
     /// Load a PQ index (page) from the disk.
     pub async fn load(
-        reader: &ObjectReader<'_>,
+        reader: &CloudObjectReader<'_>,
         pq: &ProductQuantizer,
         offset: usize,
         length: usize,

--- a/rust/src/io.rs
+++ b/rust/src/io.rs
@@ -69,16 +69,16 @@ pub fn read_metadata_offset(bytes: &Bytes) -> Result<usize> {
 }
 
 /// Read protobuf from a buffer.
-pub fn read_message<M: Message + Default>(buf: &Bytes) -> Result<M> {
+pub fn read_message_from_buf<M: Message + Default>(buf: &Bytes) -> Result<M> {
     let msg_len = LittleEndian::read_u32(buf) as usize;
     Ok(M::decode(&buf[4..4 + msg_len])?)
 }
 
 /// Read a Protobuf-backed struct from a buffer.
-pub fn read_struct<M: Message + Default, T: ProtoStruct<Proto = M> + From<M>>(
+pub fn read_struct_from_buf<M: Message + Default, T: ProtoStruct<Proto = M> + From<M>>(
     buf: &Bytes,
 ) -> Result<T> {
-    let msg: M = read_message(buf)?;
+    let msg: M = read_message_from_buf(buf)?;
     Ok(T::from(msg))
 }
 

--- a/rust/src/io/object_reader.rs
+++ b/rust/src/io/object_reader.rs
@@ -69,20 +69,6 @@ impl<'a> CloudObjectReader<'a> {
         })
     }
 
-    /// Read a Protobuf-backed struct at file position: `pos`.
-    pub async fn read_struct<
-        'm,
-        M: Message + Default + 'static,
-        T: ProtoStruct<Proto = M> + From<M>,
-    >(
-        &mut self,
-        pos: usize,
-    ) -> Result<T> {
-        let msg = read_message::<M>(self, pos).await?;
-        let obj = T::from(msg);
-        Ok(obj)
-    }
-
     /// Read a fixed stride array from disk.
     ///
     pub(crate) async fn read_fixed_stride_array(
@@ -164,6 +150,20 @@ pub async fn read_message<M: Message + Default>(
     } else {
         Ok(M::decode(&buf[4..4 + msg_len])?)
     }
+}
+
+/// Read a Protobuf-backed struct at file position: `pos`.
+pub async fn read_struct<
+    'm,
+    M: Message + Default + 'static,
+    T: ProtoStruct<Proto = M> + From<M>,
+>(
+    reader: &dyn ObjectReader,
+    pos: usize,
+) -> Result<T> {
+    let msg = read_message::<M>(reader, pos).await?;
+    let obj = T::from(msg);
+    Ok(obj)
 }
 
 #[cfg(test)]

--- a/rust/src/io/object_reader.rs
+++ b/rust/src/io/object_reader.rs
@@ -49,21 +49,21 @@ pub trait ObjectReader: Send + Sync {
 ///
 /// Object Store + Base Path
 #[derive(Debug)]
-pub struct CloudObjectReader<'a> {
+pub struct CloudObjectReader {
     // Object Store.
     // TODO: can we use reference instead?
-    pub object_store: &'a ObjectStore,
+    pub object_store: ObjectStore,
     // File path
     pub path: Path,
 
     _prefetch_size: usize,
 }
 
-impl<'a> CloudObjectReader<'a> {
+impl<'a> CloudObjectReader {
     /// Create an ObjectReader from URI
     pub fn new(object_store: &'a ObjectStore, path: Path, prefetch_size: usize) -> Result<Self> {
         Ok(Self {
-            object_store,
+            object_store: object_store.clone(),
             path,
             _prefetch_size: prefetch_size,
         })
@@ -71,7 +71,7 @@ impl<'a> CloudObjectReader<'a> {
 }
 
 #[async_trait]
-impl ObjectReader for CloudObjectReader<'_> {
+impl ObjectReader for CloudObjectReader {
     /// Object/File Size.
     async fn size(&self) -> Result<usize> {
         Ok(self.object_store.inner.head(&self.path).await?.size)

--- a/rust/src/io/object_reader.rs
+++ b/rust/src/io/object_reader.rs
@@ -24,6 +24,7 @@ use arrow_array::{
     ArrayRef,
 };
 use arrow_schema::DataType;
+use async_trait::async_trait;
 use byteorder::{ByteOrder, LittleEndian};
 use bytes::Bytes;
 use object_store::{path::Path, ObjectMeta};
@@ -36,11 +37,16 @@ use crate::error::{Error, Result};
 use crate::format::ProtoStruct;
 use crate::io::ObjectStore;
 
+#[async_trait]
+pub trait ObjectReader {
+    async fn get_range(&self, range: Range<usize>) -> Result<Bytes>;
+}
+
 /// Object Reader
 ///
 /// Object Store + Base Path
 #[derive(Debug)]
-pub struct ObjectReader<'a> {
+pub struct CloudObjectReader<'a> {
     // Object Store.
     // TODO: can we use reference instead?
     pub object_store: &'a ObjectStore,
@@ -50,7 +56,7 @@ pub struct ObjectReader<'a> {
     prefetch_size: usize,
 }
 
-impl<'a> ObjectReader<'a> {
+impl<'a> CloudObjectReader<'a> {
     /// Create an ObjectReader from URI
     pub fn new(object_store: &'a ObjectStore, path: Path, prefetch_size: usize) -> Result<Self> {
         Ok(Self {

--- a/rust/src/io/object_store.rs
+++ b/rust/src/io/object_store.rs
@@ -30,6 +30,8 @@ use crate::error::{Error, Result};
 use crate::io::object_reader::CloudObjectReader;
 use crate::io::object_writer::ObjectWriter;
 
+use super::object_reader::ObjectReader;
+
 /// Wraps [ObjectStore](object_store::ObjectStore)
 #[derive(Debug, Clone)]
 pub struct ObjectStore {
@@ -120,11 +122,12 @@ impl ObjectStore {
         &self.base_path
     }
 
-    pub async fn open(&self, path: &Path) -> Result<CloudObjectReader> {
-        match CloudObjectReader::new(self, path.clone(), self.prefetch_size) {
-            Ok(r) => Ok(r),
-            Err(e) => Err(e),
-        }
+    pub async fn open(&self, path: &Path) -> Result<Box<dyn ObjectReader>> {
+        Ok(Box::new(CloudObjectReader::new(
+            self,
+            path.clone(),
+            self.prefetch_size,
+        )?))
     }
 
     /// Create a new file.

--- a/rust/src/io/object_store.rs
+++ b/rust/src/io/object_store.rs
@@ -27,7 +27,7 @@ use path_absolutize::*;
 use url::{ParseError, Url};
 
 use crate::error::{Error, Result};
-use crate::io::object_reader::ObjectReader;
+use crate::io::object_reader::CloudObjectReader;
 use crate::io::object_writer::ObjectWriter;
 
 /// Wraps [ObjectStore](object_store::ObjectStore)
@@ -120,8 +120,8 @@ impl ObjectStore {
         &self.base_path
     }
 
-    pub async fn open(&self, path: &Path) -> Result<ObjectReader> {
-        match ObjectReader::new(self, path.clone(), self.prefetch_size) {
+    pub async fn open(&self, path: &Path) -> Result<CloudObjectReader> {
+        match CloudObjectReader::new(self, path.clone(), self.prefetch_size) {
             Ok(r) => Ok(r),
             Err(e) => Err(e),
         }

--- a/rust/src/io/object_writer.rs
+++ b/rust/src/io/object_writer.rs
@@ -129,7 +129,7 @@ mod tests {
     use tokio::io::AsyncWriteExt;
 
     use crate::format::Metadata;
-    use crate::io::object_reader::{CloudObjectReader, read_struct};
+    use crate::io::object_reader::{read_struct, CloudObjectReader};
     use crate::io::ObjectStore;
 
     use super::*;

--- a/rust/src/io/object_writer.rs
+++ b/rust/src/io/object_writer.rs
@@ -129,7 +129,7 @@ mod tests {
     use tokio::io::AsyncWriteExt;
 
     use crate::format::Metadata;
-    use crate::io::object_reader::CloudObjectReader;
+    use crate::io::object_reader::{CloudObjectReader, read_struct};
     use crate::io::ObjectStore;
 
     use super::*;
@@ -173,8 +173,8 @@ mod tests {
         assert_eq!(pos, 0);
         object_writer.shutdown().await.unwrap();
 
-        let mut object_reader = CloudObjectReader::new(&store, path, 1024).unwrap();
-        let actual: Metadata = object_reader.read_struct(pos).await.unwrap();
+        let object_reader = CloudObjectReader::new(&store, path, 1024).unwrap();
+        let actual: Metadata = read_struct(&object_reader, pos).await.unwrap();
         assert_eq!(metadata, actual);
     }
 }

--- a/rust/src/io/object_writer.rs
+++ b/rust/src/io/object_writer.rs
@@ -129,7 +129,7 @@ mod tests {
     use tokio::io::AsyncWriteExt;
 
     use crate::format::Metadata;
-    use crate::io::object_reader::ObjectReader;
+    use crate::io::object_reader::CloudObjectReader;
     use crate::io::ObjectStore;
 
     use super::*;
@@ -173,7 +173,7 @@ mod tests {
         assert_eq!(pos, 0);
         object_writer.shutdown().await.unwrap();
 
-        let mut object_reader = ObjectReader::new(&store, path, 1024).unwrap();
+        let mut object_reader = CloudObjectReader::new(&store, path, 1024).unwrap();
         let actual: Metadata = object_reader.read_struct(pos).await.unwrap();
         assert_eq!(metadata, actual);
     }

--- a/rust/src/io/reader.rs
+++ b/rust/src/io/reader.rs
@@ -41,7 +41,7 @@ use crate::encodings::{dictionary::DictionaryDecoder, AsyncIndex};
 use crate::error::{Error, Result};
 use crate::format::Manifest;
 use crate::format::{pb, Metadata, PageTable};
-use crate::io::object_reader::ObjectReader;
+use crate::io::object_reader::CloudObjectReader;
 use crate::io::{read_metadata_offset, read_struct};
 use crate::{
     datatypes::{Field, Schema},
@@ -85,7 +85,7 @@ fn compute_row_id(fragment_id: u64, offset: i32) -> u64 {
 ///
 /// It reads arrow data from one data file.
 pub struct FileReader<'a> {
-    object_reader: ObjectReader<'a>,
+    object_reader: CloudObjectReader<'a>,
     metadata: Metadata,
     page_table: PageTable,
     projection: Option<Schema>,
@@ -108,7 +108,7 @@ impl<'a> FileReader<'a> {
         manifest: Option<&Manifest>,
     ) -> Result<FileReader<'a>> {
         let mut object_reader =
-            ObjectReader::new(object_store, path.clone(), object_store.prefetch_size())?;
+            CloudObjectReader::new(object_store, path.clone(), object_store.prefetch_size())?;
 
         let file_size = object_reader.size().await?;
         let begin = if file_size < object_store.prefetch_size() {

--- a/rust/src/io/reader.rs
+++ b/rust/src/io/reader.rs
@@ -41,7 +41,7 @@ use crate::encodings::{dictionary::DictionaryDecoder, AsyncIndex};
 use crate::error::{Error, Result};
 use crate::format::Manifest;
 use crate::format::{pb, Metadata, PageTable};
-use crate::io::object_reader::CloudObjectReader;
+use crate::io::object_reader::{CloudObjectReader, ObjectReader};
 use crate::io::{read_metadata_offset, read_struct};
 use crate::{
     datatypes::{Field, Schema},


### PR DESCRIPTION
This is the prerequisite to provide a better performance local file system reader implementation. 

We will implement a `LocalObjectReader` that holds an open File descriptor, instead open/close a file for every read in `object_store` crate