### PR TITLE
fix: update minimal futures version

### DIFF
--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -47,7 +47,7 @@ prost-types = "0.11"
 tokio = { version = "1.23", features = ["rt-multi-thread"] }
 url = "2.3"
 rand = { version = "0.8.3", features = ["small_rng"] }
-futures = "0.3"
+futures = "0.3.27"
 uuid = { version = "1.2", features = ["v4"] }
 path-absolutize = "3.0.14"
 shellexpand = "3.0.0"


### PR DESCRIPTION
future 0.3.27 added `TryFlattenUnordered`, which we use now.

https://github.com/rust-lang/futures-rs/blob/master/CHANGELOG.md#0327---2023-03-11