### PR TITLE
Fix codespace prebuild

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -3,6 +3,6 @@ FROM ubuntu:22.04
 ENV DEBIAN_FRONTEND=noninteractive
 
 RUN apt update -y \
-    && apt-get -y clean \
-	&& curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh \
+    && apt-get -y install curl \
+	&& curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y \
     && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*

--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -3,10 +3,6 @@ FROM ubuntu:22.04
 ENV DEBIAN_FRONTEND=noninteractive
 
 RUN apt update -y \
-    && apt install -y -qq cmake g++ curl git ca-certificates lsb-release wget \
-    && wget https://apache.jfrog.io/artifactory/arrow/$(lsb_release --id --short | tr 'A-Z' 'a-z')/apache-arrow-apt-source-latest-$(lsb_release --codename --short).deb \
-    && apt install -y -V ./apache-arrow-apt-source-latest-$(lsb_release --codename --short).deb \
-    && apt -y update \
-    && apt install -y -qq libarrow-dev libarrow-dataset-dev libparquet-dev libarrow-python-dev \
     && apt-get -y clean \
+	&& curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh \
     && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -5,7 +5,7 @@
     "customizations": {
         "vscode": {
             "extensions": [
-                "ms-vscode.cpptools-extension-pack"
+				"rust-lang.rust-analyzer"
             ]
         }
     }

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -5,7 +5,7 @@
     "customizations": {
         "vscode": {
             "extensions": [
-				"rust-lang.rust-analyzer"
+                "rust-lang.rust-analyzer"
             ]
         }
     }


### PR DESCRIPTION
New arrow deb release breaks the build. 
And make it rust-focused.