### PR TITLE
[Python] Specify metric type in Dataset.create_index

### DIFF
--- a/python/python/lance/dataset.py
+++ b/python/python/lance/dataset.py
@@ -264,7 +264,8 @@ class LanceDataset(pa.dataset.Dataset):
             The index name. If not provided, it will be generated from the
             column name.
         metric : str
-            The distance metric type, i.e., "L2" and "cosine". Default is "L2".
+            The distance metric type, i.e., "L2" (alias to "euclidean") and "cosine".
+            Default is "L2".
         kwargs :
             Parameters passed to the index building process.
 
@@ -325,7 +326,7 @@ class LanceDataset(pa.dataset.Dataset):
                         "Set `force_build=True` to continue build anyways."
                     )
 
-        if not isinstance(metric, str) or metric.lower() not in ["l2", "cosine"]:
+        if not isinstance(metric, str) or metric.lower() not in ["l2", "cosine", "euclidean"]:
             raise ValueError(f"Metric {metric} not supported.")
         index_type = index_type.upper()
         if index_type != "IVF_PQ":

--- a/python/python/lance/dataset.py
+++ b/python/python/lance/dataset.py
@@ -247,7 +247,7 @@ class LanceDataset(pa.dataset.Dataset):
         column: str,
         index_type: str,
         name: Optional[str] = None,
-        metric: str = "l2",
+        metric: str = "L2",
         **kwargs,
     ):
         """Create index on column
@@ -264,7 +264,7 @@ class LanceDataset(pa.dataset.Dataset):
             The index name. If not provided, it will be generated from the
             column name.
         metric : str
-            The distance metric type, i.e., "l2" and "cosine". Default is "l2".
+            The distance metric type, i.e., "L2" and "cosine". Default is "L2".
         kwargs :
             Parameters passed to the index building process.
 
@@ -325,7 +325,7 @@ class LanceDataset(pa.dataset.Dataset):
                         "Set `force_build=True` to continue build anyways."
                     )
 
-        if metric not in ["l2", "cosine"]:
+        if not isinstance(metric, str) or metric.lower() not in ["l2", "cosine"]:
             raise ValueError(f"Metric {metric} not supported.")
         index_type = index_type.upper()
         if index_type != "IVF_PQ":

--- a/python/python/lance/dataset.py
+++ b/python/python/lance/dataset.py
@@ -243,7 +243,12 @@ class LanceDataset(pa.dataset.Dataset):
         return self._ds.version()
 
     def create_index(
-        self, column: str, index_type: str, name: Optional[str] = None, **kwargs
+        self,
+        column: str,
+        index_type: str,
+        name: Optional[str] = None,
+        metric: str = "l2",
+        **kwargs,
     ):
         """Create index on column
 
@@ -258,6 +263,8 @@ class LanceDataset(pa.dataset.Dataset):
         name : str, optional
             The index name. If not provided, it will be generated from the
             column name.
+        metric : str
+            The distance metric type, i.e., "l2" and "cosine". Default is "l2".
         kwargs :
             Parameters passed to the index building process.
 
@@ -317,6 +324,9 @@ class LanceDataset(pa.dataset.Dataset):
                         "Vector ndim must be divisible by 8 for SIMD. "
                         "Set `force_build=True` to continue build anyways."
                     )
+
+        if metric not in ["l2", "cosine"]:
+            raise ValueError(f"Metric {metric} not supported.")
         index_type = index_type.upper()
         if index_type != "IVF_PQ":
             raise NotImplementedError(
@@ -327,7 +337,7 @@ class LanceDataset(pa.dataset.Dataset):
                 "num_partitions and num_sub_vectors are required for IVF_PQ"
             )
 
-        self._ds.create_index(column, index_type, name, kwargs)
+        self._ds.create_index(column, index_type, name, metric, kwargs)
 
 
 class ScannerBuilder:

--- a/python/src/dataset.rs
+++ b/python/src/dataset.rs
@@ -228,15 +228,9 @@ impl Dataset {
             params.num_sub_vectors = PyAny::downcast::<PyInt>(n)?.extract()?
         };
 
-        params.metric_type = match metric_type.to_lowercase().as_str() {
-            "l2" => MetricType::L2,
-            "cosine" => MetricType::Cosine,
-            _ => {
-                return Err(PyValueError::new_err(format!(
-                    "Metric type '{metric_type}' is not supported"
-                )))
-            }
-        };
+        params.metric_type = MetricType::try_from(metric_type).map_err(|e| {
+            PyValueError::new_err(e.to_string())
+        })?;
 
         self_
             .rt

--- a/python/src/dataset.rs
+++ b/python/src/dataset.rs
@@ -204,6 +204,7 @@ impl Dataset {
         columns: Vec<&str>,
         index_type: &str,
         name: Option<String>,
+        metric_type: &str,
         kwargs: &PyDict,
     ) -> PyResult<()> {
         let idx_type = match index_type.to_uppercase().as_str() {
@@ -223,6 +224,12 @@ impl Dataset {
 
         if let Some(n) = kwargs.get_item("num_sub_vectors") {
             params.num_sub_vectors = PyAny::downcast::<PyInt>(n)?.extract()?
+        };
+
+        params.metric_type = match metric_type.to_lowercase().as_str() {
+            "l2" => MetricType::L2,
+            "cosine" => MetricType::Cosine,
+            _ => return Err(PyValueError::new_err(format!("Metric type '{metric_type}' is not supported"))),
         };
 
         self_

--- a/python/src/dataset.rs
+++ b/python/src/dataset.rs
@@ -228,9 +228,8 @@ impl Dataset {
             params.num_sub_vectors = PyAny::downcast::<PyInt>(n)?.extract()?
         };
 
-        params.metric_type = MetricType::try_from(metric_type).map_err(|e| {
-            PyValueError::new_err(e.to_string())
-        })?;
+        params.metric_type =
+            MetricType::try_from(metric_type).map_err(|e| PyValueError::new_err(e.to_string()))?;
 
         self_
             .rt

--- a/python/src/dataset.rs
+++ b/python/src/dataset.rs
@@ -22,8 +22,6 @@ use arrow::pyarrow::*;
 use arrow_array::{Float32Array, RecordBatchReader};
 use arrow_data::ArrayData;
 use arrow_schema::Schema as ArrowSchema;
-use lance::index::vector::VectorIndexParams;
-use lance::index::IndexType;
 use pyo3::exceptions::{PyIOError, PyKeyError, PyValueError};
 use pyo3::prelude::*;
 use pyo3::types::{IntoPyDict, PyDict, PyInt, PyLong};
@@ -31,9 +29,13 @@ use pyo3::{pyclass, PyObject, PyResult};
 use tokio::runtime::Runtime;
 
 use crate::Scanner;
-use ::lance::dataset::scanner::Scanner as LanceScanner;
-use ::lance::dataset::Dataset as LanceDataset;
-use lance::dataset::{Version, WriteMode, WriteParams};
+use lance::dataset::{
+    scanner::Scanner as LanceScanner, Dataset as LanceDataset, Version, WriteMode, WriteParams,
+};
+use lance::index::{
+    vector::{MetricType, VectorIndexParams},
+    IndexType,
+};
 
 const DEFAULT_NPROBS: usize = 1;
 
@@ -229,7 +231,11 @@ impl Dataset {
         params.metric_type = match metric_type.to_lowercase().as_str() {
             "l2" => MetricType::L2,
             "cosine" => MetricType::Cosine,
-            _ => return Err(PyValueError::new_err(format!("Metric type '{metric_type}' is not supported"))),
+            _ => {
+                return Err(PyValueError::new_err(format!(
+                    "Metric type '{metric_type}' is not supported"
+                )))
+            }
         };
 
         self_

--- a/rust/src/dataset.rs
+++ b/rust/src/dataset.rs
@@ -388,7 +388,7 @@ impl Dataset {
                     column,
                     vec_params.num_partitions,
                     vec_params.num_sub_vectors,
-                    vec_params.metrics_type,
+                    vec_params.metric_type,
                 )?;
                 builder.build().await?
             }

--- a/rust/src/index/vector.rs
+++ b/rust/src/index/vector.rs
@@ -138,7 +138,7 @@ pub struct VectorIndexParams {
     pub num_sub_vectors: u32,
 
     /// Vector distance metrics type.
-    pub metrics_type: MetricType,
+    pub metric_type: MetricType,
 }
 
 impl VectorIndexParams {
@@ -153,13 +153,13 @@ impl VectorIndexParams {
         num_partitions: u32,
         nbits: u8,
         num_sub_vectors: u32,
-        metrics_type: MetricType,
+        metric_type: MetricType,
     ) -> Self {
         Self {
             num_partitions,
             nbits,
             num_sub_vectors,
-            metrics_type,
+            metric_type,
         }
     }
 }
@@ -170,7 +170,7 @@ impl Default for VectorIndexParams {
             num_partitions: 32,
             nbits: 8,
             num_sub_vectors: 16,
-            metrics_type: MetricType::L2,
+            metric_type: MetricType::L2,
         }
     }
 }

--- a/rust/src/index/vector.rs
+++ b/rust/src/index/vector.rs
@@ -32,7 +32,7 @@ mod pq;
 use super::IndexParams;
 use crate::{
     utils::distance::{cosine::cosine_distance, l2::l2_distance},
-    Result,
+    Result, Error,
 };
 
 /// Query parameters for the vector indices
@@ -121,6 +121,18 @@ impl From<MetricType> for super::pb::VectorMetricType {
         match mt {
             MetricType::L2 => Self::L2,
             MetricType::Cosine => Self::Cosine,
+        }
+    }
+}
+
+impl TryFrom<&str> for MetricType {
+    type Error = Error;
+
+    fn try_from(s: &str) -> Result<Self> {
+        match s.to_lowercase().as_str() {
+            "l2" | "euclidean" => Ok(MetricType::L2),
+            "cosine" => Ok(MetricType::Cosine),
+            _ => Err(Error::Index(format!("Metric type '{s}' is not supported")))
         }
     }
 }

--- a/rust/src/index/vector.rs
+++ b/rust/src/index/vector.rs
@@ -32,7 +32,7 @@ mod pq;
 use super::IndexParams;
 use crate::{
     utils::distance::{cosine::cosine_distance, l2::l2_distance},
-    Result, Error,
+    Error, Result,
 };
 
 /// Query parameters for the vector indices
@@ -132,7 +132,7 @@ impl TryFrom<&str> for MetricType {
         match s.to_lowercase().as_str() {
             "l2" | "euclidean" => Ok(MetricType::L2),
             "cosine" => Ok(MetricType::Cosine),
-            _ => Err(Error::Index(format!("Metric type '{s}' is not supported")))
+            _ => Err(Error::Index(format!("Metric type '{s}' is not supported"))),
         }
     }
 }


### PR DESCRIPTION
Allow user to choose create cosine or l2 index from Python