### PR TITLE
Fix offset overflow in plain decoder

### DIFF
--- a/rust/src/encodings/plain.rs
+++ b/rust/src/encodings/plain.rs
@@ -325,14 +325,14 @@ impl<'a> Decoder for PlainDecoder<'a> {
             return self.take_boolean(indices).await;
         }
 
-        let block_size = self.reader.prefetch_size() as u32;
-        let byte_width = self.data_type.byte_width() as u32;
+        let block_size = self.reader.prefetch_size();
+        let byte_width = self.data_type.byte_width();
 
         let mut chunk_ranges = vec![];
         let mut start: u32 = 0;
         for j in 0..(indices.len() - 1) as u32 {
-            if indices.value(j as usize + 1) * byte_width
-                > indices.value(start as usize) * byte_width + block_size
+            if indices.value(j as usize + 1) as usize * byte_width
+                > indices.value(start as usize) as usize * byte_width + block_size
             {
                 chunk_ranges.push(start..j + 1);
                 start = j + 1;

--- a/rust/src/encodings/plain.rs
+++ b/rust/src/encodings/plain.rs
@@ -858,7 +858,7 @@ mod tests {
             20,
             100,
             120,
-            (u32_overflow / byte_width) as u32,  // Two overflow offsets
+            (u32_overflow / byte_width) as u32, // Two overflow offsets
             (u32_overflow / byte_width) as u32 + 100,
         ];
         let chunks = make_chunked_requests(&indices, byte_width, prefetch_size);

--- a/rust/src/encodings/plain.rs
+++ b/rust/src/encodings/plain.rs
@@ -314,8 +314,9 @@ fn make_chunked_requests(
 ) -> Vec<Range<usize>> {
     let mut chunked_ranges = vec![];
     let mut start: usize = 0;
-    for (i, w) in indices.windows(2).enumerate() {
-        if w[0] as usize * byte_width + block_size < w[1] as usize * byte_width {
+    for i in 0..indices.len() - 1 {
+        if indices[i + 1] as usize * byte_width > indices[start] as usize * byte_width + block_size
+        {
             chunked_ranges.push(start..i + 1);
             start = i + 1;
         }

--- a/rust/src/encodings/plain.rs
+++ b/rust/src/encodings/plain.rs
@@ -316,8 +316,8 @@ fn make_chunked_requests(
     let mut start: usize = 0;
     for (i, w) in indices.windows(2).enumerate() {
         if w[0] as usize * byte_width + block_size < w[1] as usize * byte_width {
-            chunked_ranges.push(start..i);
-            start = i;
+            chunked_ranges.push(start..i + 1);
+            start = i + 1;
         }
     }
     chunked_ranges.push(start..indices.len());
@@ -858,11 +858,11 @@ mod tests {
             20,
             100,
             120,
-            (u32_overflow / byte_width) as u32,
-            (u32_overflow / byte_width) as u32 + 20,
+            (u32_overflow / byte_width) as u32,  // Two overflow offsets
+            (u32_overflow / byte_width) as u32 + 100,
         ];
         let chunks = make_chunked_requests(&indices, byte_width, prefetch_size);
         assert_eq!(chunks.len(), 5, "got chunks: {:?}", chunks);
-        assert_eq!(chunks, vec![(0..2), (2..3), (3..4), (4..5), (5..6)])
+        assert_eq!(chunks, vec![(0..3), (3..4), (4..5), (5..6), (6..7)])
     }
 }

--- a/rust/src/encodings/plain.rs
+++ b/rust/src/encodings/plain.rs
@@ -314,6 +314,12 @@ fn make_chunked_requests(
 ) -> Vec<Range<usize>> {
     let mut chunked_ranges = vec![];
     let mut start: usize = 0;
+    // Note: limit the I/O size to the block size.
+    //
+    // Another option could be checking whether `indices[i]` and `indices[i+1]` are not
+    // farther way than the block size:
+    //    indices[i] * byte_width + block_size < indices[i+1] * byte_width
+    // It might allow slightly larger sequential reads.
     for i in 0..indices.len() - 1 {
         if indices[i + 1] as usize * byte_width > indices[start] as usize * byte_width + block_size
         {

--- a/rust/src/encodings/plain.rs
+++ b/rust/src/encodings/plain.rs
@@ -1,19 +1,16 @@
-// Licensed to the Apache Software Foundation (ASF) under one
-// or more contributor license agreements.  See the NOTICE file
-// distributed with this work for additional information
-// regarding copyright ownership.  The ASF licenses this file
-// to you under the Apache License, Version 2.0 (the
-// "License"); you may not use this file except in compliance
-// with the License.  You may obtain a copy of the License at
+// Copyright 2023 Lance Developers.
 //
-//   http://www.apache.org/licenses/LICENSE-2.0
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
 //
-// Unless required by applicable law or agreed to in writing,
-// software distributed under the License is distributed on an
-// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
-// KIND, either express or implied.  See the License for the
-// specific language governing permissions and limitations
-// under the License.
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 
 //! Plain encoding
 //!
@@ -847,5 +844,25 @@ mod tests {
             actual.column_by_name("b").unwrap().as_ref(),
             &BooleanArray::from(vec![false, false, true, false, true])
         );
+    }
+
+    #[test]
+    fn test_make_chunked_request() {
+        let byte_width: usize = 4096; // 4K
+        let prefetch_size: usize = 64 * 1024; // 64KB.
+        let u32_overflow: usize = u32::MAX as usize + 10;
+
+        let indices: Vec<u32> = vec![
+            1,
+            10,
+            20,
+            100,
+            120,
+            (u32_overflow / byte_width) as u32,
+            (u32_overflow / byte_width) as u32 + 20,
+        ];
+        let chunks = make_chunked_requests(&indices, byte_width, prefetch_size);
+        assert_eq!(chunks.len(), 5, "got chunks: {:?}", chunks);
+        assert_eq!(chunks, vec![(0..2), (2..3), (3..4), (4..5), (5..6)])
     }
 }

--- a/rust/src/encodings/plain.rs
+++ b/rust/src/encodings/plain.rs
@@ -869,7 +869,7 @@ mod tests {
             (u32_overflow / byte_width) as u32 + 100,
         ];
         let chunks = make_chunked_requests(&indices, byte_width, prefetch_size);
-        assert_eq!(chunks.len(), 5, "got chunks: {:?}", chunks);
-        assert_eq!(chunks, vec![(0..3), (3..4), (4..5), (5..6), (6..7)])
+        assert_eq!(chunks.len(), 6, "got chunks: {:?}", chunks);
+        assert_eq!(chunks, vec![(0..2), (2..3), (3..4), (4..5), (5..6), (6..7)])
     }
 }

--- a/rust/src/io/exec/projection.rs
+++ b/rust/src/io/exec/projection.rs
@@ -99,10 +99,25 @@ impl RecordBatchStream for ProjectionStream {
     }
 }
 
-#[derive(Debug)]
 pub(crate) struct ProjectionExec {
     input: Arc<dyn ExecutionPlan>,
     project: Arc<Schema>,
+}
+
+impl std::fmt::Debug for ProjectionExec {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        let columns = self
+            .project
+            .fields
+            .iter()
+            .map(|f| f.name.clone())
+            .collect::<Vec<_>>();
+        write!(
+            f,
+            "Projection(schema={:?},\n\tchild={:?})",
+            columns, self.input
+        )
+    }
 }
 
 impl ProjectionExec {

--- a/rust/src/io/exec/take.rs
+++ b/rust/src/io/exec/take.rs
@@ -67,11 +67,10 @@ impl Take {
                     let rows = if extra.fields.is_empty() {
                         batch
                     } else {
-                        let batch = dataset
+                        dataset
                             .take_rows(row_ids.values(), &extra)
                             .await?
-                            .merge(&batch)?;
-                        batch
+                            .merge(&batch)?
                     };
                     Ok::<RecordBatch, Error>(rows)
                 })

--- a/rust/src/io/exec/take.rs
+++ b/rust/src/io/exec/take.rs
@@ -67,10 +67,11 @@ impl Take {
                     let rows = if extra.fields.is_empty() {
                         batch
                     } else {
-                        dataset
+                        let batch = dataset
                             .take_rows(row_ids.values(), &extra)
                             .await?
-                            .merge(&batch)?
+                            .merge(&batch)?;
+                        batch
                     };
                     Ok::<RecordBatch, Error>(rows)
                 })
@@ -127,7 +128,6 @@ impl RecordBatchStream for Take {
 /// The rows are identified by the inexplicit row IDs from `input` plan.
 ///
 /// The output schema will be the input schema, merged with extra schemas from the dataset.
-#[derive(Debug)]
 pub(crate) struct TakeExec {
     /// Dataset to read from.
     dataset: Arc<Dataset>,
@@ -138,6 +138,18 @@ pub(crate) struct TakeExec {
 
     /// Output schema is the merged schema between input schema and extra schema.
     output_schema: Schema,
+}
+
+impl std::fmt::Debug for TakeExec {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        let columns = self
+            .output_schema
+            .fields
+            .iter()
+            .map(|f| f.name.as_str())
+            .collect::<Vec<_>>();
+        write!(f, "Take(columns={:?}, \n\tchild={:?})", columns, self.input)
+    }
 }
 
 impl TakeExec {


### PR DESCRIPTION
This happens when there was a row group that is larger than 4GB. Plain decoder calculating the chunked offsets using `u32` which causes overflow. 