### PR TITLE
[Bug] Fix IVF merge sort when refine factor is presented.

### DIFF
--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -15,7 +15,7 @@ on:
       - .github/workflows/run_tests/**
 jobs:
   linux:
-    timeout-minutes: 30
+    timeout-minutes: 45
     strategy:
       matrix:
         python-minor-version: [ "8", "9", "10", "11" ]
@@ -48,7 +48,7 @@ jobs:
     - uses: ./.github/workflows/build_linux_wheel
     - uses: ./.github/workflows/run_tests
   mac:
-    timeout-minutes: 30
+    timeout-minutes: 45
     runs-on: "macos-12"
     defaults:
       run:

--- a/rust/src/bin/lq.rs
+++ b/rust/src/bin/lq.rs
@@ -78,6 +78,9 @@ enum Commands {
         /// Distance metric type. Only support 'l2' and 'cosine'.
         #[arg(short = 'm', long, value_name = "DISTANCE")]
         metric_type: Option<String>,
+
+        #[arg(long, default_value_t = false)]
+        use_opq: bool,
     },
 }
 
@@ -130,6 +133,7 @@ async fn main() -> Result<()> {
             num_partitions,
             num_sub_vectors,
             metric_type,
+            use_opq,
         } => {
             let dataset = Dataset::open(uri).await.unwrap();
             match action {
@@ -142,6 +146,7 @@ async fn main() -> Result<()> {
                         num_partitions,
                         num_sub_vectors,
                         metric_type,
+                        *use_opq,
                     )
                     .await
                 }
@@ -158,6 +163,7 @@ async fn create_index(
     num_partitions: &u32,
     num_sub_vectors: &u32,
     metric_type: &Option<String>,
+    use_opq: bool,
 ) -> Result<()> {
     let col = column
         .as_ref()
@@ -178,7 +184,7 @@ async fn create_index(
             &[&col],
             lance::index::IndexType::Vector,
             name.clone(),
-            &VectorIndexParams::ivf_pq(*num_partitions, 8, *num_sub_vectors, true, mt, 50),
+            &VectorIndexParams::ivf_pq(*num_partitions, 8, *num_sub_vectors, use_opq, mt, 50),
             false,
         )
         .await

--- a/rust/src/bin/lq.rs
+++ b/rust/src/bin/lq.rs
@@ -184,7 +184,7 @@ async fn create_index(
             &[&col],
             lance::index::IndexType::Vector,
             name.clone(),
-            &VectorIndexParams::ivf_pq(*num_partitions, 8, *num_sub_vectors, use_opq, mt, 50),
+            &VectorIndexParams::ivf_pq(*num_partitions, 8, *num_sub_vectors, use_opq, mt, 100),
             false,
         )
         .await

--- a/rust/src/dataset/scanner.rs
+++ b/rust/src/dataset/scanner.rs
@@ -359,13 +359,11 @@ impl Scanner {
     }
 
     /// Create an Execution plan to do indexed ANN search
-    fn ann(&self, q: &Query, index: &&Index) -> Arc<dyn ExecutionPlan> {
-        let mut inner_query = q.clone();
-        inner_query.k = q.k * q.refine_factor.unwrap_or(1) as usize;
+    fn ann(&self, q: &Query, index: &Index) -> Arc<dyn ExecutionPlan> {
         Arc::new(KNNIndexExec::new(
             self.dataset.clone(),
             &index.uuid.to_string(),
-            &inner_query,
+            q,
         ))
     }
 

--- a/rust/src/index/vector/ivf.rs
+++ b/rust/src/index/vector/ivf.rs
@@ -134,6 +134,7 @@ impl VectorIndex for IVFIndex {
             ))
         })?;
 
+        // TODO: Use a heap sort to get the top-k.
         let limit = query.k * query.refine_factor.unwrap_or(1) as usize;
         let selection = sort_to_indices(score_col, None, Some(limit))?;
         let struct_arr = StructArray::from(batch);

--- a/rust/src/index/vector/ivf.rs
+++ b/rust/src/index/vector/ivf.rs
@@ -121,6 +121,7 @@ impl VectorIndex for IVFIndex {
         assert!(partition_ids.len() <= query.nprobes as usize);
         let batches = stream::iter(partition_ids.values())
             .then(|part_id| async move { self.search_in_partition(*part_id as usize, query).await })
+            .buffer_unordered(10)
             .try_collect::<Vec<_>>()
             .await?;
         let batch = concat_batches(&batches[0].schema(), &batches)?;

--- a/rust/src/index/vector/ivf.rs
+++ b/rust/src/index/vector/ivf.rs
@@ -740,7 +740,7 @@ async fn train_opq(data: &MatrixView, params: &PQBuildParams) -> Result<Optimize
 /// Train IVF partitions using kmeans.
 async fn train_ivf_model(data: &MatrixView, params: &IvfBuildParams) -> Result<Ivf> {
     let rng = SmallRng::from_entropy();
-    const REDOS: usize = 3;
+    const REDOS: usize = 1;
     let centroids = super::kmeans::train_kmeans(
         data.data().as_ref(),
         None,

--- a/rust/src/index/vector/kmeans.rs
+++ b/rust/src/index/vector/kmeans.rs
@@ -32,6 +32,7 @@ pub async fn train_kmeans(
     dimension: usize,
     k: usize,
     max_iterations: u32,
+    redos: usize,
     mut rng: impl Rng,
     metric_type: MetricType,
 ) -> Result<Float32Array> {
@@ -66,6 +67,7 @@ pub async fn train_kmeans(
         max_iters: max_iterations,
         metric_type,
         centroids,
+        redos,
         ..Default::default()
     };
     let model = KMeans::new_with_params(&data, dimension, k, &params).await;

--- a/rust/src/index/vector/opq.rs
+++ b/rust/src/index/vector/opq.rs
@@ -133,6 +133,14 @@ impl OptimizedProductQuantizer {
 
         Ok((rotation, pq_code))
     }
+
+    /// Initialize rotation matrix.
+    fn init_rotation(&self, dimension: usize) -> Result<MatrixView> {
+        let mat = MatrixView::random(dimension, dimension);
+        let (u, _, vt) = mat.svd()?;
+        let r = vt.transpose().dot(&u.transpose())?;
+        Ok(r)
+    }
 }
 
 #[async_trait]
@@ -161,7 +169,7 @@ impl Transformer for OptimizedProductQuantizer {
         let mut pq_code = pq.transform(&train, self.metric_type).await?;
 
         // Initialize R (rotation matrix)
-        let mut rotation = MatrixView::identity(dim);
+        let mut rotation = self.init_rotation(dim)?;
         for i in 0..self.num_iters {
             // Training data, this is the `X`, described in CVPR' 13
             let rotated_data = train.dot(&rotation)?;

--- a/rust/src/index/vector/opq.rs
+++ b/rust/src/index/vector/opq.rs
@@ -209,7 +209,6 @@ impl Transformer for OptimizedProductQuantizer {
     }
 }
 
-#[derive(Debug)]
 pub struct OPQIndex {
     sub_index: Arc<dyn VectorIndex>,
 
@@ -219,6 +218,21 @@ pub struct OPQIndex {
 impl OPQIndex {
     pub fn new(sub_index: Arc<dyn VectorIndex>, opq: OptimizedProductQuantizer) -> Self {
         Self { sub_index, opq }
+    }
+}
+
+impl std::fmt::Debug for OPQIndex {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(
+            f,
+            "OPQIndex(dim={}) -> {:?}",
+            self.opq
+                .rotation
+                .as_ref()
+                .map(|m| m.num_columns())
+                .unwrap_or(0),
+            self.sub_index
+        )
     }
 }
 

--- a/rust/src/index/vector/opq.rs
+++ b/rust/src/index/vector/opq.rs
@@ -162,7 +162,8 @@ impl Transformer for OptimizedProductQuantizer {
 
         // Initialize R (rotation matrix)
         let mut rotation = MatrixView::identity(dim);
-        for _ in 0..self.num_iters {
+        for i in 0..self.num_iters {
+            println!("Training OPQ iteration {}/{}", i + 1, self.num_iters);
             // Training data, this is the `X`, described in CVPR' 13
             let rotated_data = train.dot(&rotation)?;
             // Reset the pq centroids after rotation.

--- a/rust/src/index/vector/opq.rs
+++ b/rust/src/index/vector/opq.rs
@@ -110,7 +110,7 @@ impl OptimizedProductQuantizer {
         let dim = train.num_columns();
 
         // Train few times to get a better rotation matrix. See Faiss.
-        pq.train(&train, metric_type, 4).await?;
+        pq.train(&train, metric_type, 1).await?;
         let pq_code = pq.transform(&train, metric_type).await?;
 
         // Reconstruct Y
@@ -165,7 +165,7 @@ impl Transformer for OptimizedProductQuantizer {
             data.clone()
         };
 
-        // Use 10 iterations to get the initialized centroids.
+        // Run a few iterations to get the initialized centroids.
         let mut pq = ProductQuantizer::new(self.num_sub_vectors, self.num_bits, dim);
         pq.train(&train, self.metric_type, OPQ_PQ_INIT_ITERATIONS)
             .await?;

--- a/rust/src/index/vector/opq.rs
+++ b/rust/src/index/vector/opq.rs
@@ -163,7 +163,6 @@ impl Transformer for OptimizedProductQuantizer {
         // Initialize R (rotation matrix)
         let mut rotation = MatrixView::identity(dim);
         for i in 0..self.num_iters {
-            println!("Training OPQ iteration {}/{}", i + 1, self.num_iters);
             // Training data, this is the `X`, described in CVPR' 13
             let rotated_data = train.dot(&rotation)?;
             // Reset the pq centroids after rotation.
@@ -171,6 +170,14 @@ impl Transformer for OptimizedProductQuantizer {
             (rotation, pq_code) = self
                 .train_once(&mut pq, &rotated_data, self.metric_type)
                 .await?;
+            if (i + 1) % 5 == 0 {
+                println!(
+                    "Training OPQ iteration {}/{}, PQ distortion={}",
+                    i + 1,
+                    self.num_iters,
+                    pq.distortion(&rotated_data, self.metric_type).await?
+                );
+            }
         }
         self.rotation = Some(rotation);
         Ok(())

--- a/rust/src/index/vector/opq.rs
+++ b/rust/src/index/vector/opq.rs
@@ -409,13 +409,14 @@ mod tests {
 
     #[test]
     fn test_init_rotation() {
-        let r = init_rotation(64).unwrap();
-        // r * r^T = I
+        let dim: usize = 64;
+        let r = init_rotation(dim).unwrap();
+        // R^T * R = I
         let i = r.transpose().dot(&r).unwrap();
 
         assert_relative_eq!(
             i.data().values(),
-            MatrixView::identity(64).data().values(),
+            MatrixView::identity(dim).data().values(),
             epsilon = 0.001
         );
     }

--- a/rust/src/index/vector/pq.rs
+++ b/rust/src/index/vector/pq.rs
@@ -450,6 +450,7 @@ impl ProductQuantizer {
         let mut codebook_builder = Float32Builder::with_capacity(num_centroids * dimension);
         let rng = rand::rngs::SmallRng::from_entropy();
 
+        const REDOS: usize = 3;
         // TODO: parallel training.
         for (i, sub_vec) in sub_vectors.iter().enumerate() {
             // Centroids for one sub vector.
@@ -462,6 +463,7 @@ impl ProductQuantizer {
                 sub_vector_dimension,
                 num_centroids,
                 max_iters as u32,
+                REDOS,
                 rng.clone(),
                 metric_type,
             )

--- a/rust/src/index/vector/pq.rs
+++ b/rust/src/index/vector/pq.rs
@@ -450,7 +450,7 @@ impl ProductQuantizer {
         let mut codebook_builder = Float32Builder::with_capacity(num_centroids * dimension);
         let rng = rand::rngs::SmallRng::from_entropy();
 
-        const REDOS: usize = 3;
+        const REDOS: usize = 1;
         // TODO: parallel training.
         for (i, sub_vec) in sub_vectors.iter().enumerate() {
             // Centroids for one sub vector.


### PR DESCRIPTION
Previously, at the merge sort stage, IVF does not returns k * refine_factor vectors for the Take node to load the original data. This fix makes IVF returns `k * refine_factor` vectors from `IVF::search`