### PR TITLE
Recursively merge record batches

### DIFF
--- a/rust/src/arrow.rs
+++ b/rust/src/arrow.rs
@@ -21,7 +21,7 @@ use std::sync::Arc;
 use arrow::array::as_struct_array;
 use arrow_array::{
     Array, ArrayRef, ArrowNumericType, FixedSizeBinaryArray, FixedSizeListArray, GenericListArray,
-    OffsetSizeTrait, PrimitiveArray, RecordBatch, UInt8Array,
+    OffsetSizeTrait, PrimitiveArray, RecordBatch, UInt8Array, StructArray
 };
 use arrow_data::ArrayDataBuilder;
 use arrow_schema::{DataType, Field, FieldRef, Fields, Schema};
@@ -372,26 +372,11 @@ impl RecordBatchExt for RecordBatch {
                 other.num_rows()
             )));
         }
-
-        let mut fields: Vec<FieldRef> = self.schema().fields.iter().cloned().collect();
-        let mut columns = Vec::from(self.columns());
-        for field in other.schema().fields.iter() {
-            if !fields.iter().any(|f| f.name() == field.name()) {
-                fields.push(field.clone());
-                columns.push(
-                    other
-                        .column_by_name(field.name())
-                        .ok_or_else(|| {
-                            Error::Arrow(format!(
-                                "Column {} does not exist: schema={}",
-                                field.name(),
-                                other.schema()
-                            ))
-                        })?
-                        .clone(),
-                );
-            }
-        }
+        let left_fields = self.schema().fields.iter().cloned().collect::<Vec<_>>();
+        let right_fields = other.schema().fields.iter().cloned().collect::<Vec<_>>();
+        let left_columns = self.columns().iter().cloned().collect::<Vec<_>>();
+        let right_columns = other.columns().iter().cloned().collect::<Vec<_>>();
+        let (fields, columns) = merge(left_fields, left_columns, right_fields, right_columns);
         Ok(Self::try_new(Arc::new(Schema::new(fields)), columns)?)
     }
 
@@ -437,6 +422,68 @@ impl RecordBatchExt for RecordBatch {
         }
         Ok(RecordBatch::try_new(Arc::new(schema.clone()), columns)?)
     }
+}
+
+fn merge(left_fields: Vec<FieldRef>,
+         left_columns: Vec<ArrayRef>,
+         right_fields: Vec<FieldRef>,
+         right_columns: Vec<ArrayRef>) -> (Vec<FieldRef>, Vec<ArrayRef>) {
+
+    let mut fields: Vec<FieldRef> = vec![];
+    let mut columns: Vec<ArrayRef> = vec![];
+    // iterate through the fields on the left hand side
+    left_fields.iter().zip(left_columns.iter()).for_each(|(field, column)| {
+        match right_fields.iter().position(|f| f.name() == field.name()) {
+            // if the field exists on the right hand side, merge them recursively if appropriate
+            Some(right_index) => {
+                let right_field = right_fields.get(right_index).unwrap();
+                let right_column = right_columns.get(right_index).unwrap();
+                // if both fields are struct, merge them recursively
+                match (field.data_type(), right_field.data_type()) {
+                    (DataType::Struct(left_sub_fields),
+                        DataType::Struct(right_sub_fields)) => {
+                        let left_struct_array = as_struct_array(column);
+                        let right_struct_array = as_struct_array(right_column.as_ref());
+                        let (merged_fields, merged_columns) = merge(
+                            left_sub_fields.iter().cloned().collect::<Vec<_>>(),
+                            left_struct_array.columns().iter().cloned().collect::<Vec<_>>(),
+                            right_sub_fields.iter().cloned().collect::<Vec<_>>(),
+                            right_struct_array.columns().iter().cloned().collect::<Vec<_>>(),
+                        );
+                        fields.push(FieldRef::new(Field::new(
+                            field.name(),
+                            DataType::Struct(Fields::from(merged_fields.clone())),
+                            field.is_nullable(),
+                        )));
+
+                        columns.push(Arc::new(StructArray::from(
+                            merged_fields.iter().zip(merged_columns.iter())
+                                .map(|(f, c)| (f.as_ref().clone(), c.clone()))
+                                .collect::<Vec<_>>()
+                        )));
+                    }
+                    // otherwise, just use the field on the left hand side
+                    _ => {
+                        fields.push(field.clone());
+                        columns.push(column.clone());
+                    }
+                }
+            },
+            None => {
+                fields.push(field.clone());
+                columns.push(column.clone());
+            }
+        }
+    });
+    // now iterate through the fields on the right hand side
+    right_fields.iter().zip(right_columns.iter()).for_each(|(field, column)| {
+        // add new columns on the right
+        if !left_fields.iter().any(|f| f.name() == field.name()) {
+            fields.push(field.clone());
+            columns.push(column.clone() as ArrayRef);
+        }
+    });
+    (fields, columns)
 }
 
 fn get_sub_array<'a>(array: &'a ArrayRef, components: &[&str]) -> Option<&'a ArrayRef> {


### PR DESCRIPTION
If we're merging two record batches with struct fields then the existing merge method is insufficient. Instead we need to check for struct fields and do a recursive merge