### PR TITLE
GH-860:  Create a scanner from fragments

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -88,3 +88,5 @@ data
 
 # c++ lsp
 .ccls-cache/
+
+python/venv

--- a/python/python/lance/__init__.py
+++ b/python/python/lance/__init__.py
@@ -18,12 +18,13 @@ from typing import Optional, Union
 
 import pandas as pd
 
-from .dataset import LanceDataset, __version__, write_dataset
+from .dataset import LanceDataset, LanceScanner, __version__, write_dataset
 from .fragment import _FragmentMetadata
 from .util import sanitize_ts
 
 __all__ = [
     "LanceDataset",
+    "LanceScanner",
     "__version__",
     "write_dataset",
     "dataset",

--- a/python/python/lance/dataset.py
+++ b/python/python/lance/dataset.py
@@ -19,7 +19,7 @@ import os
 from datetime import datetime, timedelta
 from functools import lru_cache
 from pathlib import Path
-from typing import Any, Dict, Iterator, List, Optional, Union
+from typing import Any, Dict, Iterable, Iterator, List, Optional, Union
 
 import numpy as np
 import pandas as pd
@@ -627,6 +627,31 @@ class LanceScanner(pa.dataset.Scanner):
         Not implemented
         """
         raise NotImplementedError("from fragment")
+
+    @staticmethod
+    def from_fragments(fragments: Iterable[LanceFragment], **kwargs):
+        """
+        Create a scanner from an iterable of fragments.
+
+        Parameters
+        ----------
+        fragments : Iterable[LanceFragment]
+
+        Returns
+        -------
+        LanceScanner
+        """
+        # TODO: peek instead of list
+        if not isinstance(fragments, list):
+            fragments = list(iter(fragments))
+
+        if len(fragments) == 0:
+            raise ValueError("Must pass at least one fragment")
+        
+        dataset = fragments[0]._ds
+        # TODO: pass down an iterator
+        scanner = _Scanner.from_fragments([fragment._fragment for fragment in fragments])
+        return LanceScanner(scanner, dataset)
 
     @staticmethod
     def from_batches(*args, **kwargs):

--- a/python/src/fragment.rs
+++ b/python/src/fragment.rs
@@ -42,6 +42,10 @@ impl FileFragment {
     pub fn new(frag: LanceFragment) -> Self {
         Self { fragment: frag }
     }
+
+    pub(crate) fn fragment(&self) -> &LanceFragment {
+        &self.fragment
+    }
 }
 
 #[pymethods]
@@ -280,8 +284,8 @@ impl FragmentMetadata {
         arrow_schema.to_pyarrow(self_.py())
     }
 
-     /// Returns the data file objects associated with this fragment.
-     fn data_files(self_: PyRef<'_, Self>) -> PyResult<Vec<DataFile>> {
+    /// Returns the data file objects associated with this fragment.
+    fn data_files(self_: PyRef<'_, Self>) -> PyResult<Vec<DataFile>> {
         let data_files: Vec<DataFile> = self_
             .inner
             .files

--- a/python/src/scanner.rs
+++ b/python/src/scanner.rs
@@ -27,6 +27,7 @@ use ::lance::dataset::scanner::Scanner as LanceScanner;
 use pyo3::exceptions::PyValueError;
 
 use crate::errors::ioerror;
+use crate::fragment::FileFragment;
 use crate::reader::LanceReader;
 
 /// This will be wrapped by a python class to provide
@@ -76,5 +77,29 @@ impl Scanner {
                 }
             }
         })
+    }
+
+    #[staticmethod]
+    fn from_fragments(fragments: Vec<FileFragment>) -> PyResult<Self> {
+        let fragments = fragments
+            .into_iter()
+            .map(|f| f.fragment().clone())
+            .collect::<Vec<_>>();
+
+        if fragments.is_empty() {
+            return Err(PyValueError::new_err("No fragments provided"));
+        }
+
+        // TODO: implement conversion traits so we can avoid the clones.
+
+        let dataset = Arc::new(fragments[0].dataset().clone());
+        let fragments = fragments
+            .into_iter()
+            .map(|f| f.metadata().clone())
+            .collect::<Vec<_>>();
+
+        let scanner = LanceScanner::from_fragments(dataset, fragments);
+
+        Ok(Self::new(Arc::new(scanner), Arc::new(Runtime::new()?)))
     }
 }


### PR DESCRIPTION
Initial implementation of `LanceScanner.from_fragments()` for Python. Supports `Iterable[LanceFragment]` at the interface, but leaves actually using an iterator as a TODO.

Closes #860.