### PR TITLE
Refactor distance computation to allow pluggable dist function

### DIFF
--- a/rust/src/dataset.rs
+++ b/rust/src/dataset.rs
@@ -373,7 +373,7 @@ impl Dataset {
                                 }
                             }
                         }
-                        _ => return Err(Error::Index(format!("Must be FixedSizeList"))),
+                        _ => return Err(Error::Index("Must be FixedSizeList".to_string())),
                     }
                 }
 

--- a/rust/src/index/vector/ivf.rs
+++ b/rust/src/index/vector/ivf.rs
@@ -537,7 +537,7 @@ impl IndexBuilder for IvfPqIndexBuilder<'_> {
             train_kmean_model(
                 &scanner,
                 self.dimension,
-                self.num_partitions,
+                self.num_partitions as usize,
                 self.kmeans_max_iters,
                 rng.clone(),
             )
@@ -625,7 +625,7 @@ impl IndexBuilder for IvfPqIndexBuilder<'_> {
 async fn train_kmean_model(
     scanner: &Scanner,
     dimension: usize,
-    k: u32,
+    k: usize,
     max_iterations: u32,
     rng: impl Rng,
 ) -> Result<Arc<FixedSizeListArray>> {

--- a/rust/src/index/vector/kmeans.rs
+++ b/rust/src/index/vector/kmeans.rs
@@ -52,13 +52,13 @@ pub async fn train_kmeans(
     mut rng: impl Rng,
 ) -> Result<Float32Array> {
     let num_rows = array.len() / dimension;
-    if num_rows < k as usize {
+    if num_rows < k {
         return Err(crate::Error::Index(format!(
             "KMeans: can not train {k} centroids with {num_rows} vectors, choose a smaller K (< {num_rows}) instead"
         )));
     }
     // Ony sample 256 * num_clusters. See Faiss
-    let data = if num_rows > 256 * k as usize {
+    let data = if num_rows > 256 * k {
         println!(
             "Sample {} out of {} to train kmeans of {} dim, {} clusters",
             256 * k,
@@ -66,7 +66,7 @@ pub async fn train_kmeans(
             dimension,
             k,
         );
-        let sample_size = 256 * k as usize;
+        let sample_size = 256 * k;
         let chosen = (0..num_rows).choose_multiple(&mut rng, sample_size);
         let mut builder = Float32Builder::with_capacity(sample_size * dimension);
         for idx in chosen.iter() {

--- a/rust/src/index/vector/pq.rs
+++ b/rust/src/index/vector/pq.rs
@@ -31,8 +31,9 @@ use rand::SeedableRng;
 use crate::index::pb;
 use crate::index::vector::kmeans::train_kmeans;
 use crate::io::object_reader::{read_fixed_stride_array, ObjectReader};
+use crate::utils::distance::Distance;
 use crate::Result;
-use crate::{arrow::*, utils::distance::l2_distance};
+use crate::{arrow::*, utils::distance::L2Distance};
 
 /// Product Quantization Index.
 ///
@@ -95,10 +96,15 @@ impl<'a> PQIndex<'a> {
         let mut distance_table: Vec<f32> = vec![];
 
         let sub_vector_length = self.dimension / self.num_sub_vectors;
+        let dist_func = L2Distance::default();
         for i in 0..self.num_sub_vectors {
             let from = key.slice(i * sub_vector_length, sub_vector_length);
             let subvec_centroids = self.pq.centroids(i);
-            let distances = l2_distance(as_primitive_array(&from), &subvec_centroids)?;
+            let distances = dist_func.distance(
+                as_primitive_array(&from),
+                &subvec_centroids,
+                sub_vector_length,
+            )?;
             distance_table.extend(distances.values());
         }
 
@@ -184,7 +190,9 @@ impl ProductQuantizer {
     }
 
     /// Get the centroids for one sub-vector.
-    pub fn centroids(&self, sub_vector_idx: usize) -> Arc<FixedSizeListArray> {
+    ///
+    /// Returns a flatten `num_centroids * sub_vector_width` f32 array.
+    pub fn centroids(&self, sub_vector_idx: usize) -> Arc<Float32Array> {
         assert!(sub_vector_idx < self.num_sub_vectors);
         assert!(self.codebook.is_some());
 
@@ -195,8 +203,8 @@ impl ProductQuantizer {
             sub_vector_idx * num_centroids * sub_vector_width,
             num_centroids * sub_vector_width,
         );
-        let f32_arr: &Float32Array = as_primitive_array(&arr);
-        Arc::new(FixedSizeListArray::try_new(f32_arr, sub_vector_width as i32).unwrap())
+        // TODO: return reference instead of Arc?
+        Arc::new(as_primitive_array(&arr).clone())
     }
 
     /// Transform the vector array to PQ code array.
@@ -214,14 +222,23 @@ impl ProductQuantizer {
             .zip(stream::iter(all_centroids))
             .map(|(vec, centroid)| async move {
                 tokio::task::spawn_blocking(move || {
+                    let dist_func = L2Distance::new();
                     // TODO Use tiling to improve cache efficiency.
                     (0..vec.len())
                         .map(|i| {
                             let value = vec.value(i);
                             let vector: &Float32Array = as_primitive_array(value.as_ref());
-                            let id =
-                                argmin(l2_distance(vector, centroid.as_ref()).unwrap().as_ref())
-                                    .unwrap() as u8;
+                            let id = argmin(
+                                dist_func
+                                    .distance(
+                                        vector,
+                                        centroid.as_ref(),
+                                        vector.len(),
+                                    )
+                                    .unwrap()
+                                    .as_ref(),
+                            )
+                            .unwrap() as u8;
                             id
                         })
                         .collect::<Vec<_>>()

--- a/rust/src/index/vector/pq.rs
+++ b/rust/src/index/vector/pq.rs
@@ -230,11 +230,7 @@ impl ProductQuantizer {
                             let vector: &Float32Array = as_primitive_array(value.as_ref());
                             let id = argmin(
                                 dist_func
-                                    .distance(
-                                        vector,
-                                        centroid.as_ref(),
-                                        vector.len(),
-                                    )
+                                    .distance(vector, centroid.as_ref(), vector.len())
                                     .unwrap()
                                     .as_ref(),
                             )

--- a/rust/src/index/vector/pq.rs
+++ b/rust/src/index/vector/pq.rs
@@ -274,7 +274,7 @@ impl ProductQuantizer {
         let dimension = data.value_length() as usize / self.num_sub_vectors;
 
         let mut codebook_builder =
-            Float32Builder::with_capacity(num_centorids as usize * data.value_length() as usize);
+            Float32Builder::with_capacity(num_centorids * data.value_length() as usize);
         let rng = rand::rngs::SmallRng::from_entropy();
 
         // TODO: parallel training.

--- a/rust/src/index/vector/pq.rs
+++ b/rust/src/index/vector/pq.rs
@@ -253,7 +253,7 @@ impl ProductQuantizer {
         assert_eq!(data.null_count(), 0);
 
         let sub_vectors = divide_to_subvectors(data, self.num_sub_vectors as i32);
-        let num_centorids = 2_u32.pow(self.num_bits);
+        let num_centorids = 2_usize.pow(self.num_bits);
         let dimension = data.value_length() as usize / self.num_sub_vectors;
 
         let mut codebook_builder =

--- a/rust/src/utils/distance.rs
+++ b/rust/src/utils/distance.rs
@@ -20,9 +20,7 @@
 
 use std::sync::Arc;
 
-use arrow_array::{Array, FixedSizeListArray, Float32Array};
-
-use arrow_schema::DataType;
+use arrow_array::{Array, Float32Array};
 
 use crate::Result;
 
@@ -44,6 +42,27 @@ pub(crate) fn simd_alignment() -> i32 {
     }
 
     1
+}
+
+/// Distance trait
+pub trait Distance {
+    /// Compute distance from one vector to an array of vectors (batch mode).
+    ///
+    /// Parameters
+    ///
+    /// - *from*: the source vector, with `dimension` of values.
+    /// - *to*: the target vector list. It is a flatten array with with `N x dimension` values.
+    /// - *dimension*: the dimension of the vector.
+    ///
+    /// Returns:
+    ///
+    /// - *Scores*: N elements vector to present the distance for each from/to pair.
+    fn distance(
+        &self,
+        from: &Float32Array,
+        to: &Float32Array,
+        dimension: usize,
+    ) -> Result<Arc<Float32Array>>;
 }
 
 // TODO: wait [std::simd] to be stable to replace manually written AVX/FMA code.
@@ -112,23 +131,24 @@ unsafe fn l2_distance_neon(from: &[f32], to: &[f32]) -> f32 {
     vaddvq_f32(sum)
 }
 
-fn l2_distance_simd(from: &Float32Array, to: &FixedSizeListArray) -> Result<Arc<Float32Array>> {
-    use arrow_array::{cast::as_primitive_array, types::Float32Type};
-
-    let inner_array = to.values();
-    let buffer = as_primitive_array::<Float32Type>(&inner_array).values();
-    let dimension = from.len();
+fn l2_distance_simd(
+    from: &Float32Array,
+    to: &Float32Array,
+    dimension: usize,
+) -> Result<Arc<Float32Array>> {
+    let n = to.len() / dimension;
     let from_vector = from.values();
+    let to_buffer = to.values();
 
     let scores: Float32Array = unsafe {
         Float32Array::from_trusted_len_iter(
-            (0..to.len())
+            (0..n)
                 .map(|idx| {
                     #[cfg(any(target_arch = "x86_64"))]
                     {
                         euclidean_distance_fma(
                             from_vector,
-                            &buffer[idx * dimension..(idx + 1) * dimension],
+                            &to_buffer[idx * dimension..(idx + 1) * dimension],
                         )
                     }
 
@@ -136,7 +156,7 @@ fn l2_distance_simd(from: &Float32Array, to: &FixedSizeListArray) -> Result<Arc<
                     {
                         l2_distance_neon(
                             from_vector,
-                            &buffer[idx * dimension..(idx + 1) * dimension],
+                            &to_buffer[idx * dimension..(idx + 1) * dimension],
                         )
                     }
                 })
@@ -146,47 +166,66 @@ fn l2_distance_simd(from: &Float32Array, to: &FixedSizeListArray) -> Result<Arc<
     Ok(Arc::new(scores))
 }
 
-/// Euclidean Distance (L2) from one vector to a list of vectors.
-pub fn l2_distance(from: &Float32Array, to: &FixedSizeListArray) -> Result<Arc<Float32Array>> {
-    assert_eq!(from.len(), to.value_length() as usize);
-    assert_eq!(to.value_type(), DataType::Float32);
+/// L2 (Euclidean) distance.
+#[derive(Debug)]
+pub struct L2Distance {}
 
-    #[cfg(any(target_arch = "x86_64"))]
-    {
-        if is_x86_feature_detected!("fma") && from.len() % 8 == 0 {
-            return l2_distance_simd(from, to);
+impl Distance for L2Distance {
+    fn distance(
+        &self,
+        from: &Float32Array,
+        to: &Float32Array,
+        dimension: usize,
+    ) -> Result<Arc<Float32Array>> {
+        assert_eq!(from.len(), dimension);
+        assert_eq!(to.len() % dimension, 0);
+
+        #[cfg(any(target_arch = "x86_64"))]
+        {
+            if is_x86_feature_detected!("fma") && from.len() % 8 == 0 {
+                return l2_distance_simd(from, to, dimension);
+            }
         }
-    }
 
-    #[cfg(any(target_arch = "aarch64"))]
-    {
-        use std::arch::is_aarch64_feature_detected;
-        if is_aarch64_feature_detected!("neon") && from.len() % 4 == 0 {
-            return l2_distance_simd(from, to);
+        #[cfg(any(target_arch = "aarch64"))]
+        {
+            use std::arch::is_aarch64_feature_detected;
+            if is_aarch64_feature_detected!("neon") && from.len() % 4 == 0 {
+                return l2_distance_simd(from, to, dimension);
+            }
         }
-    }
 
-    // Fallback
-    let scores: Float32Array = unsafe {
-        Float32Array::from_trusted_len_iter(
-            (0..to.len())
-                .map(|idx| {
-                    let left = to.value(idx);
-                    let arr = left.as_any().downcast_ref::<Float32Array>().unwrap();
-                    l2_distance_arrow(from, arr)
-                })
-                .map(Some),
-        )
-    };
-    Ok(Arc::new(scores))
+        // Fallback
+        use arrow_array::cast::as_primitive_array;
+        let n = to.len() / dimension;
+        let scores: Float32Array = unsafe {
+            Float32Array::from_trusted_len_iter(
+                (0..n)
+                    .map(|idx| {
+                        l2_distance_arrow(
+                            from,
+                            as_primitive_array(to.slice(idx * dimension, dimension).as_ref()),
+                        )
+                    })
+                    .map(Some),
+            )
+        };
+        Ok(Arc::new(scores))
+    }
+}
+
+impl L2Distance {
+    pub fn new() -> Self {
+        Self {}
+    }
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::arrow::FixedSizeListArrayExt;
 
     use approx::assert_relative_eq;
+    use arrow::array::as_primitive_array;
     use arrow_array::types::Float32Type;
 
     #[test]
@@ -201,7 +240,9 @@ mod tests {
             8,
         );
         let point = Float32Array::from((2..10).map(|v| Some(v as f32)).collect::<Vec<_>>());
-        let scores = l2_distance(&point, &mat).unwrap();
+        let scores = L2Distance::new()
+            .distance(&point, as_primitive_array(mat.values().as_ref()), 8)
+            .unwrap();
 
         assert_eq!(
             scores.as_ref(),
@@ -211,12 +252,9 @@ mod tests {
 
     #[test]
     fn test_odd_length_vector() {
-        let mat = FixedSizeListArray::from_iter_primitive::<Float32Type, _, _>(
-            vec![Some((0..5).map(|v| Some(v as f32)).collect::<Vec<_>>())],
-            5,
-        );
+        let mat = Float32Array::from_iter((0..5).map(|v| Some(v as f32)));
         let point = Float32Array::from((2..7).map(|v| Some(v as f32)).collect::<Vec<_>>());
-        let scores = l2_distance(&point, &mat).unwrap();
+        let scores = L2Distance::new().distance(&point, &mat, 5).unwrap();
 
         assert_eq!(scores.as_ref(), &Float32Array::from(vec![20.0]));
     }
@@ -231,7 +269,6 @@ mod tests {
             0.04898421, 0.14728612, 0.21263947, 0.16763233,
         ]
         .into();
-        let vectors = FixedSizeListArray::try_new(values, 32).unwrap();
 
         let q: Float32Array = vec![
             0.18549609,
@@ -269,7 +306,7 @@ mod tests {
         ]
         .into();
 
-        let d = l2_distance(&q, &vectors).unwrap();
+        let d = L2Distance::new().distance(&q, &values, 32).unwrap();
         assert_relative_eq!(0.31935785197341404, d.value(0));
     }
 }

--- a/rust/src/utils/distance.rs
+++ b/rust/src/utils/distance.rs
@@ -1,19 +1,16 @@
-// Licensed to the Apache Software Foundation (ASF) under one
-// or more contributor license agreements.  See the NOTICE file
-// distributed with this work for additional information
-// regarding copyright ownership.  The ASF licenses this file
-// to you under the Apache License, Version 2.0 (the
-// "License"); you may not use this file except in compliance
-// with the License.  You may obtain a copy of the License at
+// Copyright 2023 Lance Developers.
 //
-//   http://www.apache.org/licenses/LICENSE-2.0
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
 //
-// Unless required by applicable law or agreed to in writing,
-// software distributed under the License is distributed on an
-// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
-// KIND, either express or implied.  See the License for the
-// specific language governing permissions and limitations
-// under the License.
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 
 //! Compute distance
 //!

--- a/rust/src/utils/distance.rs
+++ b/rust/src/utils/distance.rs
@@ -18,10 +18,9 @@
 //! Compute distance
 //!
 
-use std::{sync::Arc, fmt::Debug};
+use std::{fmt::Debug, sync::Arc};
 
-use arrow::array::as_primitive_array;
-use arrow_array::{Array, FixedSizeListArray, Float32Array};
+use arrow_array::{Array, Float32Array};
 
 use crate::Result;
 
@@ -46,12 +45,12 @@ pub(crate) fn simd_alignment() -> i32 {
 }
 
 /// Distance trait
-pub trait Distance : Debug + Send + Sync     {
+pub trait Distance {
     /// Compute distance from one vector to an array of vectors (batch mode).
     ///
     /// Parameters
     ///
-    /// - *from*: the source vector, with `dimension` of values.
+    /// - *from*: the source vector, with `dimension` of float numbers.
     /// - *to*: the target vector list. It is a flatten array with with `N x dimension` values.
     /// - *dimension*: the dimension of the vector.
     ///
@@ -226,7 +225,7 @@ mod tests {
     use super::*;
 
     use approx::assert_relative_eq;
-    use arrow::array::as_primitive_array;
+    use arrow::array::{as_primitive_array, FixedSizeListArray};
     use arrow_array::types::Float32Type;
 
     #[test]

--- a/rust/src/utils/distance.rs
+++ b/rust/src/utils/distance.rs
@@ -45,7 +45,7 @@ pub(crate) fn simd_alignment() -> i32 {
 }
 
 /// Distance trait
-pub trait Distance : Sync {
+pub trait Distance: Sync + Send + Clone + Default + Sized {
     /// Compute distance from one vector to an array of vectors (batch mode).
     ///
     /// Parameters
@@ -167,7 +167,7 @@ fn l2_distance_simd(
 }
 
 /// L2 (Euclidean) distance.
-#[derive(Debug, Default)]
+#[derive(Debug, Default, Clone)]
 pub struct L2Distance {}
 
 impl Distance for L2Distance {

--- a/rust/src/utils/distance.rs
+++ b/rust/src/utils/distance.rs
@@ -45,7 +45,7 @@ pub(crate) fn simd_alignment() -> i32 {
 }
 
 /// Distance trait
-pub trait Distance {
+pub trait Distance : Sync {
     /// Compute distance from one vector to an array of vectors (batch mode).
     ///
     /// Parameters

--- a/rust/src/utils/distance.rs
+++ b/rust/src/utils/distance.rs
@@ -18,9 +18,10 @@
 //! Compute distance
 //!
 
-use std::sync::Arc;
+use std::{sync::Arc, fmt::Debug};
 
-use arrow_array::{Array, Float32Array};
+use arrow::array::as_primitive_array;
+use arrow_array::{Array, FixedSizeListArray, Float32Array};
 
 use crate::Result;
 
@@ -45,7 +46,7 @@ pub(crate) fn simd_alignment() -> i32 {
 }
 
 /// Distance trait
-pub trait Distance {
+pub trait Distance : Debug + Send + Sync     {
     /// Compute distance from one vector to an array of vectors (batch mode).
     ///
     /// Parameters
@@ -167,7 +168,7 @@ fn l2_distance_simd(
 }
 
 /// L2 (Euclidean) distance.
-#[derive(Debug)]
+#[derive(Debug, Default)]
 pub struct L2Distance {}
 
 impl Distance for L2Distance {

--- a/rust/src/utils/kmeans.rs
+++ b/rust/src/utils/kmeans.rs
@@ -87,9 +87,9 @@ async fn kmean_plusplus<D: Distance + 'static>(
     mut rng: impl Rng,
     dist_func: &D,
 ) -> KMeans<D> {
-    assert!(data.len() > k);
+    assert!(data.len() > k * dimension);
     let mut kmeans = KMeans::empty(k, dimension, dist_func.clone());
-    let first_idx = rng.gen_range(0..data.len());
+    let first_idx = rng.gen_range(0..data.len() / dimension);
     let first_vector = data.slice(first_idx * dimension, dimension);
     kmeans.centroids = Arc::new(as_primitive_array(first_vector.as_ref()).clone());
 
@@ -135,7 +135,7 @@ async fn kmeans_random_init<'a, D: Distance + 'static>(
 ) -> KMeans<D> {
     assert!(data.len() > k * dimension);
 
-    let chosen = (0..data.len()).choose_multiple(&mut rng, k).to_vec();
+    let chosen = (0..data.len() / dimension).choose_multiple(&mut rng, k).to_vec();
     let mut builder = Float32Builder::with_capacity(k * dimension);
     for i in chosen {
         builder.append_slice(&data.values()[i * dimension..(i + 1) * dimension]);

--- a/rust/src/utils/kmeans.rs
+++ b/rust/src/utils/kmeans.rs
@@ -87,7 +87,7 @@ async fn kmean_plusplus<D: Distance + 'static>(
     mut rng: impl Rng,
     dist_func: &D,
 ) -> KMeans<D> {
-    assert!(data.len() > k as usize);
+    assert!(data.len() > k);
     let mut kmeans = KMeans::empty(k, dimension, dist_func.clone());
     let first_idx = rng.gen_range(0..data.len());
     let first_vector = data.slice(first_idx * dimension, dimension);
@@ -135,12 +135,8 @@ async fn kmeans_random_init<'a, D: Distance + 'static>(
 ) -> KMeans<D> {
     assert!(data.len() > k * dimension);
 
-    let chosen = (0..data.len())
-        .choose_multiple(&mut rng, k as usize)
-        .iter()
-        .copied()
-        .collect::<Vec<_>>();
-    let mut builder = Float32Builder::with_capacity(k as usize * dimension);
+    let chosen = (0..data.len()).choose_multiple(&mut rng, k).to_vec();
+    let mut builder = Float32Builder::with_capacity(k * dimension);
     for i in chosen {
         builder.append_slice(&data.values()[i * dimension..(i + 1) * dimension]);
     }
@@ -206,7 +202,7 @@ impl<D: Distance> KMeanMembership<D> {
                             divide_scalar(&sum, total).unwrap()
                         } else {
                             eprintln!("Warning: KMean: cluster {cluster} has no value, does not change centroids.");
-                            let prev_centroids = previous_centroids.slice(cluster as usize * dimension, dimension);
+                            let prev_centroids = previous_centroids.slice(cluster * dimension, dimension);
                             as_primitive_array(prev_centroids.as_ref()).clone()
                         }
                     })
@@ -242,7 +238,7 @@ impl<D: Distance> KMeanMembership<D> {
 
     /// Histogram of the size of each cluster.
     fn histogram(&self) -> Vec<usize> {
-        let mut hist: Vec<usize> = vec![0; self.k as usize];
+        let mut hist: Vec<usize> = vec![0; self.k];
         for cluster_id in self.cluster_ids.iter() {
             hist[*cluster_id as usize] += 1;
         }

--- a/rust/src/utils/kmeans.rs
+++ b/rust/src/utils/kmeans.rs
@@ -135,7 +135,9 @@ async fn kmeans_random_init<'a, D: Distance + 'static>(
 ) -> KMeans<D> {
     assert!(data.len() > k * dimension);
 
-    let chosen = (0..data.len() / dimension).choose_multiple(&mut rng, k).to_vec();
+    let chosen = (0..data.len() / dimension)
+        .choose_multiple(&mut rng, k)
+        .to_vec();
     let mut builder = Float32Builder::with_capacity(k * dimension);
     for i in chosen {
         builder.append_slice(&data.values()[i * dimension..(i + 1) * dimension]);

--- a/rust/src/utils/kmeans.rs
+++ b/rust/src/utils/kmeans.rs
@@ -24,7 +24,7 @@ use futures::stream::{self, repeat_with, StreamExt, TryStreamExt};
 use rand::prelude::*;
 use rand::{distributions::WeightedIndex, Rng};
 
-use super::distance::{Distance};
+use super::distance::Distance;
 use crate::Result;
 use crate::{arrow::*, Error};
 
@@ -362,7 +362,9 @@ impl<D: Distance + 'static> KMeans<D> {
         let cluster_with_distances = stream::iter(0..n)
             // make tiles of input data to split between threads.
             .chunks(1024)
-            .zip(repeat_with(|| (data.clone(), self.centroids.clone(), dist_func.clone())))
+            .zip(repeat_with(|| {
+                (data.clone(), self.centroids.clone(), dist_func.clone())
+            }))
             .map(|(indices, (data, centroids, dist_func))| async move {
                 let data = tokio::task::spawn_blocking(move || {
                     let mut results = vec![];


### PR DESCRIPTION
Abstract L2 distance behind a `Distance` trait,  so that we can later use other distance computation method (i.e., cosine distance).