### PR TITLE
[Rust] Implement a datafusion phyiscal expr Column that can reads nested columns

### DIFF
--- a/rust/src/arrow.rs
+++ b/rust/src/arrow.rs
@@ -1,19 +1,16 @@
-// Licensed to the Apache Software Foundation (ASF) under one
-// or more contributor license agreements.  See the NOTICE file
-// distributed with this work for additional information
-// regarding copyright ownership.  The ASF licenses this file
-// to you under the Apache License, Version 2.0 (the
-// "License"); you may not use this file except in compliance
-// with the License.  You may obtain a copy of the License at
+// Copyright 2023 Lance Developers.
 //
-//   http://www.apache.org/licenses/LICENSE-2.0
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
 //
-// Unless required by applicable law or agreed to in writing,
-// software distributed under the License is distributed on an
-// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
-// KIND, either express or implied.  See the License for the
-// specific language governing permissions and limitations
-// under the License.
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 
 //! Extend Arrow Functionality
 //!

--- a/rust/src/datafusion.rs
+++ b/rust/src/datafusion.rs
@@ -1,0 +1,18 @@
+// Copyright 2023 Lance Developers.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! Extends DataFusion
+//!
+
+pub(crate) mod physical_expr;

--- a/rust/src/datafusion/physical_expr.rs
+++ b/rust/src/datafusion/physical_expr.rs
@@ -130,7 +130,41 @@ mod tests {
         assert_eq!(column.nullable(schema.as_ref()).unwrap(), true);
 
         let column = Column::new("st.x".to_string());
-        assert_eq!(column.data_type(schema.as_ref()).unwrap(), DataType::Float32);
+        assert_eq!(
+            column.data_type(schema.as_ref()).unwrap(),
+            DataType::Float32
+        );
+        assert_eq!(column.nullable(schema.as_ref()).unwrap(), false);
+    }
+
+    #[test]
+    fn test_column_evaluate() {
+        let schema = Arc::new(ArrowSchema::new(vec![
+            Field::new("i", DataType::Int32, false),
+            Field::new("s", DataType::Utf8, true),
+            Field::new(
+                "st",
+                DataType::Struct(vec![
+                    Field::new("x", DataType::Float32, false),
+                    Field::new("y", DataType::Float32, false),
+                ]),
+                true,
+            ),
+        ]));
+
+        let column = Column::new("i".to_string());
+        assert_eq!(column.data_type(schema.as_ref()).unwrap(), DataType::Int32);
+        assert_eq!(column.nullable(schema.as_ref()).unwrap(), false);
+
+        let column = Column::new("s".to_string());
+        assert_eq!(column.data_type(schema.as_ref()).unwrap(), DataType::Utf8);
+        assert_eq!(column.nullable(schema.as_ref()).unwrap(), true);
+
+        let column = Column::new("st.x".to_string());
+        assert_eq!(
+            column.data_type(schema.as_ref()).unwrap(),
+            DataType::Float32
+        );
         assert_eq!(column.nullable(schema.as_ref()).unwrap(), false);
     }
 }

--- a/rust/src/datafusion/physical_expr.rs
+++ b/rust/src/datafusion/physical_expr.rs
@@ -1,0 +1,110 @@
+// Copyright 2023 Lance Developers.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! Extends DataFusion Physical Expression
+
+
+use std::any::Any;
+use std::sync::Arc;
+
+use arrow_array::RecordBatch;
+use arrow_schema::{DataType, Schema as ArrowSchema};
+use datafusion::{
+    error::{DataFusionError, Result},
+    physical_expr::PhysicalExpr,
+    physical_plan::ColumnarValue,
+};
+
+use crate::datatypes::Schema;
+
+/// Column expression.
+///
+/// The difference between it and [`datafusion::physical_expr::expressions::Column`] is that
+/// this one supports nested column access.
+#[derive(Debug, Hash, PartialEq, Eq, Clone)]
+pub struct Column {
+    /// Qualified column name.
+    pub name: String,
+}
+
+impl std::fmt::Display for Column {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        write!(f, "{}", self.name)
+    }
+}
+
+impl Column {
+    /// Create a column with qualified column name.
+    pub(crate) fn new(name: String) -> Self {
+        Self { name }
+    }
+}
+
+impl PhysicalExpr for Column {
+    fn as_any(&self) -> &dyn Any {
+        self
+    }
+
+    fn data_type(&self, schema: &ArrowSchema) -> Result<DataType> {
+        println!(
+            "Fetch datatype: {:?}, {:?}",
+            schema,
+            Schema::try_from(schema)?.field(self.name.as_str())
+        );
+
+        Schema::try_from(schema)?
+            .field(self.name.as_str())
+            .map(|f| f.data_type())
+            .ok_or_else(|| DataFusionError::Plan(format!("column {} does not exist", self.name)))
+    }
+
+    fn nullable(&self, schema: &ArrowSchema) -> Result<bool> {
+        Schema::try_from(schema)?
+            .field(self.name.as_str())
+            .map(|f| f.nullable)
+            .ok_or_else(|| DataFusionError::Plan(format!("column {} does not exist", self.name)))
+    }
+
+    fn evaluate(&self, batch: &RecordBatch) -> Result<ColumnarValue> {
+        todo!()
+    }
+
+    fn children(&self) -> Vec<Arc<dyn PhysicalExpr>> {
+        vec![]
+    }
+
+    fn with_new_children(
+        self: Arc<Self>,
+        _children: Vec<Arc<dyn PhysicalExpr>>,
+    ) -> Result<Arc<dyn PhysicalExpr>> {
+        todo!()
+    }
+}
+
+impl PartialEq<dyn Any> for Column {
+    fn eq(&self, other: &dyn Any) -> bool {
+        other
+            .downcast_ref::<Self>()
+            .map(|x| self == x)
+            .unwrap_or(false)
+    }
+}
+
+/// Create a column expression.
+pub fn col(name: &str) -> Arc<dyn PhysicalExpr> {
+    Arc::new(Column::new(name.to_string()))
+}
+
+#[cfg(test)]
+mod tests {}

--- a/rust/src/datafusion/physical_expr.rs
+++ b/rust/src/datafusion/physical_expr.rs
@@ -14,7 +14,6 @@
 
 //! Extends DataFusion Physical Expression
 
-
 use std::any::Any;
 use std::sync::Arc;
 
@@ -107,4 +106,33 @@ pub fn col(name: &str) -> Arc<dyn PhysicalExpr> {
 }
 
 #[cfg(test)]
-mod tests {}
+mod tests {
+
+    use super::*;
+
+    use arrow_schema::Field;
+
+    #[test]
+    fn test_simple_column() {
+        let schema = Arc::new(ArrowSchema::new(vec![
+            Field::new("i", DataType::Int32, false),
+            Field::new("s", DataType::Utf8, true),
+            Field::new(
+                "st",
+                DataType::Struct(vec![
+                    Field::new("x", DataType::Float32, false),
+                    Field::new("y", DataType::Float32, false),
+                ]),
+                true,
+            ),
+        ]));
+
+        let column = Column::new("i".to_string());
+        assert_eq!(column.data_type(schema.as_ref()).unwrap(), DataType::Int32);
+        assert_eq!(column.nullable(schema.as_ref()).unwrap(), false);
+
+        let column = Column::new("s".to_string());
+        assert_eq!(column.data_type(schema.as_ref()).unwrap(), DataType::Utf8);
+        assert_eq!(column.nullable(schema.as_ref()).unwrap(), true);
+    }
+}

--- a/rust/src/datafusion/physical_expr.rs
+++ b/rust/src/datafusion/physical_expr.rs
@@ -56,12 +56,6 @@ impl PhysicalExpr for Column {
     }
 
     fn data_type(&self, schema: &ArrowSchema) -> Result<DataType> {
-        println!(
-            "Fetch datatype: {:?}, {:?}",
-            schema,
-            Schema::try_from(schema)?.field(self.name.as_str())
-        );
-
         Schema::try_from(schema)?
             .field(self.name.as_str())
             .map(|f| f.data_type())
@@ -134,5 +128,9 @@ mod tests {
         let column = Column::new("s".to_string());
         assert_eq!(column.data_type(schema.as_ref()).unwrap(), DataType::Utf8);
         assert_eq!(column.nullable(schema.as_ref()).unwrap(), true);
+
+        let column = Column::new("st.x".to_string());
+        assert_eq!(column.data_type(schema.as_ref()).unwrap(), DataType::Float32);
+        assert_eq!(column.nullable(schema.as_ref()).unwrap(), false);
     }
 }

--- a/rust/src/datatypes.rs
+++ b/rust/src/datatypes.rs
@@ -984,17 +984,15 @@ mod tests {
 
     #[test]
     fn test_get_nested_field() {
-        let arrow_schema = ArrowSchema::new(vec![
-            ArrowField::new(
-                "b",
-                DataType::Struct(vec![
-                    ArrowField::new("f1", DataType::Utf8, true),
-                    ArrowField::new("f2", DataType::Boolean, false),
-                    ArrowField::new("f3", DataType::Float32, false),
-                ]),
-                true,
-            ),
-        ]);
+        let arrow_schema = ArrowSchema::new(vec![ArrowField::new(
+            "b",
+            DataType::Struct(vec![
+                ArrowField::new("f1", DataType::Utf8, true),
+                ArrowField::new("f2", DataType::Boolean, false),
+                ArrowField::new("f3", DataType::Float32, false),
+            ]),
+            true,
+        )]);
         let schema = Schema::try_from(&arrow_schema).unwrap();
 
         let field = schema.field("b.f2").unwrap();

--- a/rust/src/datatypes.rs
+++ b/rust/src/datatypes.rs
@@ -638,7 +638,7 @@ impl Schema {
         let split = name.split('.').collect::<Vec<_>>();
         self.fields
             .iter()
-            .find(|f| f.name == name)
+            .find(|f| f.name == split[0])
             .map(|c| c.sub_field(&split[1..]))
             .flatten()
     }
@@ -980,5 +980,23 @@ mod tests {
             protos.iter().map(|p| p.id).collect::<Vec<_>>(),
             (0..6).collect::<Vec<_>>()
         );
+    }
+
+    #[test]
+    fn test_get_nested_field() {
+        let arrow_schema = ArrowSchema::new(vec![
+            ArrowField::new(
+                "b",
+                DataType::Struct(vec![
+                    ArrowField::new("f1", DataType::Utf8, true),
+                    ArrowField::new("f2", DataType::Boolean, false),
+                    ArrowField::new("f3", DataType::Float32, false),
+                ]),
+                true,
+            ),
+        ]);
+        let schema = Schema::try_from(&arrow_schema).unwrap();
+
+        let field = schema.field("b.f2").unwrap();
     }
 }

--- a/rust/src/datatypes.rs
+++ b/rust/src/datatypes.rs
@@ -344,6 +344,19 @@ impl Field {
         }
     }
 
+    fn sub_field(&self, path_components: &[&str]) -> Option<&Self> {
+        if path_components.is_empty() {
+            Some(self)
+        } else {
+            let first = path_components[0];
+            self.children
+                .iter()
+                .find(|c| c.name == first)
+                .map(|c| c.sub_field(&path_components[1..]))
+                .flatten()
+        }
+    }
+
     fn project(&self, path_components: &[&str]) -> Result<Self> {
         let mut f = Self {
             name: self.name.clone(),
@@ -620,8 +633,14 @@ impl Schema {
         Ok(Self::from(&filtered_protos))
     }
 
+    /// Get a field by name. Return `None` if the field does not exist.
     pub fn field(&self, name: &str) -> Option<&Field> {
-        self.fields.iter().find(|f| f.name == name)
+        let split = name.split('.').collect::<Vec<_>>();
+        self.fields
+            .iter()
+            .find(|f| f.name == name)
+            .map(|c| c.sub_field(&split[1..]))
+            .flatten()
     }
 
     pub(crate) fn field_id(&self, column: &str) -> Result<i32> {
@@ -632,8 +651,7 @@ impl Schema {
 
     /// Recursively collect all the field IDs,
     pub(crate) fn field_ids(&self) -> Vec<i32> {
-        // TODO: make a tree travesal iterator.
-
+        // TODO: make a tree traversal iterator.
         let protos: Vec<pb::Field> = self.into();
         protos.iter().map(|f| f.id).collect()
     }

--- a/rust/src/lib.rs
+++ b/rust/src/lib.rs
@@ -22,9 +22,9 @@
 //! [Apache Arrow](https://arrow.apache.org/) and DuckDB compatible.
 
 pub mod arrow;
+pub mod datafusion;
 pub mod dataset;
 pub mod datatypes;
-pub mod datafusion;
 pub mod encodings;
 pub mod error;
 pub mod format;

--- a/rust/src/lib.rs
+++ b/rust/src/lib.rs
@@ -24,6 +24,7 @@
 pub mod arrow;
 pub mod dataset;
 pub mod datatypes;
+pub mod datafusion;
 pub mod encodings;
 pub mod error;
 pub mod format;


### PR DESCRIPTION
Implement [Datafusion's Column](https://docs.rs/datafusion/latest/datafusion/physical_plan/expressions/struct.Column.html`) to support nested access.

Part of the work to use Datafusion to implement predicates pushdown.