### PR TITLE
[Rust] L2 distance on not aligned data

### DIFF
--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -59,6 +59,7 @@ faiss = { version = "0.11.0", features = ["gpu"], optional = true }
 lapack = "0.19.0"
 cblas = "0.4.0"
 lru_time_cache = "0.11"
+num-traits = "0.2"
 
 [target.'cfg(target_os = "macos")'.dependencies]
 accelerate-src = "0.3.2"

--- a/rust/src/utils/distance/l2.rs
+++ b/rust/src/utils/distance/l2.rs
@@ -36,8 +36,8 @@ unsafe fn euclidean_distance_fma(from: &[f32], to: &[f32]) -> f32 {
     let mut sums = _mm256_setzero_ps();
     for i in (0..len).step_by(8) {
         // Cache line-aligned
-        let left = _mm256_load_ps(from.as_ptr().add(i));
-        let right = _mm256_load_ps(to.as_ptr().add(i));
+        let left = _mm256_loadu_ps(from.as_ptr().add(i));
+        let right = _mm256_loadu_ps(to.as_ptr().add(i));
         let sub = _mm256_sub_ps(left, right);
         // sum = sub * sub + sum
         sums = _mm256_fmadd_ps(sub, sub, sums);

--- a/rust/src/utils/distance/l2.rs
+++ b/rust/src/utils/distance/l2.rs
@@ -14,7 +14,7 @@
 
 //! L2 (Euclidean) distance.
 
-use std::{sync::Arc, iter::Sum};
+use std::{iter::Sum, sync::Arc};
 
 use arrow_array::Float32Array;
 use num_traits::real::Real;
@@ -116,9 +116,7 @@ pub fn l2_distance(from: &[f32], to: &[f32], dimension: usize) -> Result<Arc<Flo
 
     #[cfg(any(target_arch = "x86_64"))]
     {
-        if is_x86_feature_detected!("fma")
-            && from.len() % 8 == 0
-        {
+        if is_x86_feature_detected!("fma") && from.len() % 8 == 0 {
             return l2_distance_simd(from, to, dimension);
         }
     }
@@ -126,9 +124,7 @@ pub fn l2_distance(from: &[f32], to: &[f32], dimension: usize) -> Result<Arc<Flo
     #[cfg(any(target_arch = "aarch64"))]
     {
         use std::arch::is_aarch64_feature_detected;
-        if is_aarch64_feature_detected!("neon")
-            && from.len() % 4 == 0
-        {
+        if is_aarch64_feature_detected!("neon") && from.len() % 4 == 0 {
             return l2_distance_simd(from, to, dimension);
         }
     }

--- a/rust/src/utils/distance/l2.rs
+++ b/rust/src/utils/distance/l2.rs
@@ -28,14 +28,13 @@ use crate::Result;
 #[cfg(any(target_arch = "x86_64"))]
 #[target_feature(enable = "fma")]
 #[inline]
-unsafe fn euclidean_distance_fma(from: &[f32], to: &[f32]) -> f32 {
+unsafe fn l2_distance_fma(from: &[f32], to: &[f32]) -> f32 {
     use std::arch::x86_64::*;
     debug_assert_eq!(from.len(), to.len());
 
     let len = from.len();
     let mut sums = _mm256_setzero_ps();
     for i in (0..len).step_by(8) {
-        // Cache line-aligned
         let left = _mm256_loadu_ps(from.as_ptr().add(i));
         let right = _mm256_loadu_ps(to.as_ptr().add(i));
         let sub = _mm256_sub_ps(left, right);
@@ -89,7 +88,7 @@ fn l2_distance_simd(from: &[f32], to: &[f32], dimension: usize) -> Result<Arc<Fl
                 .map(|idx| {
                     #[cfg(any(target_arch = "x86_64"))]
                     {
-                        euclidean_distance_fma(from, &to[idx * dimension..(idx + 1) * dimension])
+                        l2_distance_fma(from, &to[idx * dimension..(idx + 1) * dimension])
                     }
 
                     #[cfg(any(target_arch = "aarch64"))]

--- a/rust/src/utils/distance/l2.rs
+++ b/rust/src/utils/distance/l2.rs
@@ -19,7 +19,6 @@ use std::{iter::Sum, sync::Arc};
 use arrow_array::Float32Array;
 use num_traits::real::Real;
 
-use super::is_simd_aligned;
 use crate::Result;
 
 // TODO: wait [std::simd] to be stable to replace manually written AVX/FMA code.
@@ -134,12 +133,10 @@ pub fn l2_distance(from: &[f32], to: &[f32], dimension: usize) -> Result<Arc<Flo
         }
     }
 
-    // Fallback to slow version
+    // Fallback to non-SIMD version.
     let scores: Float32Array = unsafe {
         Float32Array::from_trusted_len_iter(
-            to.chunks_exact(dimension)
-                .map(|v| l2_scalar(from, v))
-                .map(Some),
+            to.chunks_exact(dimension).map(|v| Some(l2_scalar(from, v))),
         )
     };
     Ok(Arc::new(scores))


### PR DESCRIPTION
Allow SIMD L2 code running on not cache-line aligned and odd dimensions, which fall back to non-SIMD one transparently.