### PR TITLE
[Rust] Implement LocalObjectReader that holds an open file to improve performance.

### DIFF
--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -69,3 +69,7 @@ required-features = ["cli"]
 [[bench]]
 name = "distance"
 harness = false
+
+[[bench]]
+name = "scan"
+harness = false

--- a/rust/benches/scan.rs
+++ b/rust/benches/scan.rs
@@ -1,0 +1,48 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+use criterion::{criterion_group, criterion_main, Criterion};
+use futures::stream::TryStreamExt;
+use pprof::criterion::{Output, PProfProfiler};
+
+use lance::dataset::Dataset;
+
+fn bench_scan(c: &mut Criterion) {
+    // default tokio runtime
+    let rt = tokio::runtime::Runtime::new().unwrap();
+
+    let dataset = rt.block_on(async { Dataset::open("./test.lance").await.unwrap() });
+
+    c.bench_function("Scan datasets", |b| {
+        b.to_async(&rt).iter(|| async {
+            let count = dataset
+                .scan()
+                .into_stream()
+                .try_collect::<Vec<_>>()
+                .await
+                .unwrap();
+            assert!(count.len() >= 1);
+        })
+    });
+}
+
+criterion_group!(
+    name=benches;
+    config = Criterion::default().significance_level(0.1).sample_size(10)
+        .with_profiler(PProfProfiler::new(100, Output::Flamegraph(None)));
+    targets = bench_scan);
+criterion_main!(benches);

--- a/rust/src/io.rs
+++ b/rust/src/io.rs
@@ -28,6 +28,7 @@ use prost::Message;
 use tokio::io::{AsyncWrite, AsyncWriteExt};
 
 pub(crate) mod exec;
+pub mod local;
 pub mod object_reader;
 pub mod object_store;
 pub mod object_writer;

--- a/rust/src/io/local.rs
+++ b/rust/src/io/local.rs
@@ -15,6 +15,8 @@
 // specific language governing permissions and limitations
 // under the License.
 
+//! Optimized local I/Os
+
 use std::fs::File;
 use std::ops::Range;
 use std::sync::Arc;
@@ -28,11 +30,13 @@ use object_store::path::Path;
 use super::object_reader::ObjectReader;
 use crate::Result;
 
+/// ObjectReader for local file system.
 pub struct LocalObjectReader {
     file: Arc<File>,
 }
 
 impl LocalObjectReader {
+    /// Open a local object reader.
     pub fn open(path: &Path) -> Result<Box<dyn ObjectReader>> {
         let local_path = format!("/{}", path.to_string());
         Ok(Box::new(Self {

--- a/rust/src/io/local.rs
+++ b/rust/src/io/local.rs
@@ -1,0 +1,63 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+use std::fs::File;
+use std::ops::Range;
+use std::sync::Arc;
+// TODO: worry about windows later.
+use std::os::unix::fs::FileExt;
+
+use async_trait::async_trait;
+use bytes::{Bytes, BytesMut};
+use object_store::path::Path;
+
+use super::object_reader::ObjectReader;
+use crate::Result;
+
+pub struct LocalObjectReader {
+    file: Arc<File>,
+}
+
+impl LocalObjectReader {
+    pub fn open(path: &Path) -> Result<Box<dyn ObjectReader>> {
+        let local_path = format!("/{}", path.to_string());
+        Ok(Box::new(Self {
+            file: File::open(local_path)?.into(),
+        }))
+    }
+}
+
+#[async_trait]
+impl ObjectReader for LocalObjectReader {
+    /// Returns the file size.
+    async fn size(&self) -> Result<usize> {
+        Ok(self.file.metadata()?.len() as usize)
+    }
+
+    /// Reads a range of data.
+    ///
+    /// TODO: return [arrow_buffer::Buffer] to avoid one memory copy from Bytes to Buffer.
+    async fn get_range(&self, range: Range<usize>) -> Result<Bytes> {
+        let file = self.file.clone();
+        tokio::task::spawn_blocking(move || {
+            let mut buf = BytesMut::zeroed(range.len());
+            file.read_at(buf.as_mut(), range.start as u64)?;
+            Ok(buf.freeze())
+        })
+        .await?
+    }
+}

--- a/rust/src/io/object_store.rs
+++ b/rust/src/io/object_store.rs
@@ -30,6 +30,7 @@ use crate::error::{Error, Result};
 use crate::io::object_reader::CloudObjectReader;
 use crate::io::object_writer::ObjectWriter;
 
+use super::local::LocalObjectReader;
 use super::object_reader::ObjectReader;
 
 /// Wraps [ObjectStore](object_store::ObjectStore)
@@ -122,12 +123,16 @@ impl ObjectStore {
         &self.base_path
     }
 
+    /// Open a file for path
     pub async fn open(&self, path: &Path) -> Result<Box<dyn ObjectReader>> {
-        Ok(Box::new(CloudObjectReader::new(
-            self,
-            path.clone(),
-            self.prefetch_size,
-        )?))
+        match self.scheme.as_str() {
+            "file" => LocalObjectReader::open(path),
+            _ => Ok(Box::new(CloudObjectReader::new(
+                self,
+                path.clone(),
+                self.prefetch_size,
+            )?)),
+        }
     }
 
     /// Create a new file.


### PR DESCRIPTION
Avoid open/close file for each `get_range` call in `object_store` crates.