### PR TITLE
Allow user to customize BlockSize on ObjectStore.

### DIFF
--- a/python/python/lance/__init__.py
+++ b/python/python/lance/__init__.py
@@ -33,6 +33,7 @@ def dataset(
     uri: Union[str, Path],
     version: Optional[int] = None,
     asof: Optional[Union[datetime, pd.Timestamp, str]] = None,
+    block_size: Optional[int] = None,
 ) -> LanceDataset:
     """
     Opens the Lance dataset from the address specified.
@@ -46,8 +47,10 @@ def dataset(
     asof : optional, datetime or str
         If specified, find the latest version created on or earlier than the given argument value.
         If a version is already specified, this arg is ignored.
+    block_size : optional, int
+        Block size in bytes. Provide a hint for the size of the minimal I/O request.
     """
-    ds = LanceDataset(uri, version)
+    ds = LanceDataset(uri, version, block_size)
     if version is None and asof is not None:
         ts_cutoff = sanitize_ts(asof)
         ver_cutoff = max(
@@ -59,6 +62,6 @@ def dataset(
                 f"{ts_cutoff} is earlier than the first version of this dataset"
             )
         else:
-            return LanceDataset(uri, ver_cutoff)
+            return LanceDataset(uri, ver_cutoff, block_size)
     else:
         return ds

--- a/python/python/lance/dataset.py
+++ b/python/python/lance/dataset.py
@@ -35,10 +35,15 @@ from .lance import __version__, _Dataset, _Scanner, _write_dataset
 class LanceDataset(pa.dataset.Dataset):
     """A dataset in Lance format where the data is stored at the given uri"""
 
-    def __init__(self, uri: Union[str, Path], version: Optional[int] = None):
+    def __init__(
+        self,
+        uri: Union[str, Path],
+        version: Optional[int] = None,
+        block_size: Optional[int] = None,
+    ):
         uri = os.fspath(uri) if isinstance(uri, Path) else uri
         self._uri = uri
-        self._ds = _Dataset(uri, version)
+        self._ds = _Dataset(uri, version, block_size)
 
     def __reduce__(self):
         return LanceDataset, (self.uri, self._ds.version())

--- a/python/src/dataset.rs
+++ b/python/src/dataset.rs
@@ -20,6 +20,7 @@ use arrow::pyarrow::*;
 use arrow_array::{Float32Array, RecordBatchReader};
 use arrow_data::ArrayData;
 use arrow_schema::Schema as ArrowSchema;
+use lance::dataset::ReadParams;
 use lance::datatypes::Schema;
 use lance::format::Fragment;
 use lance::index::vector::ivf::IvfBuildParams;
@@ -56,13 +57,14 @@ pub struct Dataset {
 #[pymethods]
 impl Dataset {
     #[new]
-    fn new(uri: String, version: Option<u64>) -> PyResult<Self> {
+    fn new(uri: String, version: Option<u64>, block_size: Option<usize>) -> PyResult<Self> {
         let rt = Runtime::new()?;
+        let params = ReadParams { block_size };
         let dataset = rt.block_on(async {
             if let Some(ver) = version {
-                LanceDataset::checkout(uri.as_str(), ver).await
+                LanceDataset::checkout_with_params(uri.as_str(), ver, &params).await
             } else {
-                LanceDataset::open(uri.as_str()).await
+                LanceDataset::open_with_params(uri.as_str(), &params).await
             }
         });
         match dataset {

--- a/rust/src/dataset.rs
+++ b/rust/src/dataset.rs
@@ -147,7 +147,11 @@ impl Dataset {
     }
 
     /// Check out a version of the dataset with read params.
-    pub async fn checkout_with_params(uri: &str, version: u64, params: &ReadParams) -> Result<Self> {
+    pub async fn checkout_with_params(
+        uri: &str,
+        version: u64,
+        params: &ReadParams,
+    ) -> Result<Self> {
         let mut object_store = ObjectStore::new(uri).await?;
         if let Some(block_size) = params.block_size {
             object_store.set_block_size(block_size);

--- a/rust/src/dataset.rs
+++ b/rust/src/dataset.rs
@@ -107,23 +107,55 @@ pub(crate) fn latest_manifest_path(base: &Path) -> Path {
     base.child(LATEST_MANIFEST_NAME)
 }
 
+/// Customize read behavior of a dataset.
+pub struct ReadParams {
+    /// The block size passed to the underlying Object Store reader.
+    ///
+    /// This is used to control the minimal request size.
+    pub block_size: Option<usize>,
+}
+
+impl Default for ReadParams {
+    fn default() -> Self {
+        Self { block_size: None }
+    }
+}
+
 impl Dataset {
     /// Open an existing dataset.
     pub async fn open(uri: &str) -> Result<Self> {
-        let object_store = Arc::new(ObjectStore::new(uri).await?);
+        let params = ReadParams::default();
+        Self::open_with_params(uri, &params).await
+    }
+
+    /// Open a dataset with read params.
+    pub async fn open_with_params(uri: &str, params: &ReadParams) -> Result<Self> {
+        let mut object_store = ObjectStore::new(uri).await?;
+        if let Some(block_size) = params.block_size {
+            object_store.set_block_size(block_size);
+        }
 
         let base_path = object_store.base_path().clone();
         let latest_manifest_path = latest_manifest_path(&base_path);
-        Self::checkout_manifest(object_store, base_path, &latest_manifest_path).await
+        Self::checkout_manifest(Arc::new(object_store), base_path, &latest_manifest_path).await
     }
 
     /// Check out a version of the dataset.
     pub async fn checkout(uri: &str, version: u64) -> Result<Self> {
-        let object_store = Arc::new(ObjectStore::new(uri).await?);
+        let params = ReadParams::default();
+        Self::checkout_with_params(uri, version, &params).await
+    }
+
+    /// Check out a version of the dataset with read params.
+    pub async fn checkout_with_params(uri: &str, version: u64, params: &ReadParams) -> Result<Self> {
+        let mut object_store = ObjectStore::new(uri).await?;
+        if let Some(block_size) = params.block_size {
+            object_store.set_block_size(block_size);
+        };
 
         let base_path = object_store.base_path().clone();
         let manifest_file = manifest_path(&base_path, version);
-        Self::checkout_manifest(object_store, base_path, &manifest_file).await
+        Self::checkout_manifest(Arc::new(object_store), base_path, &manifest_file).await
     }
 
     /// Check out the specified version of this dataset

--- a/rust/src/encodings/plain.rs
+++ b/rust/src/encodings/plain.rs
@@ -275,7 +275,7 @@ impl<'a> PlainDecoder<'a> {
     }
 
     async fn take_boolean(&self, indices: &UInt32Array) -> Result<ArrayRef> {
-        let block_size = self.reader.prefetch_size() as u32;
+        let block_size = self.reader.block_size() as u32;
         let boolean_block_size = block_size * 8;
 
         let mut chunk_ranges = vec![];
@@ -351,7 +351,7 @@ impl<'a> Decoder for PlainDecoder<'a> {
             return self.take_boolean(indices).await;
         }
 
-        let block_size = self.reader.prefetch_size();
+        let block_size = self.reader.block_size();
         let byte_width = self.data_type.byte_width();
 
         let chunked_ranges = make_chunked_requests(indices.values(), byte_width, block_size);
@@ -831,7 +831,7 @@ mod tests {
     #[tokio::test]
     async fn test_take_boolean_beyond_chunk() {
         let mut store = ObjectStore::memory();
-        store.set_prefetch_size(256);
+        store.set_block_size(256);
         let path = Path::from("/take_bools");
 
         let arrow_schema = Arc::new(ArrowSchema::new(vec![Field::new(

--- a/rust/src/index/vector.rs
+++ b/rust/src/index/vector.rs
@@ -324,11 +324,11 @@ pub(crate) async fn open_index(dataset: &Dataset, uuid: &str) -> Result<Arc<dyn 
     let reader: Arc<dyn ObjectReader> = object_store.open(&index_file).await?.into();
 
     let file_size = reader.size().await?;
-    let prefetch_size = object_store.prefetch_size();
-    let begin = if file_size < prefetch_size {
+    let block_size = object_store.block_size();
+    let begin = if file_size < block_size {
         0
     } else {
-        file_size - prefetch_size
+        file_size - block_size
     };
     let tail_bytes = reader.get_range(begin..file_size).await?;
     let metadata_pos = read_metadata_offset(&tail_bytes)?;

--- a/rust/src/io/local.rs
+++ b/rust/src/io/local.rs
@@ -74,7 +74,7 @@ impl ObjectReader for LocalObjectReader {
         &self.path
     }
 
-    fn prefetch_size(&self) -> usize {
+    fn block_size(&self) -> usize {
         self.prefetch_size
     }
 

--- a/rust/src/io/local.rs
+++ b/rust/src/io/local.rs
@@ -1,19 +1,16 @@
-// Licensed to the Apache Software Foundation (ASF) under one
-// or more contributor license agreements.  See the NOTICE file
-// distributed with this work for additional information
-// regarding copyright ownership.  The ASF licenses this file
-// to you under the Apache License, Version 2.0 (the
-// "License"); you may not use this file except in compliance
-// with the License.  You may obtain a copy of the License at
+// Copyright 2023 Lance Developers.
 //
-//   http://www.apache.org/licenses/LICENSE-2.0
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
 //
-// Unless required by applicable law or agreed to in writing,
-// software distributed under the License is distributed on an
-// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
-// KIND, either express or implied.  See the License for the
-// specific language governing permissions and limitations
-// under the License.
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 
 //! Optimized local I/Os
 
@@ -42,27 +39,17 @@ pub struct LocalObjectReader {
     /// Fie path.
     path: Path,
 
-    /// Preferred I/O size, in bytes.
-    ///
-    /// It could be the block size for local SSD.
-    prefetch_size: usize,
+    /// Block size, in bytes.
+    block_size: usize,
 }
-
-/// Default prefetch size for local SSD.
-const PREFETCH_SIZE: usize = 4096;
 
 impl LocalObjectReader {
     /// Open a local object reader, with default prefetch size.
-    pub fn open(path: &Path) -> Result<Box<dyn ObjectReader>> {
-        Self::open_with_prefetch(path, PREFETCH_SIZE)
-    }
-
-    /// Open a local object reader, with specified `prefetch` size.
-    pub fn open_with_prefetch(path: &Path, prefetch: usize) -> Result<Box<dyn ObjectReader>> {
+    pub fn open(path: &Path, block_size: usize) -> Result<Box<dyn ObjectReader>> {
         let local_path = format!("/{path}");
         Ok(Box::new(Self {
             file: File::open(local_path)?.into(),
-            prefetch_size: prefetch,
+            block_size,
             path: path.clone(),
         }))
     }
@@ -75,7 +62,7 @@ impl ObjectReader for LocalObjectReader {
     }
 
     fn block_size(&self) -> usize {
-        self.prefetch_size
+        self.block_size
     }
 
     /// Returns the file size.

--- a/rust/src/io/object_reader.rs
+++ b/rust/src/io/object_reader.rs
@@ -43,7 +43,7 @@ pub trait ObjectReader: Send + Sync {
     fn path(&self) -> &Path;
 
     /// Suggest optimal I/O size per storage device.
-    fn prefetch_size(&self) -> usize;
+    fn block_size(&self) -> usize;
 
     /// Object/File Size.
     async fn size(&self) -> Result<usize>;
@@ -62,16 +62,16 @@ pub struct CloudObjectReader {
     // File path
     pub path: Path,
 
-    prefetch_size: usize,
+    block_size: usize,
 }
 
 impl<'a> CloudObjectReader {
     /// Create an ObjectReader from URI
-    pub fn new(object_store: &'a ObjectStore, path: Path, prefetch_size: usize) -> Result<Self> {
+    pub fn new(object_store: &'a ObjectStore, path: Path, block_size: usize) -> Result<Self> {
         Ok(Self {
             object_store: object_store.clone(),
             path,
-            prefetch_size,
+            block_size,
         })
     }
 }
@@ -82,8 +82,8 @@ impl ObjectReader for CloudObjectReader {
         &self.path
     }
 
-    fn prefetch_size(&self) -> usize {
-        self.prefetch_size
+    fn block_size(&self) -> usize {
+        self.block_size
     }
 
     /// Object/File Size.

--- a/rust/src/io/object_store.rs
+++ b/rust/src/io/object_store.rs
@@ -162,7 +162,7 @@ impl ObjectStore {
     /// Open a file for path
     pub async fn open(&self, path: &Path) -> Result<Box<dyn ObjectReader>> {
         match self.scheme.as_str() {
-            "file" => LocalObjectReader::open(path),
+            "file" => LocalObjectReader::open(path, self.block_size),
             _ => Ok(Box::new(CloudObjectReader::new(
                 self,
                 path.clone(),

--- a/rust/src/io/object_store.rs
+++ b/rust/src/io/object_store.rs
@@ -1,19 +1,16 @@
-// Licensed to the Apache Software Foundation (ASF) under one
-// or more contributor license agreements.  See the NOTICE file
-// distributed with this work for additional information
-// regarding copyright ownership.  The ASF licenses this file
-// to you under the Apache License, Version 2.0 (the
-// "License"); you may not use this file except in compliance
-// with the License.  You may obtain a copy of the License at
+// Copyright 2023 Lance Developers.
 //
-//   http://www.apache.org/licenses/LICENSE-2.0
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
 //
-// Unless required by applicable law or agreed to in writing,
-// software distributed under the License is distributed on an
-// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
-// KIND, either express or implied.  See the License for the
-// specific language governing permissions and limitations
-// under the License.
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 
 //! Wraps [ObjectStore](object_store::ObjectStore)
 
@@ -46,7 +43,7 @@ pub struct ObjectStore {
     pub inner: Arc<dyn OSObjectStore>,
     scheme: String,
     base_path: Path,
-    prefetch_size: usize,
+    block_size: usize,
 }
 
 impl std::fmt::Display for ObjectStore {
@@ -117,7 +114,7 @@ impl ObjectStore {
             inner: Arc::new(LocalFileSystem::new_with_prefix(expanded_path.deref())?),
             scheme: String::from("flle"),
             base_path: Path::from(object_store::path::DELIMITER),
-            prefetch_size: 64 * 1024,
+            block_size: 4 * 1024,  // 4KB block size
         })
     }
 
@@ -127,16 +124,16 @@ impl ObjectStore {
                 inner: build_s3_object_store(url.to_string().as_str()).await?,
                 scheme: String::from("s3"),
                 base_path: Path::from(url.path()),
-                prefetch_size: 64 * 1024,
+                block_size: 64 * 1024,
             }),
             "gs" => Ok(Self {
                 inner: build_gcs_object_store(url.to_string().as_str()).await?,
                 scheme: String::from("gs"),
                 base_path: Path::from(url.path()),
-                prefetch_size: 64 * 1024,
+                block_size: 64 * 1024,
             }),
             "file" => Self::new_from_path(url.path()),
-            s => Err(Error::IO(format!("Unknown scheme {}", s))),
+            s => Err(Error::IO(format!("Unsupported scheme {}", s))),
         }
     }
 
@@ -146,16 +143,16 @@ impl ObjectStore {
             inner: Arc::new(InMemory::new()),
             scheme: String::from("memory"),
             base_path: Path::from("/"),
-            prefetch_size: 64 * 1024,
+            block_size: 64 * 1024,
         }
     }
 
-    pub fn prefetch_size(&self) -> usize {
-        self.prefetch_size
+    pub fn block_size(&self) -> usize {
+        self.block_size
     }
 
-    pub fn set_prefetch_size(&mut self, new_size: usize) {
-        self.prefetch_size = new_size;
+    pub fn set_block_size(&mut self, new_size: usize) {
+        self.block_size = new_size;
     }
 
     pub fn base_path(&self) -> &Path {
@@ -169,7 +166,7 @@ impl ObjectStore {
             _ => Ok(Box::new(CloudObjectReader::new(
                 self,
                 path.clone(),
-                self.prefetch_size,
+                self.block_size,
             )?)),
         }
     }

--- a/rust/src/io/object_store.rs
+++ b/rust/src/io/object_store.rs
@@ -114,7 +114,7 @@ impl ObjectStore {
             inner: Arc::new(LocalFileSystem::new_with_prefix(expanded_path.deref())?),
             scheme: String::from("flle"),
             base_path: Path::from(object_store::path::DELIMITER),
-            block_size: 4 * 1024,  // 4KB block size
+            block_size: 4 * 1024, // 4KB block size
         })
     }
 

--- a/rust/src/io/reader.rs
+++ b/rust/src/io/reader.rs
@@ -122,10 +122,10 @@ impl FileReader {
         let object_reader = object_store.open(path).await?;
 
         let file_size = object_reader.size().await?;
-        let begin = if file_size < object_store.prefetch_size() {
+        let begin = if file_size < object_store.block_size() {
             0
         } else {
-            file_size - object_store.prefetch_size()
+            file_size - object_store.block_size()
         };
         let tail_bytes = object_reader.get_range(begin..file_size).await?;
         let metadata_pos = read_metadata_offset(&tail_bytes)?;


### PR DESCRIPTION
Change API to `lance.dataset(uri, version, asof, block_size=None)`.