### PR TITLE
[Python] Set minimal version of Polars for python tests

### DIFF
--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -50,5 +50,5 @@ build-backend = "maturin"
 tests = [
     "pytest",
     "duckdb",
-    "polars[pyarrow,pandas]",
+    "polars[pyarrow,pandas]>=0.16.10",
 ]


### PR DESCRIPTION
Python tests failed on `<=0.16.9`:

```
>       polars_df = pl.scan_pyarrow_dataset(dataset)
E       AttributeError: module 'polars' has no attribute 'scan_pyarrow_dataset'
```