### PR TITLE
Implement a kmean optimized for Arrow-backed vectors in pure rust.

### DIFF
--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -52,6 +52,7 @@ faiss = { version = "0.11.0", features = ["gpu"], optional = true }
 path-absolutize = "3.0.14"
 cblas = { version = "0.4.0", optional = true }
 accelerate-src = { version = "0.3.2", optional = true }
+num_cpus = "1.0"
 
 [build-dependencies]
 prost-build = "0.11"

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -83,3 +83,7 @@ harness = false
 [[bench]]
 name = "vector_index"
 harness = false
+
+[[bench]]
+name = "kmeans"
+harness = false

--- a/rust/benches/kmeans.rs
+++ b/rust/benches/kmeans.rs
@@ -18,7 +18,6 @@
 use std::sync::Arc;
 
 use arrow_array::FixedSizeListArray;
-
 use criterion::{black_box, criterion_group, criterion_main, Criterion};
 use pprof::criterion::{Output, PProfProfiler};
 
@@ -26,13 +25,16 @@ use lance::utils::kmeans::KMeans;
 use lance::{arrow::*, utils::testing::generate_random_array};
 
 fn bench_train(c: &mut Criterion) {
+    // default tokio runtime
+    let rt = tokio::runtime::Runtime::new().unwrap();
+
     let dimension: i32 = 128;
     let array = generate_random_array(1024 * 4 * dimension as usize);
     let data = Arc::new(FixedSizeListArray::try_new(&array, dimension).unwrap());
 
     c.bench_function("train_128d_4k", |b| {
-        b.iter(|| {
-            KMeans::new(data.clone(), 256, 25);
+        b.to_async(&rt).iter(|| async {
+            KMeans::new(data.clone(), 256, 25).await;
         })
     });
 
@@ -51,14 +53,14 @@ fn bench_train(c: &mut Criterion) {
     let array = generate_random_array(1024 * 64 * dimension as usize);
     let data = Arc::new(FixedSizeListArray::try_new(&array, dimension).unwrap());
     c.bench_function("train_128d_65535", |b| {
-        b.iter(|| {
-            KMeans::new(data.clone(), 256, 25);
+        b.to_async(&rt).iter(|| async {
+            KMeans::new(data.clone(), 256, 25).await;
         })
     });
 
     #[cfg(feature = "faiss")]
     c.bench_function("train_128d_65535_faiss", |b| {
-        use arrow_array::cast::as_primitive_array;
+        use arrow_array::{cast::as_primitive_array, Float32Array};
         use faiss::cluster::kmeans_clustering;
 
         let array = data.as_ref().values();
@@ -71,6 +73,7 @@ fn bench_train(c: &mut Criterion) {
 
 criterion_group!(
     name=benches;
-    config = Criterion::default().significance_level(0.1).sample_size(10).with_profiler(PProfProfiler::new(100, Output::Flamegraph(None)));
+    config = Criterion::default().significance_level(0.1).sample_size(10)
+    .with_profiler(PProfProfiler::new(100, Output::Flamegraph(None)));
     targets = bench_train);
 criterion_main!(benches);

--- a/rust/benches/kmeans.rs
+++ b/rust/benches/kmeans.rs
@@ -40,7 +40,7 @@ fn bench_train(c: &mut Criterion) {
 
     #[cfg(feature = "faiss")]
     c.bench_function("train_128d_4k_faiss", |b| {
-        use arrow_array::cast::{as_primitive_array, Float32Array};
+        use arrow_array::{cast::as_primitive_array, Float32Array};
         use faiss::cluster::kmeans_clustering;
 
         let array = data.as_ref().values();

--- a/rust/benches/kmeans.rs
+++ b/rust/benches/kmeans.rs
@@ -1,0 +1,76 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+use std::sync::Arc;
+
+use arrow_array::FixedSizeListArray;
+
+use criterion::{black_box, criterion_group, criterion_main, Criterion};
+use pprof::criterion::{Output, PProfProfiler};
+
+use lance::utils::kmeans::KMeans;
+use lance::{arrow::*, utils::testing::generate_random_array};
+
+fn bench_train(c: &mut Criterion) {
+    let dimension: i32 = 128;
+    let array = generate_random_array(1024 * 4 * dimension as usize);
+    let data = Arc::new(FixedSizeListArray::try_new(&array, dimension).unwrap());
+
+    c.bench_function("train_128d_4k", |b| {
+        b.iter(|| {
+            KMeans::new(data.clone(), 256, 25);
+        })
+    });
+
+    #[cfg(feature = "faiss")]
+    c.bench_function("train_128d_4k_faiss", |b| {
+        use arrow_array::cast::as_primitive_array;
+        use faiss::cluster::kmeans_clustering;
+
+        let array = data.as_ref().values();
+        let f32array: &Float32Array = as_primitive_array(&array);
+        b.iter(|| {
+            kmeans_clustering(dimension as u32, 256, f32array.values()).unwrap();
+        })
+    });
+
+    let array = generate_random_array(1024 * 64 * dimension as usize);
+    let data = Arc::new(FixedSizeListArray::try_new(&array, dimension).unwrap());
+    c.bench_function("train_128d_65535", |b| {
+        b.iter(|| {
+            KMeans::new(data.clone(), 256, 25);
+        })
+    });
+
+    #[cfg(feature = "faiss")]
+    c.bench_function("train_128d_65535_faiss", |b| {
+        use arrow_array::cast::as_primitive_array;
+        use faiss::cluster::kmeans_clustering;
+
+        let array = data.as_ref().values();
+        let f32array: &Float32Array = as_primitive_array(&array);
+        b.iter(|| {
+            kmeans_clustering(dimension as u32, 256, f32array.values()).unwrap();
+        })
+    });
+}
+
+criterion_group!(
+    name=benches;
+    config = Criterion::default().significance_level(0.1).sample_size(10).with_profiler(PProfProfiler::new(100, Output::Flamegraph(None)));
+    targets = bench_train);
+criterion_main!(benches);

--- a/rust/benches/kmeans.rs
+++ b/rust/benches/kmeans.rs
@@ -40,7 +40,7 @@ fn bench_train(c: &mut Criterion) {
 
     #[cfg(feature = "faiss")]
     c.bench_function("train_128d_4k_faiss", |b| {
-        use arrow_array::cast::as_primitive_array;
+        use arrow_array::cast::{as_primitive_array, Float32Array};
         use faiss::cluster::kmeans_clustering;
 
         let array = data.as_ref().values();

--- a/rust/src/utils.rs
+++ b/rust/src/utils.rs
@@ -18,4 +18,5 @@
 //! Various utilities
 
 pub mod distance;
+pub mod kmeans;
 pub mod testing;

--- a/rust/src/utils/distance.rs
+++ b/rust/src/utils/distance.rs
@@ -137,18 +137,18 @@ fn l2_distance_simd(from: &Float32Array, to: &FixedSizeListArray) -> Result<Arc<
                 .map(|idx| {
                     #[cfg(any(target_arch = "x86_64"))]
                     {
-                        return euclidean_distance_fma(
+                        euclidean_distance_fma(
                             from_vector,
                             &buffer[idx * dimension..(idx + 1) * dimension],
-                        );
+                        )
                     }
 
                     #[cfg(any(target_arch = "aarch64"))]
                     {
-                        return l2_distance_neon(
+                        l2_distance_neon(
                             from_vector,
                             &buffer[idx * dimension..(idx + 1) * dimension],
-                        );
+                        )
                     }
                 })
                 .map(Some),

--- a/rust/src/utils/kmeans.rs
+++ b/rust/src/utils/kmeans.rs
@@ -30,8 +30,8 @@ use rand::prelude::*;
 use rand::{distributions::WeightedIndex, Rng, RngCore};
 
 use super::distance::l2_distance;
-use crate::{arrow::*, Error};
 use crate::Result;
+use crate::{arrow::*, Error};
 
 #[derive(Debug)]
 pub struct KMeansParams {
@@ -287,8 +287,16 @@ impl KMeans {
         let k = self.k;
         KMeanMembership {
             data,
-            cluster_ids: cluster_with_distances.iter().flat_map(|v| v).map(|(c, _)| *c).collect(),
-            distances: cluster_with_distances.iter().flat_map(|v| v).map(|(_, d)| *d).collect(),
+            cluster_ids: cluster_with_distances
+                .iter()
+                .flat_map(|v| v)
+                .map(|(c, _)| *c)
+                .collect(),
+            distances: cluster_with_distances
+                .iter()
+                .flat_map(|v| v)
+                .map(|(_, d)| *d)
+                .collect(),
             k,
         }
     }

--- a/rust/src/utils/kmeans.rs
+++ b/rust/src/utils/kmeans.rs
@@ -42,7 +42,7 @@ pub struct KMeansParams {
     /// threshold, stop the training.
     tolerance: f32,
 
-    /// Run kmeans mulitple times and pick the best one.
+    /// Run kmeans multiple times and pick the best one.
     redos: usize,
 }
 
@@ -173,7 +173,7 @@ impl KMeanMembership {
         self.distances.iter().sum()
     }
 
-    /// Returns how many are here
+    /// Returns how many data points are here
     fn len(&self) -> usize {
         self.cluster_ids.len()
     }

--- a/rust/src/utils/kmeans.rs
+++ b/rust/src/utils/kmeans.rs
@@ -93,7 +93,7 @@ fn kmean_plusplus(
 
     let mut seen = HashSet::new();
     seen.insert(first);
-    for i in 1..k {
+    for _ in 1..k {
         let membership = kmeans.compute_membership(data.clone());
         let weights = WeightedIndex::new(&membership.distances).unwrap();
         let mut chosen;
@@ -208,6 +208,7 @@ impl KMeans {
                 break;
             }
             kmeans = new_kmeans;
+            last_membership = new_membership;
         }
         kmeans
     }
@@ -231,4 +232,9 @@ impl KMeans {
             k,
         }
     }
+}
+
+#[cfg(test)]
+mod tests {
+
 }

--- a/rust/src/utils/kmeans.rs
+++ b/rust/src/utils/kmeans.rs
@@ -192,13 +192,16 @@ impl KMeanMembership {
         hist
     }
 
-    fn stddev(&self) -> f32 {
+    /// Std deviation of the histogram / cluster distribution.
+    fn hist_stddev(&self) -> f32 {
         let mean: f32 = self.len() as f32 * 1.0 / self.k as f32;
-        self.histogram()
+        (self
+            .histogram()
             .iter()
             .map(|c| (*c as f32 - mean).powi(2))
             .sum::<f32>()
-            / self.len() as f32
+            / self.len() as f32)
+            .sqrt()
     }
 }
 
@@ -235,7 +238,7 @@ impl KMeans {
         println!(
             "kmean historam: {:?} stddev={}",
             last_membership.histogram(),
-            last_membership.stddev(),
+            last_membership.hist_stddev(),
         );
         kmeans
     }

--- a/rust/src/utils/kmeans.rs
+++ b/rust/src/utils/kmeans.rs
@@ -1,0 +1,234 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+use std::collections::HashSet;
+use std::sync::Arc;
+
+use arrow_arith::arithmetic::{add, divide_scalar};
+use arrow_array::{
+    cast::as_primitive_array, new_empty_array, Array, FixedSizeListArray, Float32Array,
+};
+use arrow_array::{ArrayAccessor, PrimitiveArray};
+use arrow_schema::{DataType, Field as ArrowField};
+use arrow_select::concat::concat;
+use futures::stream::{self, StreamExt};
+use rand::prelude::*;
+use rand::{distributions::WeightedIndex, Rng, RngCore};
+
+use super::distance::l2_distance;
+use crate::arrow::*;
+use crate::{Error, Result};
+
+#[derive(Debug)]
+pub struct KMeansParams {
+    /// Max number of iterations.
+    max_iters: u32,
+
+    /// When the difference of mean distance to the centroids is less than this `tolerance`
+    /// threshold, stop the training.
+    tolerance: f32,
+}
+
+impl Default for KMeansParams {
+    fn default() -> Self {
+        Self {
+            max_iters: 50,
+            tolerance: 1e-2,
+        }
+    }
+}
+
+/// KMeans implementation for Apache Arrow Arrays.
+#[derive(Debug)]
+pub struct KMeans {
+    /// Centroids for each of the k clusters.
+    ///
+    /// k * dimension.
+    pub centroids: Arc<FixedSizeListArray>,
+
+    /// The number of clusters
+    pub k: u32,
+}
+
+/// Initialize using kmean++, and returns the centroids of k clusters.
+fn kmean_plusplus(
+    data: Arc<FixedSizeListArray>,
+    k: u32, /* dist_fn, rand_seed */
+    rng: &mut dyn RngCore,
+) -> KMeans {
+    assert!(data.len() > k as usize);
+    let mut kmeans = KMeans {
+        centroids: new_empty_array(&DataType::FixedSizeList(
+            Box::new(ArrowField::new("item", DataType::Float32, false)),
+            data.value_length(),
+        ))
+        .as_any()
+        .downcast_ref::<Arc<FixedSizeListArray>>()
+        .unwrap()
+        .clone(),
+        k,
+    };
+
+    let dimension = data.value_length();
+    let first = rng.gen_range(0..data.len());
+
+    let vector = data.value(first);
+    kmeans.centroids = FixedSizeListArray::try_new(vector, dimension)
+        .unwrap()
+        .into();
+
+    let mut seen = HashSet::new();
+    seen.insert(first);
+    for i in 1..k {
+        let membership = kmeans.compute_membership(data.clone());
+        let weights = WeightedIndex::new(&membership.distances).unwrap();
+        let mut chosen;
+        loop {
+            chosen = weights.sample(rng);
+            if !seen.contains(&chosen) {
+                seen.insert(chosen);
+                break;
+            }
+        }
+        let vector = data.value(chosen);
+        let new_vector: &Float32Array = as_primitive_array(&vector);
+
+        let centroids_array = kmeans.centroids.values();
+        let centroids_f32_array: &Float32Array = as_primitive_array(&centroids_array);
+        let new_centroid_values = Float32Array::from_iter_values(
+            centroids_f32_array
+                .values()
+                .iter()
+                .copied()
+                .chain(new_vector.values().iter().copied()),
+        );
+        kmeans.centroids =
+            Arc::new(FixedSizeListArray::try_new(new_centroid_values, dimension).unwrap());
+    }
+    kmeans
+}
+
+struct KMeanMembership {
+    /// Reference to the input vectors.
+    data: Arc<FixedSizeListArray>,
+
+    /// Cluster Id for each vector.
+    cluster_ids: Vec<u32>,
+
+    /// Distance between each vector, to its corresponding centroids.
+    distances: Vec<f32>,
+
+    k: u32,
+}
+
+impl TryFrom<&KMeanMembership> for KMeans {
+    type Error = Error;
+
+    fn try_from(membership: &KMeanMembership) -> Result<Self> {
+        let dimension = membership.data.value_length();
+        let means = tokio::runtime::Runtime::new().unwrap().block_on(async {
+            stream::iter(0..membership.k)
+                .map(|cluster| {
+                    membership
+                        .cluster_ids
+                        .iter()
+                        .filter(|id| **id == cluster)
+                        .fold(
+                            (
+                                Float32Array::from_iter_values(
+                                    (0..dimension).map(|_| 0.0).collect::<Vec<_>>(),
+                                ),
+                                0.0,
+                            ),
+                            |(arr, total), idx| {
+                                (
+                                    add(
+                                        &arr,
+                                        as_primitive_array(
+                                            membership.data.value(*idx as usize).as_ref(),
+                                        ),
+                                    )
+                                    .unwrap(),
+                                    total + 1.0,
+                                )
+                            },
+                        )
+                })
+                .map(|(arr, total)| divide_scalar(&arr, total).unwrap())
+                .collect::<Vec<_>>()
+                .await
+        });
+
+        let mut mean_refs: Vec<&dyn Array> = vec![];
+        for m in means.iter() {
+            mean_refs.push(m);
+        }
+        let centroids = concat(&mean_refs).unwrap();
+        Ok(KMeans {
+            centroids: Arc::new(FixedSizeListArray::try_new(centroids, dimension)?),
+            k: membership.k,
+        })
+    }
+}
+
+impl KMeans {
+    /// Train a KMean on data with `k` clusters.
+    pub fn new(data: Arc<FixedSizeListArray>, k: u32, max_iters: u32) -> Self {
+        let mut params = KMeansParams::default();
+        params.max_iters = max_iters;
+        KMeans::new_with_params(data, k, &params)
+    }
+
+    pub fn new_with_params(data: Arc<FixedSizeListArray>, k: u32, params: &KMeansParams) -> Self {
+        let mut kmeans = kmean_plusplus(data.clone(), k, &mut rand::thread_rng());
+
+        let mut last_membership = kmeans.compute_membership(data.clone());
+        for _ in 0..params.max_iters {
+            let new_kmeans: KMeans = (&last_membership).try_into().unwrap();
+            let new_membership = new_kmeans.compute_membership(data.clone());
+            if (new_membership.distances.iter().sum::<f32>()
+                - last_membership.distances.iter().sum::<f32>())
+                / last_membership.distances.iter().sum::<f32>()
+                < params.tolerance
+            {
+                break;
+            }
+            kmeans = new_kmeans;
+        }
+        kmeans
+    }
+
+    fn compute_membership(&self, data: Arc<FixedSizeListArray>) -> KMeanMembership {
+        let cluster_with_distances = (0..data.len())
+            .map(|idx| {
+                let value_arr = data.value(idx);
+                let vector: &Float32Array = as_primitive_array(&value_arr);
+                let distances = l2_distance(vector, self.centroids.as_ref()).unwrap();
+                let cluster_id = argmin(distances.as_ref()).unwrap();
+                let distance = distances.value(cluster_id as usize);
+                (cluster_id, distance)
+            })
+            .collect::<Vec<_>>();
+        let k = self.k;
+        KMeanMembership {
+            data: data.clone(),
+            cluster_ids: cluster_with_distances.iter().map(|(c, _)| *c).collect(),
+            distances: cluster_with_distances.iter().map(|(_, d)| *d).collect(),
+            k,
+        }
+    }
+}

--- a/rust/src/utils/kmeans.rs
+++ b/rust/src/utils/kmeans.rs
@@ -22,7 +22,6 @@ use arrow_arith::arithmetic::{add, divide_scalar};
 use arrow_array::{
     cast::as_primitive_array, new_empty_array, Array, FixedSizeListArray, Float32Array,
 };
-use arrow_array::{ArrayAccessor, PrimitiveArray};
 use arrow_schema::{DataType, Field as ArrowField};
 use arrow_select::concat::concat;
 use futures::stream::{self, StreamExt};
@@ -235,6 +234,4 @@ impl KMeans {
 }
 
 #[cfg(test)]
-mod tests {
-
-}
+mod tests {}

--- a/rust/src/utils/kmeans.rs
+++ b/rust/src/utils/kmeans.rs
@@ -261,6 +261,7 @@ impl KMeans {
 
     async fn compute_membership(&self, data: Arc<FixedSizeListArray>) -> KMeanMembership {
         let cluster_with_distances = stream::iter(0..data.len())
+            // make tiles of input data to split between threads.
             .chunks(1024)
             .zip(repeat_with(|| (data.clone(), self.centroids.clone())))
             .map(|(indices, (data, centroids))| async move {

--- a/rust/src/utils/kmeans.rs
+++ b/rust/src/utils/kmeans.rs
@@ -265,7 +265,6 @@ impl KMeans {
             .chunks(1024)
             .zip(repeat_with(|| (data.clone(), self.centroids.clone())))
             .map(|(indices, (data, centroids))| async move {
-                // let data = data.clone();
                 let data = tokio::task::spawn_blocking(move || {
                     let mut results = vec![];
                     for idx in indices {
@@ -290,12 +289,12 @@ impl KMeans {
             data,
             cluster_ids: cluster_with_distances
                 .iter()
-                .flat_map(|v| v)
+                .flatten()
                 .map(|(c, _)| *c)
                 .collect(),
             distances: cluster_with_distances
                 .iter()
-                .flat_map(|v| v)
+                .flatten()
                 .map(|(_, d)| *d)
                 .collect(),
             k,


### PR DESCRIPTION
* Reduce memory copy between using Arrow vs other lib (i.e., ndarray or faiss)
* Pure rust implementation to remove the dependency of C++ libraries (i.e., FAISS)