### PR TITLE
Add an argument to checkout a dataset as of a certain timestamp

### DIFF
--- a/python/python/lance/dataset.py
+++ b/python/python/lance/dataset.py
@@ -233,6 +233,13 @@ class LanceDataset(pa.dataset.Dataset):
             )  # NOTE: python datetime supports only microsecond precision
         return versions
 
+    @property
+    def active_version(self) -> int:
+        """
+        Returns the currently checked out version of the dataset
+        """
+        return self._ds.active_version()
+
     def create_index(
         self, column: str, index_type: str, name: Optional[str] = None, **kwargs
     ):

--- a/python/python/lance/dataset.py
+++ b/python/python/lance/dataset.py
@@ -15,7 +15,7 @@
 
 from __future__ import annotations
 
-from datetime import datetime
+from datetime import datetime, timedelta
 from pathlib import Path
 from typing import Iterator, Optional, Union
 
@@ -227,7 +227,10 @@ class LanceDataset(pa.dataset.Dataset):
         """
         versions = self._ds.versions()
         for v in versions:
-            v["timestamp"] = datetime.fromtimestamp(v["timestamp"])
+            ts_nanos = v["timestamp"]
+            v["timestamp"] = datetime.fromtimestamp(ts_nanos // 1e9) + timedelta(
+                microseconds=(ts_nanos % 1e9) // 1e3
+            )  # NOTE: python datetime supports only microsecond precision
         return versions
 
     def create_index(

--- a/python/python/lance/dataset.py
+++ b/python/python/lance/dataset.py
@@ -223,14 +223,16 @@ class LanceDataset(pa.dataset.Dataset):
 
     def versions(self):
         """
-        Return all versions in this dataset
+        Return all versions in this dataset.
         """
         versions = self._ds.versions()
         for v in versions:
+            # TODO: python datetime supports only microsecond precision. When a separate Version object is
+            # implemented, expose the precise timestamp (ns) to python.
             ts_nanos = v["timestamp"]
             v["timestamp"] = datetime.fromtimestamp(ts_nanos // 1e9) + timedelta(
                 microseconds=(ts_nanos % 1e9) // 1e3
-            )  # NOTE: python datetime supports only microsecond precision
+            )
         return versions
 
     @property

--- a/python/python/lance/dataset.py
+++ b/python/python/lance/dataset.py
@@ -236,11 +236,11 @@ class LanceDataset(pa.dataset.Dataset):
         return versions
 
     @property
-    def active_version(self) -> int:
+    def version(self) -> int:
         """
         Returns the currently checked out version of the dataset
         """
-        return self._ds.active_version()
+        return self._ds.version()
 
     def create_index(
         self, column: str, index_type: str, name: Optional[str] = None, **kwargs

--- a/python/python/lance/util.py
+++ b/python/python/lance/util.py
@@ -18,11 +18,11 @@ from typing import Union
 import pandas as pd
 
 
-def sanitize_ts(ts: Union[datetime, str]) -> datetime:
+def sanitize_ts(ts: Union[datetime, pd.Timestamp, str]) -> datetime:
     if isinstance(ts, str):
-        ts = pd.Timestamp.fromisoformat(ts).to_pydatetime()
+        ts = pd.to_datetime(ts).to_pydatetime()
     elif isinstance(ts, pd.Timestamp):
         ts = ts.to_pydatetime()
     elif not isinstance(ts, datetime):
-        raise TypeError(f"Unrecognized version timestamp {ts} " f"of type {type(ts)}")
+        raise TypeError(f"Unrecognized version timestamp {ts} of type {type(ts)}")
     return ts

--- a/python/python/lance/util.py
+++ b/python/python/lance/util.py
@@ -1,0 +1,28 @@
+#  Copyright (c) 2023. Lance Developers
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+
+from datetime import datetime, timezone
+from typing import Union
+
+import pandas as pd
+
+
+def sanitize_ts(ts: Union[datetime, str]) -> datetime:
+    if isinstance(ts, str):
+        ts = pd.Timestamp.fromisoformat(ts).to_pydatetime()
+    elif isinstance(ts, pd.Timestamp):
+        ts = ts.to_pydatetime()
+    elif not isinstance(ts, datetime):
+        raise TypeError(f"Unrecognized version timestamp {ts} " f"of type {type(ts)}")
+    return ts

--- a/python/python/tests/test_dataset.py
+++ b/python/python/tests/test_dataset.py
@@ -77,17 +77,17 @@ def test_asof_checkout(tmp_path: Path):
 
     # check that only the first batch is present
     ds = lance.dataset(base_dir, asof=ts_1)
-    assert ds.active_version == 1
+    assert ds.version == 1
     assert len(ds.to_table()) == 3
 
     # check that the first and second batch are present
     ds = lance.dataset(base_dir, asof=ts_2)
-    assert ds.active_version == 2
+    assert ds.version == 2
     assert len(ds.to_table()) == 6
 
     # check that all batches are present
     ds = lance.dataset(base_dir, asof=ts_3)
-    assert ds.active_version == 3
+    assert ds.version == 3
     assert len(ds.to_table()) == 9
 
 

--- a/python/python/tests/test_dataset.py
+++ b/python/python/tests/test_dataset.py
@@ -11,6 +11,7 @@
 #  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 #  See the License for the specific language governing permissions and
 #  limitations under the License.
+
 import time
 from datetime import datetime
 from pathlib import Path
@@ -54,6 +55,34 @@ def test_versions(tmp_path: Path):
     assert v1["timestamp"] < v2["timestamp"]
     assert isinstance(v1["metadata"], dict)
     assert isinstance(v2["metadata"], dict)
+
+
+def test_asof_checkout(tmp_path: Path):
+    table = pa.Table.from_pydict({"colA": [1, 2, 3], "colB": [4, 5, 6]})
+    base_dir = tmp_path / "test"
+
+    lance.write_dataset(table, base_dir)
+    assert len(lance.dataset(base_dir).versions()) == 1
+    ts_1 = datetime.now()
+    time.sleep(0.01)
+
+    lance.write_dataset(table, base_dir, mode="append")
+    assert len(lance.dataset(base_dir).versions()) == 2
+    ts_2 = datetime.now()
+    time.sleep(0.01)
+
+    lance.write_dataset(table, base_dir, mode="append")
+    assert len(lance.dataset(base_dir).versions()) == 3
+    ts_3 = datetime.now()
+
+    # check that only the first batch is present
+    assert len(lance.dataset(base_dir, asof=ts_1).to_table()) == 3
+
+    # check that the first and second batch are present
+    assert len(lance.dataset(base_dir, asof=ts_2).to_table()) == 6
+
+    # check that all batches are present
+    assert len(lance.dataset(base_dir, asof=ts_3).to_table()) == 9
 
 
 def test_take(tmp_path: Path):

--- a/python/python/tests/test_dataset.py
+++ b/python/python/tests/test_dataset.py
@@ -76,13 +76,19 @@ def test_asof_checkout(tmp_path: Path):
     ts_3 = datetime.now()
 
     # check that only the first batch is present
-    assert len(lance.dataset(base_dir, asof=ts_1).to_table()) == 3
+    ds = lance.dataset(base_dir, asof=ts_1)
+    assert ds.active_version == 1
+    assert len(ds.to_table()) == 3
 
     # check that the first and second batch are present
-    assert len(lance.dataset(base_dir, asof=ts_2).to_table()) == 6
+    ds = lance.dataset(base_dir, asof=ts_2)
+    assert ds.active_version == 2
+    assert len(ds.to_table()) == 6
 
     # check that all batches are present
-    assert len(lance.dataset(base_dir, asof=ts_3).to_table()) == 9
+    ds = lance.dataset(base_dir, asof=ts_3)
+    assert ds.active_version == 3
+    assert len(ds.to_table()) == 9
 
 
 def test_take(tmp_path: Path):

--- a/python/src/dataset.rs
+++ b/python/src/dataset.rs
@@ -195,7 +195,7 @@ impl Dataset {
     }
 
     /// Fetches the currently checked out version of the dataset.
-    fn active_version(&self) -> PyResult<u64> {
+    fn version(&self) -> PyResult<u64> {
         Ok(self.ds.version().version)
     }
 

--- a/python/src/dataset.rs
+++ b/python/src/dataset.rs
@@ -194,6 +194,11 @@ impl Dataset {
         })
     }
 
+    /// Fetches the currently checked out version of the dataset.
+    fn active_version(&self) -> PyResult<u64> {
+        Ok(self.ds.version().version)
+    }
+
     fn create_index(
         self_: PyRef<'_, Self>,
         columns: Vec<&str>,

--- a/python/src/dataset.rs
+++ b/python/src/dataset.rs
@@ -181,7 +181,8 @@ impl Dataset {
                 .map(|v| {
                     let dict = PyDict::new(py);
                     dict.set_item("version", v.version).unwrap();
-                    dict.set_item("timestamp", v.timestamp.timestamp()).unwrap();
+                    dict.set_item("timestamp", v.timestamp.timestamp_nanos())
+                        .unwrap();
                     let tup: Vec<(&String, &String)> = v.metadata.iter().collect();
                     dict.set_item("metadata", tup.into_py_dict(py)).unwrap();
                     dict.to_object(py)


### PR DESCRIPTION
This commit adds an `asof` argument to the Lance dataset reader (per #506). 

Notes
- Python only supports datetime objects with microsecond precision, while Lance stores timestamps correct to nanoseconds. Seems unlikely this will cause issues, until new batches can be commited quicker than 1 us. 
- Added a method `active_version` that returns the currently checked out version of the dataset. It is also useful to sanity check the `asof` logic, which lives in python. 