### PR TITLE
[Rust] Refactor RecordBatchStream trait

### DIFF
--- a/python/src/reader.rs
+++ b/python/src/reader.rs
@@ -21,7 +21,8 @@ use arrow_schema::{ArrowError, SchemaRef};
 use futures::stream::StreamExt;
 use tokio::runtime::Runtime;
 
-use ::lance::dataset::scanner::{RecordBatchStream, Scanner as LanceScanner};
+use lance::dataset::scanner::{Scanner as LanceScanner, DatasetRecordBatchStream};
+use lance::io::RecordBatchStream;
 
 /// Lance's RecordBatchReader
 /// This implements Arrow's RecordBatchReader trait
@@ -29,7 +30,7 @@ use ::lance::dataset::scanner::{RecordBatchStream, Scanner as LanceScanner};
 /// an ArrowArrayStream in the Arrow C Data Interface
 pub struct LanceReader {
     schema: SchemaRef,
-    stream: RecordBatchStream,
+    stream: DatasetRecordBatchStream,
     rt: Arc<Runtime>,
 }
 

--- a/rust/src/dataset/scanner.rs
+++ b/rust/src/dataset/scanner.rs
@@ -246,9 +246,7 @@ impl Scanner {
         Ok(Arc::new(schema))
     }
 
-    /// Create a stream of this Scanner.
-    ///
-    /// TODO: implement as IntoStream/IntoIterator.
+    /// Create a stream from the Scanner.
     pub async fn try_into_stream(&self) -> Result<impl RecordBatchStream> {
         let plan = self.create_plan().await?;
 

--- a/rust/src/dataset/scanner.rs
+++ b/rust/src/dataset/scanner.rs
@@ -247,7 +247,7 @@ impl Scanner {
     }
 
     /// Create a stream from the Scanner.
-    pub async fn try_into_stream(&self) -> Result<impl RecordBatchStream> {
+    pub async fn try_into_stream(&self) -> Result<DatasetRecordBatchStream> {
         let plan = self.create_plan().await?;
 
         let session_config = SessionConfig::new();

--- a/rust/src/dataset/scanner.rs
+++ b/rust/src/dataset/scanner.rs
@@ -497,7 +497,7 @@ impl Scanner {
     }
 }
 
-/// [`DatasetRecordBatchScream`] wraps the Exec nodes into a [`RecordBatchStream`] for
+/// [`DatasetRecordBatchScream`] wraps the dataset into a [`RecordBatchStream`] for
 /// consumption by the user.
 ///
 #[pin_project::pin_project]

--- a/rust/src/dataset/scanner.rs
+++ b/rust/src/dataset/scanner.rs
@@ -495,7 +495,7 @@ impl Scanner {
     }
 }
 
-/// [`DatasetRecordBatchScream`] wraps the dataset into a [`RecordBatchStream`] for
+/// [`DatasetRecordBatchStream`] wraps the dataset into a [`RecordBatchStream`] for
 /// consumption by the user.
 ///
 #[pin_project::pin_project]

--- a/rust/src/dataset/scanner.rs
+++ b/rust/src/dataset/scanner.rs
@@ -256,7 +256,7 @@ impl Scanner {
         let runtime_config = RuntimeConfig::new();
         let runtime_env = Arc::new(RuntimeEnv::new(runtime_config)?);
         let session_state = SessionState::with_config_rt(session_config, runtime_env);
-        Ok(ScannerRecordBatchStream::new(
+        Ok(DatasetRecordBatchStream::new(
             plan.execute(0, session_state.task_ctx())?,
         ))
     }
@@ -497,26 +497,28 @@ impl Scanner {
     }
 }
 
-/// ScannerStream is a container to wrap different types of ExecNode.
+/// [`DatasetRecordBatchScream`] wraps the Exec nodes into a [`RecordBatchStream`] for
+/// consumption by the user.
+///
 #[pin_project::pin_project]
-pub struct ScannerRecordBatchStream {
+pub struct DatasetRecordBatchStream {
     #[pin]
     exec_node: SendableRecordBatchStream,
 }
 
-impl ScannerRecordBatchStream {
+impl DatasetRecordBatchStream {
     pub fn new(exec_node: SendableRecordBatchStream) -> Self {
         Self { exec_node }
     }
 }
 
-impl RecordBatchStream for ScannerRecordBatchStream {
+impl RecordBatchStream for DatasetRecordBatchStream {
     fn schema(&self) -> SchemaRef {
         self.exec_node.schema()
     }
 }
 
-impl Stream for ScannerRecordBatchStream {
+impl Stream for DatasetRecordBatchStream {
     type Item = Result<RecordBatch>;
 
     fn poll_next(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Option<Self::Item>> {

--- a/rust/src/io.rs
+++ b/rust/src/io.rs
@@ -1,19 +1,16 @@
-// Licensed to the Apache Software Foundation (ASF) under one
-// or more contributor license agreements.  See the NOTICE file
-// distributed with this work for additional information
-// regarding copyright ownership.  The ASF licenses this file
-// to you under the Apache License, Version 2.0 (the
-// "License"); you may not use this file except in compliance
-// with the License.  You may obtain a copy of the License at
+// Copyright 2023 Lance Developers.
 //
-//   http://www.apache.org/licenses/LICENSE-2.0
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
 //
-// Unless required by applicable law or agreed to in writing,
-// software distributed under the License is distributed on an
-// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
-// KIND, either express or implied.  See the License for the
-// specific language governing permissions and limitations
-// under the License.
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 
 //! I/O utilities.
 
@@ -33,6 +30,7 @@ pub mod object_reader;
 pub mod object_store;
 pub mod object_writer;
 mod reader;
+mod stream;
 mod writer;
 
 use crate::format::{ProtoStruct, INDEX_MAGIC, MAGIC};
@@ -40,6 +38,7 @@ use crate::format::{ProtoStruct, INDEX_MAGIC, MAGIC};
 pub use self::object_store::ObjectStore;
 pub use reader::read_manifest;
 pub use reader::FileReader;
+pub use stream::RecordBatchStream;
 pub use writer::*;
 
 #[async_trait]

--- a/rust/src/io/exec/knn.rs
+++ b/rust/src/io/exec/knn.rs
@@ -28,7 +28,7 @@ use futures::stream::Stream;
 use tokio::sync::mpsc::Receiver;
 use tokio::task::JoinHandle;
 
-use crate::dataset::scanner::ScannerRecordBatchStream;
+use crate::dataset::scanner::DatasetRecordBatchStream;
 use crate::dataset::{Dataset, ROW_ID};
 use crate::index::vector::flat::flat_search;
 use crate::index::vector::{open_index, Query, SCORE_COL};
@@ -45,11 +45,11 @@ pub struct KNNFlatStream {
 impl KNNFlatStream {
     /// Construct a [KNNFlat] node.
     pub(crate) fn new(child: SendableRecordBatchStream, query: &Query) -> Self {
-        let stream = ScannerRecordBatchStream::new(child);
+        let stream = DatasetRecordBatchStream::new(child);
         KNNFlatStream::from_stream(stream, query)
     }
 
-    fn from_stream(stream: impl RecordBatchStream + Send + 'static, query: &Query) -> Self {
+    fn from_stream(stream: impl RecordBatchStream, query: &Query) -> Self {
         let (tx, rx) = tokio::sync::mpsc::channel(2);
 
         let q = query.clone();

--- a/rust/src/io/exec/knn.rs
+++ b/rust/src/io/exec/knn.rs
@@ -28,10 +28,11 @@ use futures::stream::Stream;
 use tokio::sync::mpsc::Receiver;
 use tokio::task::JoinHandle;
 
-use crate::dataset::scanner::RecordBatchStream;
+use crate::dataset::scanner::ScannerRecordBatchStream;
 use crate::dataset::{Dataset, ROW_ID};
 use crate::index::vector::flat::flat_search;
 use crate::index::vector::{open_index, Query, SCORE_COL};
+use crate::io::RecordBatchStream;
 use crate::{Error, Result};
 
 /// KNN node for post-filtering.
@@ -44,11 +45,11 @@ pub struct KNNFlatStream {
 impl KNNFlatStream {
     /// Construct a [KNNFlat] node.
     pub(crate) fn new(child: SendableRecordBatchStream, query: &Query) -> Self {
-        let stream = RecordBatchStream::new(child);
+        let stream = ScannerRecordBatchStream::new(child);
         KNNFlatStream::from_stream(stream, query)
     }
 
-    fn from_stream(stream: RecordBatchStream, query: &Query) -> Self {
+    fn from_stream(stream: impl RecordBatchStream + Send + 'static, query: &Query) -> Self {
         let (tx, rx) = tokio::sync::mpsc::channel(2);
 
         let q = query.clone();

--- a/rust/src/io/exec/knn.rs
+++ b/rust/src/io/exec/knn.rs
@@ -43,7 +43,7 @@ pub struct KNNFlatStream {
 }
 
 impl KNNFlatStream {
-    /// Construct a [KNNFlat] node.
+    /// Construct a [`KNNFlatStream`] node.
     pub(crate) fn new(child: SendableRecordBatchStream, query: &Query) -> Self {
         let stream = DatasetRecordBatchStream::new(child);
         KNNFlatStream::from_stream(stream, query)

--- a/rust/src/io/stream.rs
+++ b/rust/src/io/stream.rs
@@ -1,0 +1,25 @@
+// Copyright 2023 Lance Developers.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use arrow_array::RecordBatch;
+use arrow_schema::SchemaRef;
+use futures::Stream;
+
+use crate::Result;
+
+/// RecordBatch Stream trait.
+pub trait RecordBatchStream: Stream<Item = Result<RecordBatch>> + Send + 'static {
+    /// Returns the schema of the stream.
+    fn schema(&self) -> SchemaRef;
+}


### PR DESCRIPTION
Refactor to extract `RecordBatchStream`. There will be two implementation, one is `DatasetRecordBatchStream` (already implemented), and `FragmentRecordBatchStream` (to support #557). 