### PR TITLE
Add a check to make sure field names don't contain periods

### DIFF
--- a/rust/src/dataset.rs
+++ b/rust/src/dataset.rs
@@ -1080,4 +1080,35 @@ mod tests {
         assert!(dataset.manifest.index_section.is_none());
         assert!(dataset.load_indices().await.unwrap().is_empty());
     }
+
+    async fn create_bad_file() -> Result<Dataset> {
+        let test_dir = tempdir().unwrap();
+
+        let schema = Arc::new(ArrowSchema::new(vec![Field::new(
+            "a.b.c",
+            DataType::Int32,
+            false,
+        )]));
+
+        let batches = RecordBatchBuffer::new(
+            (0..20)
+                .map(|i| {
+                    RecordBatch::try_new(
+                        schema.clone(),
+                        vec![Arc::new(Int32Array::from_iter_values(i * 20..(i + 1) * 20))],
+                    )
+                    .unwrap()
+                })
+                .collect(),
+        );
+        let test_uri = test_dir.path().to_str().unwrap();
+        let mut reader: Box<dyn RecordBatchReader> = Box::new(batches);
+        Dataset::write(&mut reader, test_uri, None).await
+    }
+
+    #[tokio::test]
+    async fn test_bad_field_name() {
+        // don't allow `.` in the field name
+        assert!(create_bad_file().await.is_err());
+    }
 }

--- a/rust/src/dataset.rs
+++ b/rust/src/dataset.rs
@@ -174,6 +174,7 @@ impl Dataset {
             if let Ok(b) = batch {
                 schema = Schema::try_from(b.schema().as_ref())?;
                 schema.set_dictionary(b)?;
+                schema.validate()?;
             } else {
                 return Err(Error::from(batch.as_ref().unwrap_err()));
             }

--- a/rust/src/datatypes/field.rs
+++ b/rust/src/datatypes/field.rs
@@ -54,7 +54,6 @@ pub struct Field {
 }
 
 impl Field {
-
     /// Returns arrow data type.
     pub fn data_type(&self) -> DataType {
         match &self.logical_type {

--- a/rust/src/datatypes/field.rs
+++ b/rust/src/datatypes/field.rs
@@ -54,6 +54,7 @@ pub struct Field {
 }
 
 impl Field {
+
     /// Returns arrow data type.
     pub fn data_type(&self) -> DataType {
         match &self.logical_type {

--- a/rust/src/datatypes/schema.rs
+++ b/rust/src/datatypes/schema.rs
@@ -72,7 +72,7 @@ impl Schema {
         for field in self.fields.iter() {
             if field.name.contains('.') {
                 return Err(Error::Schema(format!(
-                    "Field {} cannot contain `.`",
+                    "Top level field {} cannot contain `.`. Maybe you meant to create a struct field?",
                     field.name.clone()
                 )));
             }

--- a/rust/src/datatypes/schema.rs
+++ b/rust/src/datatypes/schema.rs
@@ -68,6 +68,15 @@ impl Schema {
         })
     }
 
+    pub(crate) fn validate(&self) -> Result<bool> {
+        for field in self.fields.iter() {
+            if field.name.contains('.') {
+                return Err(Error::Schema(format!("Field {} cannot contain `.`", field.name.clone())));
+            }
+        }
+        Ok(true)
+    }
+
     /// Intersection between two [`Schema`].
     pub fn intersection(&self, other: &Self) -> Result<Self> {
         let mut candidates: Vec<Field> = vec![];

--- a/rust/src/datatypes/schema.rs
+++ b/rust/src/datatypes/schema.rs
@@ -71,7 +71,10 @@ impl Schema {
     pub(crate) fn validate(&self) -> Result<bool> {
         for field in self.fields.iter() {
             if field.name.contains('.') {
-                return Err(Error::Schema(format!("Field {} cannot contain `.`", field.name.clone())));
+                return Err(Error::Schema(format!(
+                    "Field {} cannot contain `.`",
+                    field.name.clone()
+                )));
             }
         }
         Ok(true)

--- a/rust/src/datatypes/schema.rs
+++ b/rust/src/datatypes/schema.rs
@@ -68,6 +68,8 @@ impl Schema {
         })
     }
 
+    /// Check that the top level fields don't contain `.` in their names
+    /// to distinguish from nested fields.
     pub(crate) fn validate(&self) -> Result<bool> {
         for field in self.fields.iter() {
             if field.name.contains('.') {


### PR DESCRIPTION
This makes it indistinguishable from nested fields and causes all sorts of problems. For now we just disallow them.