### PR TITLE
Do not use lifetime on FileWriter

### DIFF
--- a/rust/src/dataset.rs
+++ b/rust/src/dataset.rs
@@ -83,16 +83,16 @@ impl From<&Manifest> for Version {
 }
 
 /// Create a new [FileWriter] with the related `data_file_path` under `<DATA_DIR>`.
-async fn new_file_writer<'a>(
-    object_store: &'a ObjectStore,
+async fn new_file_writer(
+    object_store: &ObjectStore,
     data_file_path: &str,
-    schema: &'a Schema,
-) -> Result<FileWriter<'a>> {
+    schema: &Schema,
+) -> Result<FileWriter> {
     let full_path = object_store
         .base_path()
         .child(DATA_DIR)
         .child(data_file_path);
-    FileWriter::try_new(object_store, &full_path, schema).await
+    FileWriter::try_new(object_store, &full_path, schema.clone()).await
 }
 
 /// Get the manifest file path for a version.

--- a/rust/src/encodings/plain.rs
+++ b/rust/src/encodings/plain.rs
@@ -715,7 +715,7 @@ mod tests {
             false,
         )]));
         let schema = Schema::try_from(arrow_schema.as_ref()).unwrap();
-        let mut file_writer = FileWriter::try_new(&store, &path, &schema).await.unwrap();
+        let mut file_writer = FileWriter::try_new(&store, &path, schema).await.unwrap();
 
         let array = Int32Array::from_iter_values(0..1000);
 
@@ -746,7 +746,7 @@ mod tests {
             false,
         )]));
         let schema = Schema::try_from(arrow_schema.as_ref()).unwrap();
-        let mut file_writer = FileWriter::try_new(&store, &path, &schema).await.unwrap();
+        let mut file_writer = FileWriter::try_new(&store, &path, schema).await.unwrap();
 
         let array = BooleanArray::from((0..120).map(|v| v % 5 == 0).collect::<Vec<_>>());
         for i in 0..10 {
@@ -775,7 +775,7 @@ mod tests {
             false,
         )]));
         let schema = Schema::try_from(arrow_schema.as_ref()).unwrap();
-        let mut file_writer = FileWriter::try_new(&store, &path, &schema).await.unwrap();
+        let mut file_writer = FileWriter::try_new(&store, &path, schema).await.unwrap();
 
         for i in (0..100).step_by(4) {
             let slice: FixedSizeListArray = fixed_size_list.slice(i, 4);
@@ -806,7 +806,9 @@ mod tests {
             false,
         )]));
         let schema = Schema::try_from(arrow_schema.as_ref()).unwrap();
-        let mut file_writer = FileWriter::try_new(&store, &path, &schema).await.unwrap();
+        let mut file_writer = FileWriter::try_new(&store, &path, schema.clone())
+            .await
+            .unwrap();
 
         let array = BooleanArray::from((0..120).map(|v| v % 5 == 0).collect::<Vec<_>>());
         let batch =
@@ -835,7 +837,9 @@ mod tests {
             false,
         )]));
         let schema = Schema::try_from(arrow_schema.as_ref()).unwrap();
-        let mut file_writer = FileWriter::try_new(&store, &path, &schema).await.unwrap();
+        let mut file_writer = FileWriter::try_new(&store, &path, schema.clone())
+            .await
+            .unwrap();
 
         let array = BooleanArray::from((0..5000).map(|v| v % 5 == 0).collect::<Vec<_>>());
         let batch =

--- a/rust/src/index/vector/graph/persisted.rs
+++ b/rust/src/index/vector/graph/persisted.rs
@@ -219,7 +219,7 @@ pub(crate) async fn write_graph<V: Vertex + Clone>(
     ]));
     let schema = Schema::try_from(arrow_schema.as_ref())?;
 
-    let mut writer = FileWriter::try_new(object_store, path, &schema).await?;
+    let mut writer = FileWriter::try_new(object_store, path, schema).await?;
     for nodes in graph.nodes.as_slice().chunks(params.batch_size) {
         let mut vertex_builder =
             FixedSizeBinaryBuilder::with_capacity(nodes.len(), binary_size as i32);

--- a/rust/src/io/reader.rs
+++ b/rust/src/io/reader.rs
@@ -591,7 +591,7 @@ mod tests {
         let path = Path::from("/foo");
 
         // Write 10 batches.
-        let mut file_writer = FileWriter::try_new(&store, &path, &schema).await.unwrap();
+        let mut file_writer = FileWriter::try_new(&store, &path, schema).await.unwrap();
         for batch_id in 0..10 {
             let value_range = batch_id * 10..batch_id * 10 + 10;
             let columns: Vec<ArrayRef> = vec![
@@ -668,7 +668,7 @@ mod tests {
         }
         schema.set_dictionary(&batches[0]).unwrap();
 
-        let mut file_writer = FileWriter::try_new(&store, &path, &schema).await.unwrap();
+        let mut file_writer = FileWriter::try_new(&store, &path, schema).await.unwrap();
         for batch in batches.iter() {
             file_writer.write(&[&batch]).await.unwrap();
         }
@@ -722,7 +722,7 @@ mod tests {
         )]));
         let batch = RecordBatch::try_new(arrow_schema.clone(), vec![struct_arr]).unwrap();
 
-        let mut file_writer = FileWriter::try_new(&store, &path, &schema).await.unwrap();
+        let mut file_writer = FileWriter::try_new(&store, &path, schema).await.unwrap();
         file_writer.write(&[&batch]).await.unwrap();
         file_writer.finish().await.unwrap();
 
@@ -766,7 +766,7 @@ mod tests {
             .collect::<Vec<_>>();
         let batches_ref = batches.iter().collect::<Vec<_>>();
 
-        let mut file_writer = FileWriter::try_new(&store, &path, &schema).await.unwrap();
+        let mut file_writer = FileWriter::try_new(&store, &path, schema).await.unwrap();
         file_writer.write(batches_ref.as_slice()).await.unwrap();
         file_writer.finish().await.unwrap();
 
@@ -786,7 +786,7 @@ mod tests {
         let schema: Schema = Schema::try_from(arrow_schema.as_ref()).unwrap();
         let batch = RecordBatch::try_new(arrow_schema.clone(), vec![struct_array.clone()]).unwrap();
 
-        let mut file_writer = FileWriter::try_new(&store, &path, &schema).await.unwrap();
+        let mut file_writer = FileWriter::try_new(&store, &path, schema).await.unwrap();
         file_writer.write(&[&batch]).await.unwrap();
         file_writer.finish().await.unwrap();
 
@@ -964,7 +964,9 @@ mod tests {
         // write to a lance file
         let store = ObjectStore::memory();
         let path = Path::from("/takes");
-        let mut file_writer = FileWriter::try_new(&store, &path, &schema).await.unwrap();
+        let mut file_writer = FileWriter::try_new(&store, &path, schema.clone())
+            .await
+            .unwrap();
         file_writer.write(&[&batch]).await.unwrap();
         file_writer.finish().await.unwrap();
 
@@ -1061,7 +1063,9 @@ mod tests {
         let store = ObjectStore::memory();
         let path = Path::from("/take_list");
         let schema: Schema = (&arrow_schema).try_into().unwrap();
-        let mut file_writer = FileWriter::try_new(&store, &path, &schema).await.unwrap();
+        let mut file_writer = FileWriter::try_new(&store, &path, schema.clone())
+            .await
+            .unwrap();
         file_writer.write(&[&batch]).await.unwrap();
         file_writer.finish().await.unwrap();
 
@@ -1129,7 +1133,7 @@ mod tests {
         .unwrap();
 
         let schema: Schema = (&arrow_schema).try_into().unwrap();
-        let mut file_writer = FileWriter::try_new(&store, &path, &schema).await.unwrap();
+        let mut file_writer = FileWriter::try_new(&store, &path, schema).await.unwrap();
         file_writer.write(&[&batch.clone()]).await.unwrap();
         file_writer.finish().await.unwrap();
 
@@ -1153,7 +1157,7 @@ mod tests {
         // write to a lance file
         let store = ObjectStore::memory();
         let path = Path::from("/read_range");
-        let mut file_writer = FileWriter::try_new(&store, &path, &schema).await.unwrap();
+        let mut file_writer = FileWriter::try_new(&store, &path, schema).await.unwrap();
         file_writer.write(&[&batch]).await.unwrap();
         file_writer.finish().await.unwrap();
 


### PR DESCRIPTION
Remove lifetime from `FileWriter`, because the `pyo3` can not hold a struct with lifetime