### PR TITLE
Use the released crate for DataFusion

### DIFF
--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -54,7 +54,7 @@ num_cpus = "1.0"
 sqlparser = "0.30.0"
 # TODO: use datafusion sub-modules to reduce build size?
 # datafusion = { version = "17.0.0", default-features = false }
-datafusion = { git = "https://github.com/apache/arrow-datafusion.git", tag="18.0.0-rc1", default-features = false }
+datafusion = { version = "18.0.0", default-features = false }
 faiss = { version = "0.11.0", features = ["gpu"], optional = true }
 
 [build-dependencies]

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -53,7 +53,6 @@ arrow = { version = "32.0.0", features = ["prettyprint"] }
 num_cpus = "1.0"
 sqlparser = "0.30.0"
 # TODO: use datafusion sub-modules to reduce build size?
-# datafusion = { version = "17.0.0", default-features = false }
 datafusion = { version = "18.0.0", default-features = false }
 faiss = { version = "0.11.0", features = ["gpu"], optional = true }
 


### PR DESCRIPTION
DataFusion 18.0 is released and compatible with the rest of our arrow-32.0 usage.