### PR TITLE
[Rust] Persist graph using lance file format.

### DIFF
--- a/protos/index.proto
+++ b/protos/index.proto
@@ -106,6 +106,7 @@ message VectorIndexStage {
   }
 }
 
+
 // Metric Type for Vector Index
 enum VectorMetricType {
   // L2 (Euclidean) Distance

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -58,6 +58,7 @@ datafusion = { version = "19.0.0", default-features = false }
 faiss = { version = "0.11.0", features = ["gpu"], optional = true }
 lapack = "0.19.0"
 cblas = "0.4.0"
+lru_time_cache = "0.11"
 
 [target.'cfg(target_os = "macos")'.dependencies]
 accelerate-src = "0.3.2"

--- a/rust/src/arrow.rs
+++ b/rust/src/arrow.rs
@@ -267,6 +267,10 @@ impl FixedSizeBinaryArrayExt for FixedSizeBinaryArray {
     }
 }
 
+pub fn as_fixed_size_binary_array(arr: &dyn Array) -> &FixedSizeBinaryArray {
+    arr.as_any().downcast_ref::<FixedSizeBinaryArray>().unwrap()
+}
+
 /// Extends Arrow's [RecordBatch].
 pub trait RecordBatchExt {
     /// Append a new column to this [`RecordBatch`] and returns a new RecordBatch.

--- a/rust/src/index/vector.rs
+++ b/rust/src/index/vector.rs
@@ -21,6 +21,7 @@ use std::sync::Arc;
 use arrow_array::Float32Array;
 
 pub mod flat;
+mod graph;
 pub mod ivf;
 mod kmeans;
 mod opq;

--- a/rust/src/index/vector/graph.rs
+++ b/rust/src/index/vector/graph.rs
@@ -18,7 +18,7 @@
 use crate::Result;
 use std::any::Any;
 
-mod memory;
+mod builder;
 mod persisted;
 
 /// Vertex (metadata). It does not include the actual data.
@@ -26,6 +26,9 @@ pub trait Vertex: Sized {
     fn byte_length(&self) -> usize;
 
     fn from_bytes(data: &[u8]) -> Result<Self>;
+
+    // TODO: impl as Into trait?
+    fn to_bytes(&self) -> Vec<u8>;
 
     fn as_any(&self) -> &dyn Any;
 }

--- a/rust/src/index/vector/graph.rs
+++ b/rust/src/index/vector/graph.rs
@@ -15,13 +15,17 @@
 //! Graph-based vector index.
 //!
 
+use crate::Result;
 use std::any::Any;
 
+mod memory;
 mod persisted;
 
 /// Vertex (metadata). It does not include the actual data.
-pub trait Vertex {
-    fn bytes(&self) -> usize;
+pub trait Vertex: Sized {
+    fn byte_length(&self) -> usize;
+
+    fn from_bytes(data: &[u8]) -> Result<Self>;
 
     fn as_any(&self) -> &dyn Any;
 }

--- a/rust/src/index/vector/graph.rs
+++ b/rust/src/index/vector/graph.rs
@@ -16,7 +16,6 @@
 //!
 
 use crate::Result;
-use std::any::Any;
 
 mod builder;
 mod persisted;
@@ -29,6 +28,4 @@ pub trait Vertex: Sized {
 
     // TODO: impl as Into trait?
     fn to_bytes(&self) -> Vec<u8>;
-
-    fn as_any(&self) -> &dyn Any;
 }

--- a/rust/src/index/vector/graph.rs
+++ b/rust/src/index/vector/graph.rs
@@ -1,0 +1,27 @@
+// Copyright 2023 Lance Developers.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! Graph-based vector index.
+//!
+
+use std::any::Any;
+
+mod persisted;
+
+/// Vertex (metadata). It does not include the actual data.
+pub trait Vertex {
+    fn bytes(&self) -> usize;
+
+    fn as_any(&self) -> &dyn Any;
+}

--- a/rust/src/index/vector/graph.rs
+++ b/rust/src/index/vector/graph.rs
@@ -17,7 +17,10 @@
 
 use crate::Result;
 
+// TODO: remove dead_code after implementing the index.
+#[allow(dead_code)]
 mod builder;
+#[allow(dead_code)]
 mod persisted;
 
 /// Vertex (metadata). It does not include the actual data.

--- a/rust/src/index/vector/graph/builder.rs
+++ b/rust/src/index/vector/graph/builder.rs
@@ -14,10 +14,7 @@
 
 //! Graph in memory.
 
-use std::any::Any;
-
 use super::Vertex;
-use crate::Result;
 
 /// A graph node to hold the vertex data and its neighbors.
 #[derive(Debug)]
@@ -86,6 +83,7 @@ mod tests {
     use approx::assert_relative_eq;
 
     use super::*;
+    use crate::Result;
 
     struct FooVertex {
         id: u32,

--- a/rust/src/index/vector/graph/builder.rs
+++ b/rust/src/index/vector/graph/builder.rs
@@ -19,7 +19,11 @@ use super::Vertex;
 /// A graph node to hold the vertex data and its neighbors.
 #[derive(Debug)]
 pub(crate) struct Node<V: Vertex> {
+    /// The vertex metadata. will be serialized into fixed size binary in the persisted graph.
     pub(crate) vertex: V,
+
+    /// Neighbors are the ids of vertex in the graph.
+    /// This id is not the same as the row_id in the original lance dataset.
     pub(crate) neighbors: Vec<u32>,
 }
 

--- a/rust/src/index/vector/graph/builder.rs
+++ b/rust/src/index/vector/graph/builder.rs
@@ -26,7 +26,9 @@ pub(crate) struct Node<V: Vertex> {
     pub(crate) neighbors: Vec<u32>,
 }
 
-/// Graph, used to build the persisted graph.
+/// A Graph that allows dynamically build graph to be persisted later.
+///
+/// It requires all vertices to be of the same size.
 pub struct GraphBuilder<V: Vertex> {
     pub(crate) nodes: Vec<Node<V>>,
 }
@@ -59,6 +61,10 @@ impl<V: Vertex> GraphBuilder<V> {
     pub fn neighbors_mut(&mut self, id: usize) -> &mut Vec<u32> {
         &mut self.nodes[id].neighbors
     }
+
+    pub fn add_edge(&mut self, from: usize, to: usize) {
+        self.nodes[from].neighbors.push(to as u32);
+    }
 }
 
 impl<V: Vertex> FromIterator<V> for GraphBuilder<V> {
@@ -77,6 +83,8 @@ impl<V: Vertex> FromIterator<V> for GraphBuilder<V> {
 
 #[cfg(test)]
 mod tests {
+    use approx::assert_relative_eq;
+
     use super::*;
 
     struct FooVertex {
@@ -110,7 +118,7 @@ mod tests {
 
     #[test]
     fn test_construct_builder() {
-        let builder: GraphBuilder<FooVertex> = (0..100)
+        let mut builder: GraphBuilder<FooVertex> = (0..100)
             .map(|v| FooVertex {
                 id: v as u32,
                 val: v as f32 * 0.5,
@@ -119,6 +127,10 @@ mod tests {
 
         assert_eq!(builder.len(), 100);
         assert_eq!(builder.vertex(77).id, 77);
+        assert_relative_eq!(builder.vertex(77).val, 38.5);
         assert!(builder.neighbors(55).is_empty());
+
+        builder.vertex_mut(88).val = 22.0;
+        assert_relative_eq!(builder.vertex(88).val, 22.0);
     }
 }

--- a/rust/src/index/vector/graph/builder.rs
+++ b/rust/src/index/vector/graph/builder.rs
@@ -110,10 +110,6 @@ mod tests {
             bytes.extend_from_slice(&self.val.to_le_bytes());
             bytes
         }
-
-        fn as_any(&self) -> &dyn Any {
-            self
-        }
     }
 
     #[test]

--- a/rust/src/index/vector/graph/builder.rs
+++ b/rust/src/index/vector/graph/builder.rs
@@ -1,0 +1,124 @@
+// Copyright 2023 Lance Developers.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! Graph in memory.
+
+use std::any::Any;
+
+use super::Vertex;
+use crate::Result;
+
+/// A graph node to hold the vertex data and its neighbors.
+#[derive(Debug)]
+pub(crate) struct Node<V: Vertex> {
+    pub(crate) vertex: V,
+    pub(crate) neighbors: Vec<u32>,
+}
+
+/// Graph, used to build the persisted graph.
+pub struct GraphBuilder<V: Vertex> {
+    pub(crate) nodes: Vec<Node<V>>,
+}
+
+impl<V: Vertex> GraphBuilder<V> {
+    pub fn new() -> Self {
+        Self { nodes: vec![] }
+    }
+
+    pub fn len(&self) -> usize {
+        self.nodes.len()
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.nodes.is_empty()
+    }
+
+    pub fn vertex(&self, id: usize) -> &V {
+        &self.nodes[id].vertex
+    }
+
+    pub fn vertex_mut(&mut self, id: usize) -> &mut V {
+        &mut self.nodes[id].vertex
+    }
+
+    pub fn neighbors(&self, id: usize) -> &[u32] {
+        self.nodes[id].neighbors.as_slice()
+    }
+
+    pub fn neighbors_mut(&mut self, id: usize) -> &mut Vec<u32> {
+        &mut self.nodes[id].neighbors
+    }
+}
+
+impl<V: Vertex> FromIterator<V> for GraphBuilder<V> {
+    fn from_iter<I: IntoIterator<Item = V>>(iter: I) -> Self {
+        let nodes: Vec<Node<V>> = iter
+            .into_iter()
+            .map(|v| Node {
+                vertex: v,
+                neighbors: vec![],
+            })
+            .collect();
+
+        GraphBuilder { nodes: nodes }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    struct FooVertex {
+        id: u32,
+        val: f32,
+    }
+
+    impl Vertex for FooVertex {
+        fn byte_length(&self) -> usize {
+            8
+        }
+
+        fn from_bytes(data: &[u8]) -> Result<Self> {
+            Ok(Self {
+                id: u32::from_le_bytes(data[0..4].try_into().unwrap()),
+                val: f32::from_le_bytes(data[4..8].try_into().unwrap()),
+            })
+        }
+
+        fn to_bytes(&self) -> Vec<u8> {
+            let mut bytes = vec![];
+            bytes.extend_from_slice(&self.id.to_le_bytes());
+            bytes.extend_from_slice(&self.val.to_le_bytes());
+            bytes
+        }
+
+        fn as_any(&self) -> &dyn Any {
+            self
+        }
+    }
+
+    #[test]
+    fn test_construct_builder() {
+        let builder: GraphBuilder<FooVertex> = (0..100)
+            .map(|v| FooVertex {
+                id: v as u32,
+                val: v as f32 * 0.5,
+            })
+            .collect();
+
+        assert_eq!(builder.len(), 100);
+        assert_eq!(builder.vertex(77).id, 77);
+        assert!(builder.neighbors(55).is_empty());
+    }
+}

--- a/rust/src/index/vector/graph/persisted.rs
+++ b/rust/src/index/vector/graph/persisted.rs
@@ -258,10 +258,6 @@ mod tests {
             return 20;
         }
 
-        fn as_any(&self) -> &dyn std::any::Any {
-            self
-        }
-
         fn to_bytes(&self) -> Vec<u8> {
             let mut bytes = Vec::with_capacity(20);
             bytes.extend_from_slice(&self.row_id.to_le_bytes());

--- a/rust/src/index/vector/graph/persisted.rs
+++ b/rust/src/index/vector/graph/persisted.rs
@@ -17,8 +17,7 @@ use std::sync::{Arc, Mutex};
 use arrow::array::{as_list_array, as_primitive_array};
 use arrow_array::{
     builder::{FixedSizeBinaryBuilder, ListBuilder, UInt32Builder},
-    iterator::FixedSizeBinaryIter,
-    Array, ArrayAccessor, RecordBatch, UInt32Array,
+    Array, RecordBatch, UInt32Array,
 };
 use arrow_schema::{DataType, Field, Schema as ArrowSchema};
 use lru_time_cache::LruCache;

--- a/rust/src/index/vector/graph/persisted.rs
+++ b/rust/src/index/vector/graph/persisted.rs
@@ -1,0 +1,103 @@
+// Copyright 2023 Lance Developers.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::sync::{Arc, Mutex};
+
+use arrow_array::UInt32Array;
+use lru_time_cache::LruCache;
+use object_store::path::Path;
+
+use super::Vertex;
+use crate::io::{FileReader, ObjectStore};
+use crate::Result;
+
+const NEIGHBORS_COL: &str = "neighbors";
+const VERTEX_COL: &str = "vertex";
+
+/// Persisted graph on disk, stored in the file.
+pub struct PersistedGraph<'a, V: Vertex> {
+    reader: FileReader<'a>,
+
+    /// LRU cache for vertices.
+    cache: Arc<Mutex<LruCache<u32, Arc<V>>>>,
+
+    /// LRU cache for neighbors.
+    neighbors_cache: Arc<Mutex<LruCache<u32, UInt32Array>>>,
+}
+
+impl<'a, V: Vertex> PersistedGraph<'a, V> {
+    /// Try open a persisted graph from a given URI.
+    pub async fn try_new(
+        object_store: &'a ObjectStore,
+        path: &Path,
+    ) -> Result<PersistedGraph<'a, V>> {
+        let file_reader = FileReader::try_new(object_store, path).await?;
+        Ok(Self {
+            reader: file_reader,
+            cache: Arc::new(Mutex::new(LruCache::with_capacity(1000000))),
+            neighbors_cache: Arc::new(Mutex::new(LruCache::with_capacity(1000))),
+        })
+    }
+
+    /// The number of vertices in the graph.
+    pub fn len(&self) -> usize {
+        self.reader.len()
+    }
+
+    /// Get the vertex specified by its id.
+    pub async fn vertex(&self, id: u32) -> Result<Arc<V>> {
+        {
+            let mut cache = self.cache.lock().unwrap();
+            if let Some(vertex) = cache.get(&id) {
+                return Ok(vertex.clone());
+            }
+        }
+        todo!()
+    }
+
+    /// Get the neighbors of a vertex, specified by its id.
+    pub async fn neighbors(&self, id: u32) -> Result<&[u32]> {
+        todo!()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    struct TestVertex {
+        row_id: u32,
+        pq: Vec<u8>,
+    }
+
+    impl Vertex for TestVertex {
+        fn bytes(&self) -> usize {
+            return 20;
+        }
+
+        fn as_any(&self) -> &dyn std::any::Any {
+            self
+        }
+    }
+
+    #[tokio::test]
+    async fn test_persisted_graph() {
+        let store = ObjectStore::memory();
+        let path = Path::from("/graph");
+
+        let graph = PersistedGraph::<TestVertex>::try_new(&store, &path)
+            .await
+            .unwrap();
+    }
+}

--- a/rust/src/index/vector/graph/persisted.rs
+++ b/rust/src/index/vector/graph/persisted.rs
@@ -221,6 +221,7 @@ pub async fn write_graph<V: Vertex>(
         let inner_builder = UInt32Builder::with_capacity(total_neighbors);
         let mut neighbors_builder = ListBuilder::with_capacity(inner_builder, nodes.len());
         for node in nodes {
+            // Serialize the vertex metadata to fixed size binary bytes.
             vertex_builder.append_value(node.vertex.to_bytes())?;
             neighbors_builder
                 .values()


### PR DESCRIPTION
We are going to use lance to persist a graph, because lance offers good random access already, which is good for graph access.

This PR writes a graph as a two column table:
```
struct<
   vertex: FixedSizeBinary(...),
   neighbours: list<u32>,
>
```

It requires the vertex struct to be able to serialized to fixed size binary. 

It will be the `GraphBuilder`'s responsibility to re-orgnize the graph vertex in a way that it preserves certain locally. 