### PR TITLE
Allow append mode even if dataset doesn't already exist

### DIFF
--- a/python/python/tests/test_dataset.py
+++ b/python/python/tests/test_dataset.py
@@ -16,7 +16,6 @@ import os
 import time
 from datetime import datetime
 from pathlib import Path
-from typing import Any
 from unittest import mock
 
 import lance

--- a/rust/src/dataset.rs
+++ b/rust/src/dataset.rs
@@ -16,6 +16,7 @@
 //!
 
 use std::collections::BTreeMap;
+use std::fmt::Write;
 use std::sync::Arc;
 use std::time::SystemTime;
 
@@ -157,18 +158,12 @@ impl Dataset {
         params: Option<WriteParams>,
     ) -> Result<Self> {
         let object_store = Arc::new(ObjectStore::new(uri).await?);
-        let params = params.unwrap_or_default();
+        let mut params = params.unwrap_or_default();
 
+        // Read expected manifest path for the dataset
         let latest_manifest_path = latest_manifest_path(object_store.base_path());
-        let latest_manifest = if matches!(params.mode, WriteMode::Create) {
-            if object_store.exists(&latest_manifest_path).await? {
-                return Err(Error::IO(format!("Dataset already exists: {uri}")));
-            }
-            None
-        } else {
-            Some(read_manifest(&object_store, &latest_manifest_path).await?)
-        };
 
+        // Read schema for the input batches
         let mut peekable = batches.peekable();
         let mut schema: Schema;
         if let Some(batch) = peekable.peek() {
@@ -184,6 +179,32 @@ impl Dataset {
             ));
         }
 
+        // Running checks for the different write modes
+        // create + dataset already exists = error
+        if object_store.exists(&latest_manifest_path).await?
+            && matches!(params.mode, WriteMode::Create)
+        {
+            return Err(Error::IO(format!("Dataset already exists: {uri}")));
+        }
+
+        // append + dataset doesn't already exists = warn + switch to create mode
+        if !object_store.exists(&latest_manifest_path).await?
+            && matches!(params.mode, WriteMode::Append)
+        {
+            eprintln!("Warning: No existing dataset at {uri}, it will be created");
+            params = WriteParams {
+                mode: WriteMode::Create,
+                ..params
+            };
+        }
+        let params = params; // discard mut
+
+        // append + input schema different from existing schema = error
+        let latest_manifest = if matches!(params.mode, WriteMode::Create) {
+            None
+        } else {
+            Some(read_manifest(&object_store, &latest_manifest_path).await?)
+        };
         if matches!(params.mode, WriteMode::Append) {
             if let Some(m) = latest_manifest.as_ref() {
                 if schema != m.schema {

--- a/rust/src/dataset.rs
+++ b/rust/src/dataset.rs
@@ -16,7 +16,6 @@
 //!
 
 use std::collections::BTreeMap;
-use std::fmt::Write;
 use std::sync::Arc;
 use std::time::SystemTime;
 


### PR DESCRIPTION
When writing a new dataset with mode set as `append`, it is cast to `create` so it takes the code path for `create`. 

Reference #568 