### PR TITLE
Matrix::centroids method

### DIFF
--- a/rust/src/arrow/kernels.rs
+++ b/rust/src/arrow/kernels.rs
@@ -1,19 +1,16 @@
-// Licensed to the Apache Software Foundation (ASF) under one
-// or more contributor license agreements.  See the NOTICE file
-// distributed with this work for additional information
-// regarding copyright ownership.  The ASF licenses this file
-// to you under the Apache License, Version 2.0 (the
-// "License"); you may not use this file except in compliance
-// with the License.  You may obtain a copy of the License at
+// Copyright 2023 Lance Developers.
 //
-//   http://www.apache.org/licenses/LICENSE-2.0
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
 //
-// Unless required by applicable law or agreed to in writing,
-// software distributed under the License is distributed on an
-// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
-// KIND, either express or implied.  See the License for the
-// specific language governing permissions and limitations
-// under the License.
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 
 use std::cmp::Ordering;
 

--- a/rust/src/arrow/linalg.rs
+++ b/rust/src/arrow/linalg.rs
@@ -51,7 +51,6 @@ fn transpose(input: &[f32], dimension: usize) -> Vec<f32> {
 
 /// A 2-D matrix view on top of Arrow Arrays.
 ///
-/// [MatrixView] does not own the data.
 #[derive(Debug, Clone)]
 pub struct MatrixView {
     /// Underneath data array.
@@ -130,7 +129,7 @@ impl MatrixView {
         }
     }
 
-    /// Returns a row at index `i`. Returns None if the index is out of bound.
+    /// Returns a row at index `i`. Returns `None` if the index is out of bound.
     ///
     /// # Panics if the matrix is transposed.
     pub fn row(&self, i: usize) -> Option<&[f32]> {
@@ -146,7 +145,7 @@ impl MatrixView {
         }
     }
 
-    /// Compute the centroid of all the rows. Returns None if the matrix is empty.
+    /// Compute the centroid from all the rows. Returns `None` if this matrix is empty.
     ///
     /// # Panics if the matrix is transposed.
     pub fn centroid(&self) -> Option<Float32Array> {

--- a/rust/src/arrow/linalg.rs
+++ b/rust/src/arrow/linalg.rs
@@ -130,12 +130,19 @@ impl MatrixView {
         }
     }
 
-    pub fn row(&self, i: usize) -> Option<Float32Array> {
+    /// Returns a row at index `i`. Returns None if the index is out of bound.
+    ///
+    /// # Panics if the matrix is transposed.
+    pub fn row(&self, i: usize) -> Option<&[f32]> {
+        assert!(
+            !self.transpose,
+            "Centroid is not defined for transposed matrix."
+        );
         if i >= self.num_rows() {
             None
         } else {
-            let slice_arr = self.data.slice(i * self.num_columns(), self.num_columns());
-            Some(as_primitive_array(slice_arr.as_ref()).clone())
+            let dim = self.num_columns();
+            Some(&self.data.values()[i * dim..(i + 1) * dim])
         }
     }
 

--- a/rust/src/arrow/linalg.rs
+++ b/rust/src/arrow/linalg.rs
@@ -382,8 +382,6 @@ impl SingularValueDecomposition for MatrixView {
     }
 }
 
-
-
 #[cfg(test)]
 mod tests {
     use std::collections::HashSet;

--- a/rust/src/index/vector/ivf.rs
+++ b/rust/src/index/vector/ivf.rs
@@ -332,6 +332,13 @@ impl Ivf {
             .unwrap();
             part_id_builder.append_value(part_id);
             let cent = centroids.row(part_id as usize).unwrap();
+            if vector.len() != cent.len() {
+                return Err(Error::IO(format!(
+                    "Ivf::compute_residual: dimension mismatch: {} != {}",
+                    vector.len(),
+                    cent.len()
+                )));
+            }
             unsafe {
                 residual_builder
                     .append_trusted_len_iter(vector.iter().zip(cent.iter()).map(|(v, c)| v - c))
@@ -454,6 +461,13 @@ fn compute_residual_matrix(
         )
         .unwrap();
         let centroid = centroids.row(part_id as usize).unwrap();
+        if row.len() != centroid.len() {
+            return Err(Error::IO(format!(
+                "Ivf::compute_residual: dimension mismatch: {} != {}",
+                row.len(),
+                centroid.len()
+            )));
+        };
         unsafe {
             builder.append_trusted_len_iter(row.iter().zip(centroid.iter()).map(|(v, c)| v - c))
         }

--- a/rust/src/index/vector/pq.rs
+++ b/rust/src/index/vector/pq.rs
@@ -358,7 +358,7 @@ impl ProductQuantizer {
     /// Compute the quantization distortion (E).
     ///
     /// Quantization distortion is the difference between the centroids
-    /// from the PQ codeto the actual vector.
+    /// from the PQ code to the actual vector.
     pub async fn distortion(&self, data: &MatrixView, metric_type: MetricType) -> Result<f64> {
         let sub_vectors = divide_to_subvectors(data, self.num_sub_vectors);
         debug_assert_eq!(sub_vectors.len(), self.num_sub_vectors);

--- a/rust/src/index/vector/pq.rs
+++ b/rust/src/index/vector/pq.rs
@@ -358,7 +358,7 @@ impl ProductQuantizer {
     /// Compute the quantization distortion (E).
     ///
     /// Quantization distortion is the difference between the centroids
-    /// from the PQ code to the actual vector.
+    /// from the PQ codeto the actual vector.
     pub async fn distortion(&self, data: &MatrixView, metric_type: MetricType) -> Result<f64> {
         let sub_vectors = divide_to_subvectors(data, self.num_sub_vectors);
         debug_assert_eq!(sub_vectors.len(), self.num_sub_vectors);
@@ -574,13 +574,9 @@ fn divide_to_subvectors(data: &MatrixView, m: usize) -> Vec<Arc<FixedSizeListArr
     for i in 0..m {
         let mut builder = Float32Builder::with_capacity(capacity);
         for j in 0..data.num_rows() {
-            let arr = data.row(j).unwrap();
-            let row: &Float32Array = as_primitive_array(&arr);
+            let row = data.row(j).unwrap();
             let start = i * sub_vector_length;
-
-            for k in start..start + sub_vector_length {
-                builder.append_value(row.value(k));
-            }
+            builder.append_slice(&row[start..start + sub_vector_length]);
         }
         let values = builder.finish();
         let sub_array =


### PR DESCRIPTION
* Consolidate centorids computation to MatirxView, for later optimization
* Change `MatrixView::row()` to return `&[f32]` slice for better code and performance (by avoiding more memory allocation to create `Float32Array`)