### PR TITLE
Get S3 credentials from_env

### DIFF
--- a/python/src/reader.rs
+++ b/python/src/reader.rs
@@ -21,7 +21,7 @@ use arrow_schema::{ArrowError, SchemaRef};
 use futures::stream::StreamExt;
 use tokio::runtime::Runtime;
 
-use lance::dataset::scanner::{Scanner as LanceScanner, DatasetRecordBatchStream};
+use lance::dataset::scanner::{DatasetRecordBatchStream, Scanner as LanceScanner};
 use lance::io::RecordBatchStream;
 
 /// Lance's RecordBatchReader

--- a/rust/src/io/object_store.rs
+++ b/rust/src/io/object_store.rs
@@ -60,13 +60,9 @@ async fn build_s3_object_store(uri: &str) -> Result<Arc<dyn OSObjectStore>> {
     const DEFAULT_REGION: &str = "us-west-2";
 
     let region_provider = RegionProviderChain::default_provider().or_else(DEFAULT_REGION);
-    let provider = aws_config::default_provider::credentials::default_provider().await;
-    let credentials = provider.provide_credentials().await.unwrap();
     Ok(Arc::new(
-        AmazonS3Builder::new()
+        AmazonS3Builder::from_env()
             .with_url(uri)
-            .with_access_key_id(credentials.access_key_id())
-            .with_secret_access_key(credentials.secret_access_key())
             .with_region(
                 region_provider
                     .region()


### PR DESCRIPTION
passing in the credentials directly does not work if you're in EC2 with IAM role configured. Instead we use `from_env` and let it pick up from the environment. 

closes #692 