### PR TITLE
Fix Projection for struct fields

### DIFF
--- a/rust/src/dataset/scanner.rs
+++ b/rust/src/dataset/scanner.rs
@@ -1312,7 +1312,7 @@ mod test {
         let dataset = Dataset::open(test_uri).await.unwrap();
         let batches = dataset
             .scan()
-            .filter("struct.i >= 20")
+            .filter("struct.o = 'o-20'")
             .unwrap()
             .try_into_stream()
             .await


### PR DESCRIPTION
Previously we didn't check the leaf nodes inside the struct fields in a projection which causes problems. when filtering / selecting from nested struct fields