### PR TITLE
feat: add fragments option to the scanner itself

### DIFF
--- a/python/python/lance/dataset.py
+++ b/python/python/lance/dataset.py
@@ -697,34 +697,6 @@ class LanceScanner(pa.dataset.Scanner):
         raise NotImplementedError("from fragment")
 
     @staticmethod
-    def from_fragments(fragments: Iterable[LanceFragment], **kwargs):
-        """
-        Create a scanner from an iterable of fragments.
-
-        Parameters
-        ----------
-        fragments : Iterable[LanceFragment]
-
-        Returns
-        -------
-        LanceScanner
-        """
-        warnings.warn(
-            "Deprecated in version 0.4.13. Use the fragments argument in LanceDataset.scanner() instead.",
-            DeprecationWarning,
-            stacklevel=2
-        )
-        if not isinstance(fragments, list):
-            fragments = list(iter(fragments))
-
-        if len(fragments) == 0:
-            raise ValueError("Must pass at least one fragment")
-        
-        dataset = fragments[0]._ds
-        scanner = _Scanner.from_fragments([fragment._fragment for fragment in fragments])
-        return LanceScanner(scanner, dataset)
-
-    @staticmethod
     def from_batches(*args, **kwargs):
         """
         Not implemented

--- a/python/python/lance/dataset.py
+++ b/python/python/lance/dataset.py
@@ -602,7 +602,7 @@ class ScannerBuilder:
                 if isinstance(f, LanceFragment):
                     inner_fragments.append(f._fragment)
                 else:
-                    raise TypeError("fragments must be an iterable of LanceFragment")
+                    raise TypeError(f"fragments must be an iterable of LanceFragment. Got {type(f)} instead.")
             fragments = inner_fragments
 
         self._fragments = fragments

--- a/python/python/lance/dataset.py
+++ b/python/python/lance/dataset.py
@@ -20,6 +20,7 @@ from datetime import datetime, timedelta
 from functools import lru_cache
 from pathlib import Path
 from typing import Any, Dict, Iterable, Iterator, List, Optional, Union
+import warnings
 
 import numpy as np
 import pandas as pd
@@ -708,8 +709,11 @@ class LanceScanner(pa.dataset.Scanner):
         -------
         LanceScanner
         """
-        # TODO: can we take kwargs here for the scanner builder?
-        # TODO: peek instead of list
+        warnings.warn(
+            "Deprecated in version 0.4.13. Use the fragments argument in LanceDataset.scanner() instead.",
+            DeprecationWarning,
+            stacklevel=2
+        )
         if not isinstance(fragments, list):
             fragments = list(iter(fragments))
 
@@ -717,7 +721,6 @@ class LanceScanner(pa.dataset.Scanner):
             raise ValueError("Must pass at least one fragment")
         
         dataset = fragments[0]._ds
-        # TODO: pass down an iterator
         scanner = _Scanner.from_fragments([fragment._fragment for fragment in fragments])
         return LanceScanner(scanner, dataset)
 

--- a/python/python/tests/test_dataset.py
+++ b/python/python/tests/test_dataset.py
@@ -335,24 +335,6 @@ def test_load_scanner_from_fragments(tmp_path: Path):
     fragments = list(dataset.get_fragments())
     assert len(fragments) == 3
 
-    # Deprecated API
-    # --------------
-    # Create a scanner from first two fragments
-    with pytest.warns(DeprecationWarning):
-        scanner = lance.LanceScanner.from_fragments(fragments[0:2])
-    assert scanner.to_table().num_rows == 2 * 100
-
-    # Accepts an iterator
-    with pytest.warns(DeprecationWarning):
-        scanner = lance.LanceScanner.from_fragments(iter(fragments[0:2]))
-    assert scanner.to_table().num_rows == 2 * 100
-
-    # Fails if no fragments passed
-    with pytest.raises(ValueError, match="Must pass at least one fragment"):
-        with pytest.warns(DeprecationWarning):
-            lance.LanceScanner.from_fragments([])
-
-    # New API
     scanner = dataset.scanner(fragments=fragments[0:2])
     assert scanner.to_table().num_rows == 2 * 100
 

--- a/python/python/tests/test_dataset.py
+++ b/python/python/tests/test_dataset.py
@@ -335,6 +335,8 @@ def test_load_scanner_from_fragments(tmp_path: Path):
     fragments = list(dataset.get_fragments())
     assert len(fragments) == 3
 
+    # Deprecated API
+    # --------------
     # Create a scanner from first two fragments
     scanner = lance.LanceScanner.from_fragments(fragments[0:2])
     assert scanner.to_table().num_rows == 2 * 100
@@ -347,3 +349,10 @@ def test_load_scanner_from_fragments(tmp_path: Path):
     with pytest.raises(ValueError, match="Must pass at least one fragment"):
         lance.LanceScanner.from_fragments([])
 
+    # New API
+    scanner = dataset.scanner(fragments=fragments[0:2])
+    assert scanner.to_table().num_rows == 2 * 100
+
+    # Accepts an iterator
+    scanner = dataset.scanner(fragments=iter(fragments[0:2]), scan_in_order=False)
+    assert scanner.to_table().num_rows == 2 * 100

--- a/python/python/tests/test_dataset.py
+++ b/python/python/tests/test_dataset.py
@@ -338,16 +338,19 @@ def test_load_scanner_from_fragments(tmp_path: Path):
     # Deprecated API
     # --------------
     # Create a scanner from first two fragments
-    scanner = lance.LanceScanner.from_fragments(fragments[0:2])
+    with pytest.warns(DeprecationWarning):
+        scanner = lance.LanceScanner.from_fragments(fragments[0:2])
     assert scanner.to_table().num_rows == 2 * 100
 
     # Accepts an iterator
-    scanner = lance.LanceScanner.from_fragments(iter(fragments[0:2]))
+    with pytest.warns(DeprecationWarning):
+        scanner = lance.LanceScanner.from_fragments(iter(fragments[0:2]))
     assert scanner.to_table().num_rows == 2 * 100
 
     # Fails if no fragments passed
     with pytest.raises(ValueError, match="Must pass at least one fragment"):
-        lance.LanceScanner.from_fragments([])
+        with pytest.warns(DeprecationWarning):
+            lance.LanceScanner.from_fragments([])
 
     # New API
     scanner = dataset.scanner(fragments=fragments[0:2])

--- a/python/src/dataset.rs
+++ b/python/src/dataset.rs
@@ -20,6 +20,7 @@ use arrow::pyarrow::*;
 use arrow_array::{Float32Array, RecordBatchReader};
 use arrow_data::ArrayData;
 use arrow_schema::Schema as ArrowSchema;
+use lance::dataset::fragment::FileFragment as LanceFileFragment;
 use lance::dataset::ReadParams;
 use lance::datatypes::Schema;
 use lance::format::Fragment;
@@ -168,8 +169,11 @@ impl Dataset {
 
         if let Some(fragments) = fragments {
             let fragments = fragments
-                .iter()
-                .map(|f| f.fragment().metadata().clone())
+                .into_iter()
+                .map(|f| {
+                    let file_fragment = LanceFileFragment::from(f);
+                    file_fragment.into()
+                })
                 .collect();
             scanner.with_fragments(fragments);
         }

--- a/python/src/dataset.rs
+++ b/python/src/dataset.rs
@@ -138,6 +138,7 @@ impl Dataset {
         batch_readahead: Option<usize>,
         fragment_readahead: Option<usize>,
         scan_in_order: Option<bool>,
+        fragments: Option<Vec<FileFragment>>,
     ) -> PyResult<Scanner> {
         let mut scanner: LanceScanner = self_.ds.scan();
         if let Some(c) = columns {
@@ -164,6 +165,14 @@ impl Dataset {
         }
 
         scanner.scan_in_order(scan_in_order.unwrap_or(true));
+
+        if let Some(fragments) = fragments {
+            let fragments = fragments
+                .iter()
+                .map(|f| f.fragment().metadata().clone())
+                .collect();
+            scanner.with_fragments(fragments);
+        }
 
         if let Some(nearest) = nearest {
             let column = nearest

--- a/python/src/fragment.rs
+++ b/python/src/fragment.rs
@@ -42,10 +42,6 @@ impl FileFragment {
     pub fn new(frag: LanceFragment) -> Self {
         Self { fragment: frag }
     }
-
-    pub(crate) fn fragment(&self) -> &LanceFragment {
-        &self.fragment
-    }
 }
 
 #[pymethods]
@@ -181,6 +177,12 @@ impl FileFragment {
             .map(|f| DataFile::new(f.clone()))
             .collect();
         Ok(data_files)
+    }
+}
+
+impl From<FileFragment> for LanceFragment {
+    fn from(fragment: FileFragment) -> Self {
+        fragment.fragment
     }
 }
 

--- a/python/src/scanner.rs
+++ b/python/src/scanner.rs
@@ -24,11 +24,9 @@ use pyo3::{pyclass, PyObject, PyResult};
 use tokio::runtime::Runtime;
 
 use ::lance::dataset::scanner::Scanner as LanceScanner;
-use lance::dataset::fragment::FileFragment as LanceFileFragment;
 use pyo3::exceptions::PyValueError;
 
 use crate::errors::ioerror;
-use crate::fragment::FileFragment;
 use crate::reader::LanceReader;
 
 /// This will be wrapped by a python class to provide
@@ -78,25 +76,5 @@ impl Scanner {
                 }
             }
         })
-    }
-
-    #[staticmethod]
-    fn from_fragments(fragments: Vec<FileFragment>) -> PyResult<Self> {
-        let fragments = fragments
-            .into_iter()
-            .map(LanceFileFragment::from)
-            .collect::<Vec<_>>();
-
-        if fragments.is_empty() {
-            return Err(PyValueError::new_err("No fragments provided"));
-        }
-
-        let dataset = Arc::new(fragments[0].dataset().clone());
-        let fragments = fragments.into_iter().map(|f| f.into()).collect::<Vec<_>>();
-
-        #[allow(deprecated)]
-        let scanner = LanceScanner::from_fragments(dataset, fragments);
-
-        Ok(Self::new(Arc::new(scanner), Arc::new(Runtime::new()?)))
     }
 }

--- a/python/src/scanner.rs
+++ b/python/src/scanner.rs
@@ -98,6 +98,7 @@ impl Scanner {
             .map(|f| f.metadata().clone())
             .collect::<Vec<_>>();
 
+        #[allow(deprecated)]
         let scanner = LanceScanner::from_fragments(dataset, fragments);
 
         Ok(Self::new(Arc::new(scanner), Arc::new(Runtime::new()?)))

--- a/rust/src/dataset/fragment.rs
+++ b/rust/src/dataset/fragment.rs
@@ -200,6 +200,12 @@ impl FileFragment {
     }
 }
 
+impl From<FileFragment> for Fragment {
+    fn from(fragment: FileFragment) -> Self {
+        fragment.metadata
+    }
+}
+
 /// [`FragmentReader`] is an abstract reader for a [`FileFragment`].
 ///
 /// It opens the data files that contains the columns of the projection schema, and

--- a/rust/src/dataset/scanner.rs
+++ b/rust/src/dataset/scanner.rs
@@ -115,7 +115,7 @@ impl Scanner {
             fragments: None,
         }
     }
-    
+
     pub fn from_fragment(dataset: Arc<Dataset>, fragment: Fragment) -> Self {
         let projection = dataset.schema().clone();
         Self {
@@ -154,7 +154,7 @@ impl Scanner {
     }
 
     /// Set which fragments should be scanned.
-    /// 
+    ///
     /// If scan_in_order is set to true, the fragments will be scanned in the order of the vector.
     pub fn with_fragments(&mut self, fragments: Vec<Fragment>) -> &mut Self {
         self.fragments = Some(fragments);

--- a/rust/src/dataset/scanner.rs
+++ b/rust/src/dataset/scanner.rs
@@ -134,25 +134,6 @@ impl Scanner {
         }
     }
 
-    #[deprecated(since = "0.4.13", note = "Please use `with_fragments` instead")]
-    pub fn from_fragments(dataset: Arc<Dataset>, fragments: Vec<Fragment>) -> Self {
-        let projection = dataset.schema().clone();
-        Self {
-            dataset,
-            projections: projection,
-            filter: None,
-            batch_size: DEFAULT_BATCH_SIZE,
-            batch_readahead: DEFAULT_BATCH_READAHEAD,
-            fragment_readahead: DEFAULT_FRAGMENT_READAHEAD,
-            limit: None,
-            offset: None,
-            nearest: None,
-            with_row_id: false,
-            ordered: true,
-            fragments: Some(fragments),
-        }
-    }
-
     /// Set which fragments should be scanned.
     ///
     /// If scan_in_order is set to true, the fragments will be scanned in the order of the vector.

--- a/rust/src/dataset/scanner.rs
+++ b/rust/src/dataset/scanner.rs
@@ -115,7 +115,7 @@ impl Scanner {
             fragments: None,
         }
     }
-
+    
     pub fn from_fragment(dataset: Arc<Dataset>, fragment: Fragment) -> Self {
         let projection = dataset.schema().clone();
         Self {
@@ -134,6 +134,7 @@ impl Scanner {
         }
     }
 
+    #[deprecated(since = "0.4.13", note = "Please use `with_fragments` instead")]
     pub fn from_fragments(dataset: Arc<Dataset>, fragments: Vec<Fragment>) -> Self {
         let projection = dataset.schema().clone();
         Self {
@@ -150,6 +151,14 @@ impl Scanner {
             ordered: true,
             fragments: Some(fragments),
         }
+    }
+
+    /// Set which fragments should be scanned.
+    /// 
+    /// If scan_in_order is set to true, the fragments will be scanned in the order of the vector.
+    pub fn with_fragments(&mut self, fragments: Vec<Fragment>) -> &mut Self {
+        self.fragments = Some(fragments);
+        self
     }
 
     fn ensure_not_fragment_scan(&self) -> Result<()> {

--- a/rust/src/dataset/scanner.rs
+++ b/rust/src/dataset/scanner.rs
@@ -1154,8 +1154,8 @@ mod test {
         let fragment2 = dataset.get_fragment(1).unwrap().metadata().clone();
 
         // 1 then 2
-        let scanner =
-            Scanner::from_fragments(dataset.clone(), vec![fragment1.clone(), fragment2.clone()]);
+        let mut scanner = dataset.scan();
+        scanner.with_fragments(vec![fragment1.clone(), fragment2.clone()]);
         let output = scanner
             .try_into_stream()
             .await
@@ -1168,7 +1168,8 @@ mod test {
         assert_eq!(output[1], batch2);
 
         // 2 then 1
-        let scanner = Scanner::from_fragments(dataset, vec![fragment2, fragment1]);
+        let mut scanner = dataset.scan();
+        scanner.with_fragments(vec![fragment2, fragment1]);
         let output = scanner
             .try_into_stream()
             .await


### PR DESCRIPTION
To support setting other scanner options along with the fragments, add `fragments` as an argument in the scanner itself. 