### PR TITLE
Expose batch_readahead via Python scanner API

### DIFF
--- a/python/python/tests/test_dataset.py
+++ b/python/python/tests/test_dataset.py
@@ -198,7 +198,7 @@ def test_to_batches(tmp_path: Path):
     lance.write_dataset(table, base_dir)
 
     dataset = lance.dataset(base_dir)
-    batches = dataset.to_batches()
+    batches = dataset.to_batches(batch_readahead=20)
     assert pa.Table.from_batches(batches) == table
 
 

--- a/python/src/dataset.rs
+++ b/python/src/dataset.rs
@@ -125,7 +125,7 @@ impl Dataset {
         limit: Option<i64>,
         offset: Option<i64>,
         nearest: Option<&PyDict>,
-        prefetch_size: Option<usize>,
+        batch_readahead: Option<usize>,
     ) -> PyResult<Scanner> {
         let mut scanner: LanceScanner = self_.ds.scan();
         if let Some(c) = columns {
@@ -143,8 +143,8 @@ impl Dataset {
                 .limit(limit, offset)
                 .map_err(|err| PyValueError::new_err(err.to_string()))?;
         }
-        if let Some(prefetch_size) = prefetch_size {
-            scanner.prefetch_size(prefetch_size);
+        if let Some(batch_readahead) = batch_readahead {
+            scanner.batch_readahead(batch_readahead);
         }
         if let Some(nearest) = nearest {
             let column = nearest

--- a/python/src/dataset.rs
+++ b/python/src/dataset.rs
@@ -125,6 +125,7 @@ impl Dataset {
         limit: Option<i64>,
         offset: Option<i64>,
         nearest: Option<&PyDict>,
+        prefetch_size: Option<usize>,
     ) -> PyResult<Scanner> {
         let mut scanner: LanceScanner = self_.ds.scan();
         if let Some(c) = columns {
@@ -141,6 +142,9 @@ impl Dataset {
             scanner
                 .limit(limit, offset)
                 .map_err(|err| PyValueError::new_err(err.to_string()))?;
+        }
+        if let Some(prefetch_size) = prefetch_size {
+            scanner.prefetch_size(prefetch_size);
         }
         if let Some(nearest) = nearest {
             let column = nearest

--- a/rust/src/dataset/scanner.rs
+++ b/rust/src/dataset/scanner.rs
@@ -46,7 +46,7 @@ use crate::{Error, Result};
 pub const ROW_ID: &str = "_rowid";
 pub const DEFAULT_BATCH_SIZE: usize = 8192;
 
-const PREFETCH_SIZE: usize = 8;
+const DEFAULT_PREFETCH_SIZE: usize = 8;
 
 /// Dataset Scanner
 ///
@@ -72,6 +72,9 @@ pub struct Scanner {
     /// The batch size controls the maximum size of rows to return for each read.
     batch_size: usize,
 
+    /// Number of batches to prefetch
+    prefetch_size: usize,
+
     limit: Option<i64>,
     offset: Option<i64>,
 
@@ -92,6 +95,7 @@ impl Scanner {
             projections: projection,
             filter: None,
             batch_size: DEFAULT_BATCH_SIZE,
+            prefetch_size: DEFAULT_PREFETCH_SIZE,
             limit: None,
             offset: None,
             nearest: None,
@@ -107,6 +111,7 @@ impl Scanner {
             projections: projection,
             filter: None,
             batch_size: DEFAULT_BATCH_SIZE,
+            prefetch_size: DEFAULT_PREFETCH_SIZE,
             limit: None,
             offset: None,
             nearest: None,
@@ -161,6 +166,12 @@ impl Scanner {
     /// Set the batch size.
     pub fn batch_size(&mut self, batch_size: usize) -> &mut Self {
         self.batch_size = batch_size;
+        self
+    }
+
+    /// Set the prefetch size.
+    pub fn prefetch_size(&mut self, prefetch_size: usize) -> &mut Self {
+        self.prefetch_size = prefetch_size;
         self
     }
 
@@ -492,7 +503,7 @@ impl Scanner {
             fragments,
             projection,
             self.batch_size,
-            PREFETCH_SIZE,
+            self.prefetch_size,
             with_row_id,
         ))
     }

--- a/rust/src/dataset/scanner.rs
+++ b/rust/src/dataset/scanner.rs
@@ -46,7 +46,8 @@ use crate::{Error, Result};
 pub const ROW_ID: &str = "_rowid";
 pub const DEFAULT_BATCH_SIZE: usize = 8192;
 
-const DEFAULT_PREFETCH_SIZE: usize = 8;
+// Same as pyarrow Dataset::scanner()
+const DEFAULT_BATCH_READAHEAD: usize = 16;
 
 /// Dataset Scanner
 ///
@@ -73,7 +74,7 @@ pub struct Scanner {
     batch_size: usize,
 
     /// Number of batches to prefetch
-    prefetch_size: usize,
+    batch_readahead: usize,
 
     limit: Option<i64>,
     offset: Option<i64>,
@@ -95,7 +96,7 @@ impl Scanner {
             projections: projection,
             filter: None,
             batch_size: DEFAULT_BATCH_SIZE,
-            prefetch_size: DEFAULT_PREFETCH_SIZE,
+            batch_readahead: DEFAULT_BATCH_READAHEAD,
             limit: None,
             offset: None,
             nearest: None,
@@ -111,7 +112,7 @@ impl Scanner {
             projections: projection,
             filter: None,
             batch_size: DEFAULT_BATCH_SIZE,
-            prefetch_size: DEFAULT_PREFETCH_SIZE,
+            batch_readahead: DEFAULT_BATCH_READAHEAD,
             limit: None,
             offset: None,
             nearest: None,
@@ -170,8 +171,8 @@ impl Scanner {
     }
 
     /// Set the prefetch size.
-    pub fn prefetch_size(&mut self, prefetch_size: usize) -> &mut Self {
-        self.prefetch_size = prefetch_size;
+    pub fn batch_readahead(&mut self, nbatches: usize) -> &mut Self {
+        self.batch_readahead = nbatches;
         self
     }
 
@@ -503,7 +504,7 @@ impl Scanner {
             fragments,
             projection,
             self.batch_size,
-            self.prefetch_size,
+            self.batch_readahead,
             with_row_id,
         ))
     }

--- a/rust/src/io/exec/scan.rs
+++ b/rust/src/io/exec/scan.rs
@@ -55,7 +55,7 @@ impl LanceStream {
     ///  - ***projection***: the projection [Schema].
     ///  - ***filter***: filter [`PhysicalExpr`], optional.
     ///  - ***read_size***: the number of rows to read for each request.
-    ///  - ***prefetch_size***: the number of batches to read ahead.
+    ///  - ***batch_readahead***: the number of batches to read ahead.
     ///  - ***with_row_id***: load row ID from the datasets.
     ///
     pub fn try_new(
@@ -63,10 +63,10 @@ impl LanceStream {
         fragments: Arc<Vec<Fragment>>,
         projection: Arc<Schema>,
         read_size: usize,
-        prefetch_size: usize,
+        batch_readahead: usize,
         with_row_id: bool,
     ) -> Result<Self> {
-        let (tx, rx) = mpsc::channel(prefetch_size);
+        let (tx, rx) = mpsc::channel(batch_readahead);
 
         let project_schema = projection.clone();
         let io_thread = tokio::spawn(async move {
@@ -147,7 +147,7 @@ pub struct LanceScanExec {
     fragments: Arc<Vec<Fragment>>,
     projection: Arc<Schema>,
     read_size: usize,
-    prefetch_size: usize,
+    batch_readahead: usize,
     with_row_id: bool,
 }
 
@@ -175,7 +175,7 @@ impl LanceScanExec {
         fragments: Arc<Vec<Fragment>>,
         projection: Arc<Schema>,
         read_size: usize,
-        prefetch_size: usize,
+        batch_readahead: usize,
         with_row_id: bool,
     ) -> Self {
         Self {
@@ -183,7 +183,7 @@ impl LanceScanExec {
             fragments,
             projection,
             read_size,
-            prefetch_size,
+            batch_readahead,
             with_row_id,
         }
     }
@@ -235,7 +235,7 @@ impl ExecutionPlan for LanceScanExec {
             self.fragments.clone(),
             self.projection.clone(),
             self.read_size,
-            self.prefetch_size,
+            self.batch_readahead,
             self.with_row_id,
         )?))
     }


### PR DESCRIPTION
* Also added type hints to `Dataset::to_batches()` . 