### PR TITLE
Load S3 credentials using default credentials chain

### DIFF
--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -38,6 +38,8 @@ byteorder = "1.4.3"
 chrono = "0.4.23"
 clap = { version = "4.1.1", features = ["derive"], optional = true }
 object_store = { version = "0.5", features = ["aws"] }
+aws-config = "0.54"
+aws-credential-types = "0.54.1"
 pin-project = "1.0"
 prost = "0.11"
 prost-types = "0.11"

--- a/rust/src/bin/lq.rs
+++ b/rust/src/bin/lq.rs
@@ -37,9 +37,6 @@ enum Commands {
     Inspect {
         /// The URI of the dataset.
         uri: String,
-
-        /// AWS profile
-        aws_profile: Option<String>,
     },
 
     /// Query the dataset
@@ -97,7 +94,7 @@ async fn main() -> Result<()> {
     let args = Args::parse();
 
     match &args.command {
-        Commands::Inspect { uri, aws_profile } => {
+        Commands::Inspect { uri } => {
             let dataset = Dataset::open(uri).await.unwrap();
             println!("Dataset URI: {}", uri);
             println!(

--- a/rust/src/dataset.rs
+++ b/rust/src/dataset.rs
@@ -93,7 +93,7 @@ fn latest_manifest_path(base: &Path) -> Path {
 impl Dataset {
     /// Open an existing dataset.
     pub async fn open(uri: &str) -> Result<Self> {
-        let object_store = Arc::new(ObjectStore::new(uri)?);
+        let object_store = Arc::new(ObjectStore::new(uri).await?);
 
         let base_path = object_store.base_path().clone();
         let latest_manifest_path = latest_manifest_path(&base_path);
@@ -102,7 +102,7 @@ impl Dataset {
 
     /// Check out a version of the dataset.
     pub async fn checkout(uri: &str, version: u64) -> Result<Self> {
-        let object_store = Arc::new(ObjectStore::new(uri)?);
+        let object_store = Arc::new(ObjectStore::new(uri).await?);
 
         let base_path = object_store.base_path().clone();
         let manifest_file = manifest_path(&base_path, version);
@@ -142,7 +142,7 @@ impl Dataset {
         uri: &str,
         params: Option<WriteParams>,
     ) -> Result<Self> {
-        let object_store = Arc::new(ObjectStore::new(uri)?);
+        let object_store = Arc::new(ObjectStore::new(uri).await?);
         let params = params.unwrap_or_default();
 
         let latest_manifest_path = latest_manifest_path(object_store.base_path());

--- a/rust/src/dataset.rs
+++ b/rust/src/dataset.rs
@@ -97,7 +97,7 @@ impl Dataset {
 
         let base_path = object_store.base_path().clone();
         let latest_manifest_path = latest_manifest_path(&base_path);
-        Dataset::checkout_manifest(object_store, base_path, &latest_manifest_path).await
+        Self::checkout_manifest(object_store, base_path, &latest_manifest_path).await
     }
 
     /// Check out a version of the dataset.
@@ -106,7 +106,7 @@ impl Dataset {
 
         let base_path = object_store.base_path().clone();
         let manifest_file = manifest_path(&base_path, version);
-        Dataset::checkout_manifest(object_store, base_path, &manifest_file).await
+        Self::checkout_manifest(object_store, base_path, &manifest_file).await
     }
 
     async fn checkout_manifest(
@@ -114,10 +114,10 @@ impl Dataset {
         base_path: Path,
         manifest_path: &Path,
     ) -> Result<Self> {
-        let object_reader = object_store.open(&manifest_path).await?;
+        let object_reader = object_store.open(manifest_path).await?;
         let bytes = object_store
             .inner
-            .get(&manifest_path)
+            .get(manifest_path)
             .await?
             .bytes()
             .await?;
@@ -492,7 +492,7 @@ impl Dataset {
             Ok(section
                 .indices
                 .iter()
-                .map(|pb| Index::try_from(pb))
+                .map(Index::try_from)
                 .collect::<Result<Vec<_>>>()?)
         } else {
             Ok(vec![])

--- a/rust/src/dataset.rs
+++ b/rust/src/dataset.rs
@@ -115,12 +115,7 @@ impl Dataset {
         manifest_path: &Path,
     ) -> Result<Self> {
         let object_reader = object_store.open(manifest_path).await?;
-        let bytes = object_store
-            .inner
-            .get(manifest_path)
-            .await?
-            .bytes()
-            .await?;
+        let bytes = object_store.inner.get(manifest_path).await?.bytes().await?;
         let offset = read_metadata_offset(&bytes)?;
         let mut manifest: Manifest = read_struct(object_reader.as_ref(), offset).await?;
         manifest

--- a/rust/src/encodings/binary.rs
+++ b/rust/src/encodings/binary.rs
@@ -111,7 +111,7 @@ impl<'a, T: ByteArrayType> BinaryDecoder<'a, T> {
     /// use lance::encodings::binary::BinaryDecoder;
     ///
     /// async {
-    ///     let object_store = ObjectStore::new(":memory:").unwrap();
+    ///     let object_store = ObjectStore::new(":memory:").await.unwrap();
     ///     let path = Path::from("/data.lance");
     ///     let reader = object_store.open(&path).await.unwrap();
     ///     let string_decoder = BinaryDecoder::<Utf8Type>::new(reader.as_ref(), 100, 1024);

--- a/rust/src/encodings/dictionary.rs
+++ b/rust/src/encodings/dictionary.rs
@@ -77,7 +77,7 @@ impl<'a> Encoder for DictionaryEncoder<'a> {
             Int32 => self.write_typed_array::<Int32Type>(array).await,
             Int64 => self.write_typed_array::<Int64Type>(array).await,
             _ => Err(Error::Schema(format!(
-                "DictionaryEncoder: unsurpported key type: {:?}",
+                "DictionaryEncoder: unsupported key type: {:?}",
                 self.key_type
             ))),
         }
@@ -208,7 +208,7 @@ mod tests {
         let values = vec!["a", "b", "b", "a", "c"];
         let arr: DictionaryArray<T> = values.into_iter().collect();
 
-        let store = ObjectStore::new(":memory:").unwrap();
+        let store = ObjectStore::new(":memory:").await.unwrap();
         let path = Path::from("/foo");
 
         let pos;

--- a/rust/src/encodings/plain.rs
+++ b/rust/src/encodings/plain.rs
@@ -372,7 +372,7 @@ mod tests {
     }
 
     async fn test_round_trip(expected: ArrayRef, data_type: DataType) {
-        let store = ObjectStore::new(":memory:").unwrap();
+        let store = ObjectStore::new(":memory:").await.unwrap();
         let path = Path::from("/foo");
         let mut object_writer = ObjectWriter::new(&store, &path).await.unwrap();
         let mut encoder = PlainEncoder::new(&mut object_writer, &data_type);

--- a/rust/src/io/object_store.rs
+++ b/rust/src/io/object_store.rs
@@ -49,9 +49,34 @@ impl std::fmt::Display for ObjectStore {
     }
 }
 
+/// BUild S3 ObjectStore using default credential chain.
+async fn build_s3_object_store(uri: &str) -> Result<Arc<dyn OSObjectStore>> {
+    use aws_config::meta::region::RegionProviderChain;
+    use aws_credential_types::provider::ProvideCredentials;
+
+    let region_provider = RegionProviderChain::default_provider().or_else("us-west-1");
+    let provider = aws_config::default_provider::credentials::default_provider().await;
+    // let credentials = provider.
+    let credentials = provider.provide_credentials().await.unwrap();
+    Ok(Arc::new(
+        AmazonS3Builder::new()
+            .with_url(uri)
+            .with_access_key_id(credentials.access_key_id())
+            .with_secret_access_key(credentials.secret_access_key())
+            .with_region(
+                region_provider
+                    .region()
+                    .await
+                    .map(|r| r.as_ref().to_string())
+                    .unwrap_or("us-west-2".to_string()),
+            )
+            .build()?,
+    ))
+}
+
 impl ObjectStore {
     /// Create a ObjectStore instance from a given URL.
-    pub fn new(uri: &str) -> Result<Self> {
+    pub async fn new(uri: &str) -> Result<Self> {
         if uri == ":memory:" {
             return Ok(Self::memory());
         };
@@ -68,23 +93,16 @@ impl ObjectStore {
                 });
             }
             Err(e) => {
-                println!("Parse err: {}", e);
-                return Err(Error::IO(format!("URI parse error: {}", e)));
+                eprintln!("Parse err: {e}");
+                return Err(Error::IO(format!("URI parse error: {e}")));
             }
         };
 
-        let bucket_name = parsed.host().unwrap().to_string();
         let scheme: String;
         let object_store: Arc<dyn OSObjectStore> = match parsed.scheme() {
             "s3" => {
                 scheme = "s3".to_string();
-                match AmazonS3Builder::from_env()
-                    .with_bucket_name(bucket_name)
-                    .build()
-                {
-                    Ok(s3) => Arc::new(s3),
-                    Err(e) => return Err(e.into()),
-                }
+                build_s3_object_store(uri).await?
             }
             "file" => {
                 scheme = "flle".to_string();

--- a/rust/src/io/object_store.rs
+++ b/rust/src/io/object_store.rs
@@ -54,9 +54,10 @@ async fn build_s3_object_store(uri: &str) -> Result<Arc<dyn OSObjectStore>> {
     use aws_config::meta::region::RegionProviderChain;
     use aws_credential_types::provider::ProvideCredentials;
 
-    let region_provider = RegionProviderChain::default_provider().or_else("us-west-1");
+    const DEFAULT_REGION: &str = "us-west-2";
+
+    let region_provider = RegionProviderChain::default_provider().or_else(DEFAULT_REGION);
     let provider = aws_config::default_provider::credentials::default_provider().await;
-    // let credentials = provider.
     let credentials = provider.provide_credentials().await.unwrap();
     Ok(Arc::new(
         AmazonS3Builder::new()
@@ -68,7 +69,7 @@ async fn build_s3_object_store(uri: &str) -> Result<Arc<dyn OSObjectStore>> {
                     .region()
                     .await
                     .map(|r| r.as_ref().to_string())
-                    .unwrap_or("us-west-2".to_string()),
+                    .unwrap_or(DEFAULT_REGION.to_string()),
             )
             .build()?,
     ))

--- a/rust/src/io/object_writer.rs
+++ b/rust/src/io/object_writer.rs
@@ -136,7 +136,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_write() {
-        let store = ObjectStore::new(":memory:").unwrap();
+        let store = ObjectStore::new(":memory:").await.unwrap();
 
         let mut object_writer = ObjectWriter::new(&store, &Path::from("/foo"))
             .await
@@ -159,7 +159,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_write_proto_structs() {
-        let store = ObjectStore::new(":memory:").unwrap();
+        let store = ObjectStore::new(":memory:").await.unwrap();
         let path = Path::from("/foo");
 
         let mut object_writer = ObjectWriter::new(&store, &path).await.unwrap();


### PR DESCRIPTION
Improve user experience: user does not need to specify environment vars to read s3 data correctly.