### PR TITLE
support arrow-rs duration type in lance

### DIFF
--- a/rust/src/arrow.rs
+++ b/rust/src/arrow.rs
@@ -94,6 +94,7 @@ impl DataTypeExt for DataType {
                 | Decimal256(_, _)
                 | FixedSizeList(_, _)
                 | FixedSizeBinary(_)
+                | Duration(_)
         )
     }
 
@@ -118,6 +119,7 @@ impl DataTypeExt for DataType {
             Self::Date64 => 8,
             Self::Time32(_) => 4,
             Self::Time64(_) => 8,
+            Self::Duration(_) => 8,
             Self::Decimal128(_, _) => 16,
             Self::Decimal256(_, _) => 32,
             Self::FixedSizeBinary(s) => *s as usize,

--- a/rust/src/datatypes.rs
+++ b/rust/src/datatypes.rs
@@ -87,6 +87,7 @@ impl TryFrom<&DataType> for LogicalType {
             DataType::Time32(tu) => format!("time32:{}", timeunit_to_str(tu)),
             DataType::Time64(tu) => format!("time64:{}", timeunit_to_str(tu)),
             DataType::Timestamp(tu, _) => format!("timestamp:{}", timeunit_to_str(tu)),
+            DataType::Duration(tu) => format!("duration:{}", timeunit_to_str(tu)),
             DataType::Struct(_) => "struct".to_string(),
             DataType::Dictionary(key_type, value_type) => {
                 format!(
@@ -151,6 +152,10 @@ impl TryFrom<&LogicalType> for DataType {
             "timestamp:ms" => Some(Timestamp(TimeUnit::Millisecond, None)),
             "timestamp:us" => Some(Timestamp(TimeUnit::Microsecond, None)),
             "timestamp:ns" => Some(Timestamp(TimeUnit::Nanosecond, None)),
+            "duration:s" => Some(Duration(TimeUnit::Second)),
+            "duration:ms" => Some(Duration(TimeUnit::Millisecond)),
+            "duration:us" => Some(Duration(TimeUnit::Microsecond)),
+            "duration:ns" => Some(Duration(TimeUnit::Nanosecond)),
             _ => None,
         } {
             Ok(t)
@@ -797,6 +802,10 @@ mod tests {
             ("time32:ms", DataType::Time32(TimeUnit::Millisecond)),
             ("time64:us", DataType::Time64(TimeUnit::Microsecond)),
             ("time64:ns", DataType::Time64(TimeUnit::Nanosecond)),
+            ("duration:s", DataType::Duration(TimeUnit::Second)),
+            ("duration:ms", DataType::Duration(TimeUnit::Millisecond)),
+            ("duration:us", DataType::Duration(TimeUnit::Microsecond)),
+            ("duration:ns", DataType::Duration(TimeUnit::Nanosecond)),
             ("fixed_size_binary:100", DataType::FixedSizeBinary(100)),
             (
                 "fixed_size_list:int32:10",

--- a/rust/src/io/writer.rs
+++ b/rust/src/io/writer.rs
@@ -276,11 +276,12 @@ mod tests {
 
     use arrow_array::{
         types::UInt32Type, BooleanArray, Decimal128Array, Decimal256Array, DictionaryArray,
-        FixedSizeBinaryArray, FixedSizeListArray, Float32Array, Int64Array, LargeListArray,
-        ListArray, StringArray, UInt8Array,
+        DurationMicrosecondArray, DurationMillisecondArray, DurationNanosecondArray,
+        DurationSecondArray, FixedSizeBinaryArray, FixedSizeListArray, Float32Array, Int64Array,
+        LargeListArray, ListArray, StringArray, UInt8Array,
     };
     use arrow_buffer::i256;
-    use arrow_schema::{DataType, Field as ArrowField, Schema as ArrowSchema};
+    use arrow_schema::{DataType, Field as ArrowField, Schema as ArrowSchema, TimeUnit};
     use object_store::path::Path;
 
     use crate::io::{FileReader, ObjectStore};
@@ -294,6 +295,22 @@ mod tests {
             ArrowField::new("b", DataType::Utf8, true),
             ArrowField::new("decimal128", DataType::Decimal128(7, 3), false),
             ArrowField::new("decimal256", DataType::Decimal256(7, 3), false),
+            ArrowField::new("duration_sec", DataType::Duration(TimeUnit::Second), false),
+            ArrowField::new(
+                "duration_msec",
+                DataType::Duration(TimeUnit::Millisecond),
+                false,
+            ),
+            ArrowField::new(
+                "duration_usec",
+                DataType::Duration(TimeUnit::Microsecond),
+                false,
+            ),
+            ArrowField::new(
+                "duration_nsec",
+                DataType::Duration(TimeUnit::Nanosecond),
+                false,
+            ),
             ArrowField::new(
                 "d",
                 DataType::Dictionary(Box::new(DataType::UInt32), Box::new(DataType::Utf8)),
@@ -379,6 +396,16 @@ mod tests {
                 .with_precision_and_scale(7, 3)
                 .unwrap(),
             ),
+            Arc::new(DurationSecondArray::from_iter_values((0..100).into_iter())),
+            Arc::new(DurationMillisecondArray::from_iter_values(
+                (0..100).into_iter(),
+            )),
+            Arc::new(DurationMicrosecondArray::from_iter_values(
+                (0..100).into_iter(),
+            )),
+            Arc::new(DurationNanosecondArray::from_iter_values(
+                (0..100).into_iter(),
+            )),
             Arc::new(dict_arr),
             Arc::new(fixed_size_list_arr),
             Arc::new(fixed_size_binary_arr),


### PR DESCRIPTION
This commit adds the Arrow Duration type per issue #577. 