### PR TITLE
[Rust] Use folked sqlparser to unblock rust crate release

### DIFF
--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -52,7 +52,7 @@ path-absolutize = "3.0.14"
 shellexpand = "3.0.0"
 arrow = { version = "33.0.0", features = ["prettyprint"] }
 num_cpus = "1.0"
-sqlparser = { git = "https://github.com/eto-ai/sqlparser-rs.git", branch = "lei/double_eq" }
+sqlparser-lance = "0.32.0"
 # TODO: use datafusion sub-modules to reduce build size?
 datafusion = { version = "19.0.0", default-features = false }
 faiss = { version = "0.11.0", features = ["gpu"], optional = true }

--- a/rust/src/io/exec/planner.rs
+++ b/rust/src/io/exec/planner.rs
@@ -108,7 +108,7 @@ impl Planner {
             Value::UnQuotedString(_) => todo!(),
             Value::SingleQuotedByteStringLiteral(_) => todo!(),
             Value::DoubleQuotedByteStringLiteral(_) => todo!(),
-            Value::RawStringLiteral(_) => todo!()
+            Value::RawStringLiteral(_) => todo!(),
         })
     }
 

--- a/rust/src/io/exec/planner.rs
+++ b/rust/src/io/exec/planner.rs
@@ -108,6 +108,7 @@ impl Planner {
             Value::UnQuotedString(_) => todo!(),
             Value::SingleQuotedByteStringLiteral(_) => todo!(),
             Value::DoubleQuotedByteStringLiteral(_) => todo!(),
+            Value::RawStringLiteral(_) => todo!()
         })
     }
 
@@ -115,7 +116,7 @@ impl Planner {
         match func_args {
             FunctionArg::Unnamed(FunctionArgExpr::Expr(expr)) => self.parse_sql_expr(expr),
             _ => Err(Error::IO(format!(
-                "Unsuppoted function args: {:?}",
+                "Unsupported function args: {:?}",
                 func_args
             ))),
         }


### PR DESCRIPTION
Published a forked version of `sqlparser-lance`, which means that we can use crate version of sqlparser instead of git version as dependency, which prevents `cargo publish`.