### PR TITLE
refactor: make from_fragments() a little more efficient

### DIFF
--- a/python/src/dataset.rs
+++ b/python/src/dataset.rs
@@ -55,6 +55,12 @@ pub struct Dataset {
     rt: Arc<Runtime>,
 }
 
+impl Dataset {
+    pub(crate) fn dataset(&self) -> &Arc<LanceDataset> {
+        &self.ds
+    }
+}
+
 #[pymethods]
 impl Dataset {
     #[new]

--- a/python/src/fragment.rs
+++ b/python/src/fragment.rs
@@ -42,10 +42,6 @@ impl FileFragment {
     pub fn new(frag: LanceFragment) -> Self {
         Self { fragment: frag }
     }
-
-    pub(crate) fn fragment(&self) -> &LanceFragment {
-        &self.fragment
-    }
 }
 
 #[pymethods]
@@ -181,6 +177,12 @@ impl FileFragment {
             .map(|f| DataFile::new(f.clone()))
             .collect();
         Ok(data_files)
+    }
+}
+
+impl From<FileFragment> for LanceFragment {
+    fn from(fragment: FileFragment) -> Self {
+        fragment.fragment
     }
 }
 

--- a/rust/src/dataset/fragment.rs
+++ b/rust/src/dataset/fragment.rs
@@ -200,6 +200,12 @@ impl FileFragment {
     }
 }
 
+impl From<FileFragment> for Fragment {
+    fn from(fragment: FileFragment) -> Self {
+        fragment.metadata
+    }
+}
+
 /// [`FragmentReader`] is an abstract reader for a [`FileFragment`].
 ///
 /// It opens the data files that contains the columns of the projection schema, and


### PR DESCRIPTION
Adds some conversion traits for various fragment types, so we can convert owned values by moving the inner types instead of cloning them.

Also pushed down some of the fragment iterator implementation. However, pushing it down any further will likely require an invasive refactor of the scan logic. We'll probably need to make sure we have a use case that justifies doing that before we commit to doing that.