### PR TITLE
streaming ivf training

### DIFF
--- a/rust/src/dataset.rs
+++ b/rust/src/dataset.rs
@@ -391,6 +391,7 @@ impl Dataset {
                     index_id,
                     &index_name,
                     column,
+                    self.count_rows().await?,
                     vec_params.num_partitions,
                     vec_params.num_sub_vectors,
                     vec_params.metric_type,

--- a/rust/src/index/vector/ivf.rs
+++ b/rust/src/index/vector/ivf.rs
@@ -949,7 +949,8 @@ impl KMeansModel {
             &params,
         )
         .await;
-        Ok(as_fixed_size_list_array(model.centroids.as_ref()).clone())
+        let values = model.centroids.as_ref();
+        FixedSizeListArray::try_new(values, dimension as i32)
     }
 
     async fn maybe_sample_training_data(


### PR DESCRIPTION
This PR samples the IVF input data in-stream during scan. Does not handle opq/pq kmeans yet. The complication here is that we need the sampled data for kmeans trainining and then to compute pq codes for all vectors we need an additional scan 

to avoid the higher order lifetime issue, i pass in the count_rows from the create_index call. I believe the closure makes it so the compiler can't prove the lifetimes here.