### PR TITLE
[Rust] make distance function to take slice instead of Float32Array

### DIFF
--- a/rust/src/index/vector.rs
+++ b/rust/src/index/vector.rs
@@ -92,8 +92,7 @@ pub enum MetricType {
 impl MetricType {
     pub fn func(
         &self,
-    ) -> Arc<dyn Fn(&Float32Array, &Float32Array, usize) -> Result<Arc<Float32Array>> + Send + Sync>
-    {
+    ) -> Arc<dyn Fn(&[f32], &[f32], usize) -> Result<Arc<Float32Array>> + Send + Sync> {
         match self {
             Self::L2 => Arc::new(l2_distance),
             Self::Cosine => Arc::new(cosine_distance),

--- a/rust/src/index/vector/flat.rs
+++ b/rust/src/index/vector/flat.rs
@@ -19,6 +19,7 @@ use std::any::Any;
 use std::sync::Arc;
 
 use arrow::array::as_primitive_array;
+use arrow::datatypes::Float32Type;
 use arrow_array::{cast::as_struct_array, ArrayRef, RecordBatch, StructArray};
 use arrow_ord::sort::sort_to_indices;
 use arrow_schema::{DataType, Field as ArrowField};
@@ -80,7 +81,12 @@ pub async fn flat_search(
                 .clone();
             let flatten_vectors = as_fixed_size_list_array(vectors.as_ref()).values().clone();
             let scores = tokio::task::spawn_blocking(move || {
-                mt.func()(&k, as_primitive_array(flatten_vectors.as_ref()), k.len()).unwrap()
+                mt.func()(
+                    k.values(),
+                    as_primitive_array::<Float32Type>(flatten_vectors.as_ref()).values(),
+                    k.len(),
+                )
+                .unwrap()
             })
             .await? as ArrayRef;
 

--- a/rust/src/index/vector/pq.rs
+++ b/rust/src/index/vector/pq.rs
@@ -15,6 +15,7 @@
 use std::any::Any;
 use std::sync::Arc;
 
+use arrow::datatypes::Float32Type;
 use arrow_arith::aggregate::min;
 use arrow_array::{
     builder::Float32Builder, cast::as_primitive_array, Array, ArrayRef, FixedSizeListArray,
@@ -101,8 +102,8 @@ impl PQIndex {
                 Error::Index("PQIndex::l2_scores: PQ is not initialized".to_string())
             })?;
             let distances = l2_distance(
-                as_primitive_array(&from),
-                &subvec_centroids,
+                as_primitive_array::<Float32Type>(&from).values(),
+                subvec_centroids.values(),
                 sub_vector_length,
             )?;
             distance_table.extend(distances.values());

--- a/rust/src/index/vector/pq.rs
+++ b/rust/src/index/vector/pq.rs
@@ -377,7 +377,8 @@ impl ProductQuantizer {
                             let value = vec.value(i);
                             let vector: &Float32Array = as_primitive_array(value.as_ref());
                             let distances =
-                                dist_func(vector, centroid.as_ref(), vector.len()).unwrap();
+                                dist_func(vector.values(), centroid.values(), vector.len())
+                                    .unwrap();
                             min(distances.as_ref()).unwrap_or(0.0)
                         })
                         .sum::<f32>() as f64 // in case of overflow
@@ -408,21 +409,20 @@ impl ProductQuantizer {
         let dim = self.dimension;
         let num_rows = data.num_rows();
         let values = tokio::task::spawn_blocking(move || {
+            let flatten_values = flatten_data.values();
             let capacity = num_sub_vectors * num_rows;
             let mut builder: Vec<u8> = vec![0; capacity];
             // Dimension of each sub-vector.
             let sub_dim = dim / num_sub_vectors;
             for i in 0..num_rows {
                 let row_offset = i * dim;
+
                 for sub_idx in 0..num_sub_vectors {
                     let offset = row_offset + sub_idx * sub_dim;
-                    let sub_vector = flatten_data.slice(offset, sub_dim);
+                    let sub_vector = &flatten_values[offset..offset + sub_dim];
                     let centroids = all_centroids[sub_idx].as_ref();
-                    let code = argmin(
-                        dist_func(as_primitive_array(sub_vector.as_ref()), centroids, sub_dim)?
-                            .as_ref(),
-                    )
-                    .unwrap();
+                    let code = argmin(dist_func(sub_vector, centroids.values(), sub_dim)?.as_ref())
+                        .unwrap();
                     builder[i * num_sub_vectors + sub_idx] = code as u8;
                 }
             }

--- a/rust/src/utils/distance.rs
+++ b/rust/src/utils/distance.rs
@@ -39,6 +39,24 @@ pub(crate) fn simd_alignment() -> i32 {
     1
 }
 
+/// Is the pointer aligned to the given alignment?
 fn is_simd_aligned(ptr: *const f32, alignment: usize) -> bool {
     ptr as usize % alignment == 0
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    use arrow_array::Float32Array;
+
+    #[test]
+    fn test_is_simd_aligned() {
+        let arr = Float32Array::from_iter([1.9, 2.3, 3.4, 4.5]);
+        assert!(is_simd_aligned(arr.values().as_ptr(), 32));
+
+        unsafe {
+            assert!(!is_simd_aligned(arr.values().as_ptr().add(3), 32));
+        }
+    }
 }

--- a/rust/src/utils/distance.rs
+++ b/rust/src/utils/distance.rs
@@ -38,3 +38,7 @@ pub(crate) fn simd_alignment() -> i32 {
 
     1
 }
+
+fn is_simd_aligned(ptr: *const f32, alignment: usize) -> bool {
+    ptr as usize % alignment == 0
+}

--- a/rust/src/utils/distance/cosine.rs
+++ b/rust/src/utils/distance/cosine.rs
@@ -20,20 +20,20 @@ use std::sync::Arc;
 use arrow_array::Float32Array;
 
 use super::compute::normalize;
-use crate::Result;
+use crate::{utils::distance::is_simd_aligned, Result};
 
 /// Fallback Cosine Distance function.
-fn cosine_dist(from: &Float32Array, to: &Float32Array, dimension: usize) -> Arc<Float32Array> {
+fn cosine_dist_slow(from: &[f32], to: &[f32], dimension: usize) -> Arc<Float32Array> {
     assert_eq!(from.len(), dimension);
     let n = to.len() / dimension;
 
-    let distances: Float32Array = (0..n)
-        .map(|idx| {
-            let vector = &to.values()[idx * dimension..(idx + 1) * dimension];
+    let distances: Float32Array = to
+        .chunks_exact(dimension)
+        .map(|vector| {
             let mut x_sq = 0_f32;
             let mut y_sq = 0_f32;
             let mut xy = 0_f32;
-            from.values().iter().zip(vector.iter()).for_each(|(x, y)| {
+            from.iter().zip(vector.iter()).for_each(|(x, y)| {
                 xy += x * y;
                 x_sq += x.powi(2);
                 y_sq += y.powi(2);
@@ -82,16 +82,15 @@ unsafe fn cosine_dist_fma(x_vector: &[f32], y_vector: &[f32], x_norm: f32) -> f3
 }
 
 #[inline]
-fn cosine_dist_simd(from: &Float32Array, to: &Float32Array, dimension: usize) -> Arc<Float32Array> {
+fn cosine_dist_simd(from: &[f32], to: &[f32], dimension: usize) -> Arc<Float32Array> {
     assert!(to.len() % dimension == 0);
     use arrow::array::Float32Builder;
 
-    let x = from.values();
-    let to_values = to.values();
+    let x = from;
     let x_norm = normalize(x);
     let n = to.len() / dimension;
     let mut builder = Float32Builder::with_capacity(n);
-    for y in to_values.chunks_exact(dimension) {
+    for y in to.chunks_exact(dimension) {
         #[cfg(any(target_arch = "aarch64"))]
         {
             builder.append_value(unsafe { cosine_dist_neon(x, y, x_norm) });
@@ -107,28 +106,32 @@ fn cosine_dist_simd(from: &Float32Array, to: &Float32Array, dimension: usize) ->
 /// Cosine Distance
 ///
 /// <https://en.wikipedia.org/wiki/Cosine_similarity>
-pub fn cosine_distance(
-    from: &Float32Array,
-    to: &Float32Array,
-    dimension: usize,
-) -> Result<Arc<Float32Array>> {
+pub fn cosine_distance(from: &[f32], to: &[f32], dimension: usize) -> Result<Arc<Float32Array>> {
     #[cfg(target_arch = "aarch64")]
     {
         use std::arch::is_aarch64_feature_detected;
-        if is_aarch64_feature_detected!("neon") && from.len() % 4 == 0 {
+        if is_aarch64_feature_detected!("neon")
+            && is_simd_aligned(from.as_ptr(), 16)
+            && is_simd_aligned(to.as_ptr(), 16)
+            && from.len() % 4 == 0
+        {
             return Ok(cosine_dist_simd(from, to, dimension));
         }
     }
 
     #[cfg(target_arch = "x86_64")]
     {
-        if is_x86_feature_detected!("fma") && from.len() % 8 == 0 {
+        if is_x86_feature_detected!("fma")
+            && is_simd_aligned(from.as_ptr(), 32)
+            && is_simd_aligned(to.as_ptr(), 32)
+            && from.len() % 8 == 0
+        {
             return Ok(cosine_dist_simd(from, to, dimension));
         }
     }
 
     // Fallback
-    Ok(cosine_dist(from, to, dimension))
+    Ok(cosine_dist_slow(from, to, dimension))
 }
 
 #[cfg(test)]
@@ -141,13 +144,13 @@ mod tests {
     fn test_cosine() {
         let x: Float32Array = (1..9).map(|v| v as f32).collect();
         let y: Float32Array = (100..108).map(|v| v as f32).collect();
-        let d = cosine_distance(&x, &y, 8).unwrap();
+        let d = cosine_distance(x.values(), y.values(), 8).unwrap();
         // from scipy.spatial.distance.cosine
         assert_relative_eq!(d.value(0), 1.0 - 0.90095701);
 
         let x = Float32Array::from_iter_values([3.0, 45.0, 7.0, 2.0, 5.0, 20.0, 13.0, 12.0]);
         let y = Float32Array::from_iter_values([2.0, 54.0, 13.0, 15.0, 22.0, 34.0, 50.0, 1.0]);
-        let d = cosine_distance(&x, &y, 8).unwrap();
+        let d = cosine_distance(x.values(), y.values(), 8).unwrap();
         // from sklearn.metrics.pairwise import cosine_similarity
         assert_relative_eq!(d.value(0), 1.0 - 0.8735806510613104);
     }

--- a/rust/src/utils/distance/cosine.rs
+++ b/rust/src/utils/distance/cosine.rs
@@ -25,7 +25,6 @@ use crate::{utils::distance::is_simd_aligned, Result};
 /// Fallback Cosine Distance function.
 fn cosine_dist_slow(from: &[f32], to: &[f32], dimension: usize) -> Arc<Float32Array> {
     assert_eq!(from.len(), dimension);
-    let n = to.len() / dimension;
 
     let distances: Float32Array = to
         .chunks_exact(dimension)

--- a/rust/src/utils/distance/l2.rs
+++ b/rust/src/utils/distance/l2.rs
@@ -16,8 +16,9 @@
 
 use std::sync::Arc;
 
-use arrow_array::{Array, Float32Array};
+use arrow_array::Float32Array;
 
+use super::is_simd_aligned;
 use crate::Result;
 
 // TODO: wait [std::simd] to be stable to replace manually written AVX/FMA code.
@@ -53,20 +54,12 @@ unsafe fn euclidean_distance_fma(from: &[f32], to: &[f32]) -> f32 {
     results[0]
 }
 
-/// Calculate L2 distance directly using Arrow compute kernels.
-///
 #[inline]
-pub fn l2_distance_arrow(from: &Float32Array, to: &Float32Array) -> f32 {
-    let a = from.values();
-    let b = to.values();
-    let mut d = 0.0;
-    // Better chance to auto-vectorization.
-    let l = a.len();
-    for i in 0..l {
-        let s = a[i] - b[i];
-        d += s * s;
-    }
-    d
+fn l2_distance_slow(from: &[f32], to: &[f32]) -> f32 {
+    from.iter()
+        .zip(to.iter())
+        .map(|(a, b)| (a - b).powi(2))
+        .sum()
 }
 
 #[cfg(any(target_arch = "aarch64"))]
@@ -86,14 +79,8 @@ unsafe fn l2_distance_neon(from: &[f32], to: &[f32]) -> f32 {
     vaddvq_f32(sum)
 }
 
-fn l2_distance_simd(
-    from: &Float32Array,
-    to: &Float32Array,
-    dimension: usize,
-) -> Result<Arc<Float32Array>> {
+fn l2_distance_simd(from: &[f32], to: &[f32], dimension: usize) -> Result<Arc<Float32Array>> {
     let n = to.len() / dimension;
-    let from_vector = from.values();
-    let to_buffer = to.values();
 
     let scores: Float32Array = unsafe {
         Float32Array::from_trusted_len_iter(
@@ -101,18 +88,12 @@ fn l2_distance_simd(
                 .map(|idx| {
                     #[cfg(any(target_arch = "x86_64"))]
                     {
-                        euclidean_distance_fma(
-                            from_vector,
-                            &to_buffer[idx * dimension..(idx + 1) * dimension],
-                        )
+                        euclidean_distance_fma(from, &to[idx * dimension..(idx + 1) * dimension])
                     }
 
                     #[cfg(any(target_arch = "aarch64"))]
                     {
-                        l2_distance_neon(
-                            from_vector,
-                            &to_buffer[idx * dimension..(idx + 1) * dimension],
-                        )
+                        l2_distance_neon(from, &to[idx * dimension..(idx + 1) * dimension])
                     }
                 })
                 .map(Some),
@@ -121,17 +102,24 @@ fn l2_distance_simd(
     Ok(Arc::new(scores))
 }
 
-pub fn l2_distance(
-    from: &Float32Array,
-    to: &Float32Array,
-    dimension: usize,
-) -> Result<Arc<Float32Array>> {
+/// Compute L2 distance
+///
+/// Parameters
+///
+/// - `from`: the vector to compute distance from.
+/// - `to`: a list of vectors to compute distance to.
+/// - `dimension`: the dimension of the vectors.
+pub fn l2_distance(from: &[f32], to: &[f32], dimension: usize) -> Result<Arc<Float32Array>> {
     assert_eq!(from.len(), dimension);
     assert_eq!(to.len() % dimension, 0);
 
     #[cfg(any(target_arch = "x86_64"))]
     {
-        if is_x86_feature_detected!("fma") && from.len() % 8 == 0 {
+        if is_x86_feature_detected!("fma")
+            && is_simd_aligned(from.as_ptr(), 32)
+            && is_simd_aligned(to.as_ptr(), 32)
+            && from.len() % 8 == 0
+        {
             return l2_distance_simd(from, to, dimension);
         }
     }
@@ -139,23 +127,21 @@ pub fn l2_distance(
     #[cfg(any(target_arch = "aarch64"))]
     {
         use std::arch::is_aarch64_feature_detected;
-        if is_aarch64_feature_detected!("neon") && from.len() % 4 == 0 {
+        if is_aarch64_feature_detected!("neon")
+            && is_simd_aligned(from.as_ptr(), 16)
+            && is_simd_aligned(to.as_ptr(), 16)
+            && from.len() % 4 == 0
+        {
             return l2_distance_simd(from, to, dimension);
         }
     }
 
     // Fallback
-    use arrow_array::cast::as_primitive_array;
     let n = to.len() / dimension;
     let scores: Float32Array = unsafe {
         Float32Array::from_trusted_len_iter(
-            (0..n)
-                .map(|idx| {
-                    l2_distance_arrow(
-                        from,
-                        as_primitive_array(to.slice(idx * dimension, dimension).as_ref()),
-                    )
-                })
+            to.chunks_exact(dimension)
+                .map(|v| l2_distance_slow(from, v))
                 .map(Some),
         )
     };
@@ -182,7 +168,8 @@ mod tests {
             8,
         );
         let point = Float32Array::from((2..10).map(|v| Some(v as f32)).collect::<Vec<_>>());
-        let scores = l2_distance(&point, as_primitive_array(mat.values().as_ref()), 8).unwrap();
+        let scores =
+            l2_distance(point.values(), as_primitive_array(mat.values().as_ref()), 8).unwrap();
 
         assert_eq!(
             scores.as_ref(),

--- a/rust/src/utils/kmeans.rs
+++ b/rust/src/utils/kmeans.rs
@@ -412,14 +412,17 @@ impl KMeans {
             .map(|(indices, (data, centroids))| async move {
                 let data = tokio::task::spawn_blocking(move || {
                     let dist = metric_type.func();
-                    data.values()
-                        .chunks_exact(dimension)
-                        .map(|v| {
-                            let distances = dist(v, centroids.values(), dimension).unwrap();
-                            let cluster_id = argmin(distances.as_ref()).unwrap();
-                            (cluster_id, distances.value(cluster_id as usize))
-                        })
-                        .collect()
+                    let mut results = vec![];
+                    for idx in indices {
+                        let value_arr = data.slice(idx * dimension, dimension);
+                        let vector: &Float32Array = as_primitive_array(&value_arr);
+                        let distances =
+                            dist(vector.values(), centroids.values(), dimension).unwrap();
+                        let cluster_id = argmin(distances.as_ref()).unwrap();
+                        let distance = distances.value(cluster_id as usize);
+                        results.push((cluster_id, distance))
+                    }
+                    results
                 })
                 .await?;
                 Ok::<Vec<_>, Error>(data)


### PR DESCRIPTION
It eliminates some of the Arrow Array creation, resulted a speed up in vanama graph construction by 2-3x. 

Closes #747 