### PR TITLE
Improve `take_rows()` performance by binary search

### DIFF
--- a/rust/src/dataset.rs
+++ b/rust/src/dataset.rs
@@ -422,12 +422,7 @@ impl Dataset {
 
         let remapping_index: UInt64Array = row_ids
             .iter()
-            .map(|o| {
-                sorted_row_ids
-                    .iter()
-                    .position(|sorted_id| sorted_id == o)
-                    .unwrap() as u64
-            })
+            .map(|o| sorted_row_ids.binary_search(o).unwrap() as u64)
             .collect();
         let struct_arr: StructArray = one_batch.into();
         let reordered = take(&struct_arr, &remapping_index, None)?;


### PR DESCRIPTION
We can find the index in the sorted row IDs by binary search,
to improve reordering performance from $O(n^2)$ to $O(nlogn)$

Signed-off-by: yah01 <yah2er0ne@outlook.com>