### PR TITLE
[Rust] Minor SIMD benchmark fix set minimal CPU target for AVX2

### DIFF
--- a/rust/.cargo/config.toml
+++ b/rust/.cargo/config.toml
@@ -15,5 +15,8 @@ rustflags = [
     "-Wclippy::use_self",
 ]
 
+[target.x86_64-unknown-linux-gnu]
+rustflags = ["-C", "target-cpu=haswell", "-C", "target-feature=+avx2"]
+
 [target.aarch64-apple-darwin]
 # rustflags = ["-C", "target-cpu=native", "-C", "target-feature=+neon"]

--- a/rust/.cargo/config.toml
+++ b/rust/.cargo/config.toml
@@ -19,4 +19,4 @@ rustflags = [
 rustflags = ["-C", "target-cpu=haswell", "-C", "target-feature=+avx2"]
 
 [target.aarch64-apple-darwin]
-# rustflags = ["-C", "target-cpu=native", "-C", "target-feature=+neon"]
+rustflags = ["-C", "target-cpu=apple-m1", "-C", "target-feature=+neon"]

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -75,7 +75,7 @@ openblas-src = { version = "0.10.8", default-features= false, features = ["syste
 [target.'cfg(target_os="windows")'.build-dependencies]
 vcpkg = "0.2"
 
-[target.'cfg(target_os = "unix")'.dev-dependencies]
+[target.'cfg(target_os = "linux")'.dev-dependencies]
 pprof = { version = "0.11", features = ["flamegraph", "criterion"] }
 
 [build-dependencies]

--- a/rust/benches/l2.rs
+++ b/rust/benches/l2.rs
@@ -39,10 +39,9 @@ fn l2_arrow_arity(x: &Float32Array, y: &Float32Array) -> f32 {
 }
 
 #[inline]
-fn l2_auto_vectorization(x: &Float32Array, y: &Float32Array) -> f32 {
-    x.values()
-        .iter()
-        .zip(y.values().iter())
+fn l2_auto_vectorization(x: &[f32], y: &[f32]) -> f32 {
+    x.iter()
+        .zip(y.iter())
         .map(|(a, b)| (a - b).powi(2))
         .sum::<f32>()
 }
@@ -80,10 +79,11 @@ fn bench_distance(c: &mut Criterion) {
     });
 
     c.bench_function("L2(auto-vectorization)", |b| {
+        let x = key.values();
         b.iter(|| unsafe {
             Float32Array::from_trusted_len_iter((0..target.len() / DIMENSION).map(|idx| {
-                let arr = target.slice(idx * DIMENSION, DIMENSION);
-                Some(l2_auto_vectorization(&key, as_primitive_array(&arr)))
+                let y = target.values()[idx * DIMENSION..(idx + 1) * DIMENSION].as_ref();
+                Some(l2_auto_vectorization(x, y))
             }))
         });
     });

--- a/rust/src/linalg/l2.rs
+++ b/rust/src/linalg/l2.rs
@@ -46,11 +46,11 @@ impl L2 for [f32] {
 
     #[inline]
     fn l2(&self, other: &[f32]) -> f32 {
-        #[cfg(all(target_arch = "x86_64"))]
+        #[cfg(target_arch = "x86_64")]
         {
             // TODO: Only known platform that does not support FMA is Github Action Mac(Intel) Runner.
             // However, it introduces one more branch, which may affect performance.
-            if is_x86_feature_detected!("fma") {
+            if is_x86_feature_detected!("avx2") {
                 // AVX2 / FMA is the lowest x86_64 CPU requirement (released from 2011) for Lance.
                 use x86_64::avx::l2_f32;
                 return l2_f32(self, other);


### PR DESCRIPTION
* Set default CPU target to haswell to enable AVX2 routine. Haswell is the oldest CPU still available on AWS and GCP now.  One generation newer (Broadwell) does not bring statistically significant improvement in our benchmarks.
* Fixed `pprof` build on Linux.
* Update the benchmark to reduce the calls to `Float32Array::values()` to make the comparision fair. 