### PR TITLE
[Rust] A arrow kernel to compute hash value of the array.

### DIFF
--- a/rust/src/arrow/kernels.rs
+++ b/rust/src/arrow/kernels.rs
@@ -13,8 +13,19 @@
 // limitations under the License.
 
 use std::cmp::Ordering;
+use std::{collections::hash_map::DefaultHasher, hash::Hash, hash::Hasher};
 
-use arrow_array::{ArrowNumericType, PrimitiveArray};
+use arrow::array::{as_largestring_array, as_string_array};
+use arrow_array::{
+    cast::as_primitive_array,
+    types::{
+        Int16Type, Int32Type, Int64Type, Int8Type, UInt16Type, UInt32Type, UInt64Type, UInt8Type,
+    },
+    Array, ArrowNumericType, GenericStringArray, OffsetSizeTrait, PrimitiveArray, UInt64Array,
+};
+use arrow_schema::DataType;
+
+use crate::{Error, Result};
 
 /// Argmax on a [PrimitiveArray].
 ///
@@ -52,10 +63,66 @@ where
         .map(|(idx, _)| idx as u32)
 }
 
+fn hash_numeric_type<T: ArrowNumericType>(array: &PrimitiveArray<T>) -> Result<UInt64Array>
+where
+    T::Native: Hash,
+{
+    let mut builder = UInt64Array::builder(array.len());
+    for i in 0..array.len() {
+        if array.is_null(i) {
+            builder.append_null();
+        } else {
+            let mut s = DefaultHasher::new();
+            array.value(i).hash(&mut s);
+            builder.append_value(s.finish());
+        }
+    }
+    Ok(builder.finish())
+}
+
+fn hash_string_type<O: OffsetSizeTrait>(array: &GenericStringArray<O>) -> Result<UInt64Array> {
+    let mut builder = UInt64Array::builder(array.len());
+    for i in 0..array.len() {
+        if array.is_null(i) {
+            builder.append_null();
+        } else {
+            let mut s = DefaultHasher::new();
+            array.value(i).hash(&mut s);
+            builder.append_value(s.finish());
+        }
+    }
+    Ok(builder.finish())
+}
+
+/// Calculate hash values for an Arrow Array, using `std::hash::Hash` in rust.
+pub fn hash(array: &dyn Array) -> Result<UInt64Array> {
+    match array.data_type() {
+        DataType::UInt8 => hash_numeric_type(as_primitive_array::<UInt8Type>(array)),
+        DataType::UInt16 => hash_numeric_type(as_primitive_array::<UInt16Type>(array)),
+        DataType::UInt32 => hash_numeric_type(as_primitive_array::<UInt32Type>(array)),
+        DataType::UInt64 => hash_numeric_type(as_primitive_array::<UInt64Type>(array)),
+        DataType::Int8 => hash_numeric_type(as_primitive_array::<Int8Type>(array)),
+        DataType::Int16 => hash_numeric_type(as_primitive_array::<Int16Type>(array)),
+        DataType::Int32 => hash_numeric_type(as_primitive_array::<Int32Type>(array)),
+        DataType::Int64 => hash_numeric_type(as_primitive_array::<Int64Type>(array)),
+        DataType::Utf8 => hash_string_type(as_string_array(array)),
+        DataType::LargeUtf8 => hash_string_type(as_largestring_array(array)),
+        _ => {
+            return Err(Error::Arrow(format!(
+                "Hash only supports integer or string array, got: {}",
+                array.data_type()
+            )))
+        }
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
-    use arrow_array::{Float32Array, Int16Array, UInt32Array};
+
+    use std::collections::HashSet;
+
+    use arrow_array::{Float32Array, Int16Array, Int8Array, StringArray, UInt32Array, UInt8Array};
 
     #[test]
     fn test_argmax() {
@@ -87,5 +154,36 @@ mod tests {
         let empty_vec: Vec<i16> = vec![];
         let emtpy = Int16Array::from(empty_vec);
         assert_eq!(argmin(&emtpy), None)
+    }
+
+    #[test]
+    fn test_numeric_hashes() {
+        let a: UInt8Array = [1_u8, 2, 3, 4, 5].iter().copied().collect();
+        let ha = hash(&a).unwrap();
+        let distinct_values: HashSet<u64> = ha.values().iter().copied().collect();
+        assert_eq!(distinct_values.len(), 5, "hash should be distinct");
+
+        let b: Int8Array = [1_i8, 2, 3, 4, 5].iter().copied().collect();
+        let hb = hash(&b).unwrap();
+
+        assert_eq!(ha, hb, "hash of the same numeric value should be the same");
+    }
+
+    #[test]
+    fn test_string_hashes() {
+        let a = StringArray::from(vec!["a", "b", "ccc", "dec", "e", "a"]);
+        let h = hash(&a).unwrap();
+        // first and last value are the same.
+        assert_eq!(h.value(0), h.value(5));
+
+        // Other than that, all values should be distinct
+        let distinct_values: HashSet<u64> = h.values().iter().copied().collect();
+        assert_eq!(distinct_values.len(), 5);
+    }
+
+    #[test]
+    fn test_hash_unsupported_type() {
+        let a = Float32Array::from(vec![1.0, 2.0, 3.0, 4.0, 5.0]);
+        assert!(hash(&a).is_err());
     }
 }

--- a/rust/src/arrow/kernels.rs
+++ b/rust/src/arrow/kernels.rs
@@ -107,12 +107,10 @@ pub fn hash(array: &dyn Array) -> Result<UInt64Array> {
         DataType::Int64 => hash_numeric_type(as_primitive_array::<Int64Type>(array)),
         DataType::Utf8 => hash_string_type(as_string_array(array)),
         DataType::LargeUtf8 => hash_string_type(as_largestring_array(array)),
-        _ => {
-            return Err(Error::Arrow(format!(
-                "Hash only supports integer or string array, got: {}",
-                array.data_type()
-            )))
-        }
+        _ => Err(Error::Arrow(format!(
+            "Hash only supports integer or string array, got: {}",
+            array.data_type()
+        ))),
     }
 }
 
@@ -122,7 +120,9 @@ mod tests {
 
     use std::collections::HashSet;
 
-    use arrow_array::{Float32Array, Int16Array, Int8Array, StringArray, UInt32Array, UInt8Array};
+    use arrow_array::{
+        Float32Array, Int16Array, Int8Array, LargeStringArray, StringArray, UInt32Array, UInt8Array,
+    };
 
     #[test]
     fn test_argmax() {
@@ -179,6 +179,11 @@ mod tests {
         // Other than that, all values should be distinct
         let distinct_values: HashSet<u64> = h.values().iter().copied().collect();
         assert_eq!(distinct_values.len(), 5);
+
+        let a = LargeStringArray::from(vec!["a", "b", "ccc", "dec", "e", "a"]);
+        let h = hash(&a).unwrap();
+        // first and last value are the same.
+        assert_eq!(h.value(0), h.value(5));
     }
 
     #[test]


### PR DESCRIPTION
Add a `hash(arr: &dyn Array)` kernel to compute hash value returned from `std::hash::Hash`