### PR TITLE
disable-clippy: disable clippy on format and index pb (#465)

### DIFF
--- a/rust/src/format.rs
+++ b/rust/src/format.rs
@@ -17,9 +17,7 @@ pub use metadata::Metadata;
 pub use page_table::{PageInfo, PageTable};
 
 /// Protobuf definitions
-#[allow(clippy::all)]
 pub mod pb {
-    #![allow(clippy::all)]
     include!(concat!(env!("OUT_DIR"), "/lance.format.pb.rs"));
 }
 

--- a/rust/src/index.rs
+++ b/rust/src/index.rs
@@ -23,7 +23,6 @@ use std::any::Any;
 use async_trait::async_trait;
 
 /// Protobuf definitions for the index on-disk format.
-#[allow(clippy::all)]
 pub mod pb {
     include!(concat!(env!("OUT_DIR"), "/lance.index.pb.rs"));
 }


### PR DESCRIPTION
have disabled the clippy from lance::format::pb and lance::index::pb modules